### PR TITLE
Make calendar compact and show multiple months at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1763,7 +1762,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
       "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.90.1",
         "@supabase/functions-js": "2.90.1",
@@ -2108,7 +2106,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2177,7 +2174,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2677,7 +2673,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3018,7 +3013,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3651,7 +3645,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3837,7 +3830,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6081,7 +6073,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6091,7 +6082,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6780,7 +6770,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6963,7 +6952,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7259,7 +7247,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo } from "react";
 import {
   format,
   startOfMonth,
   endOfMonth,
   eachDayOfInterval,
-  isSameMonth,
   addMonths,
-  subMonths,
   getDay,
   isToday,
   isBefore,
@@ -34,17 +32,17 @@ export function AvailabilityCalendar({
 }: AvailabilityCalendarProps) {
   const today = startOfDay(new Date());
   const maxDate = endOfMonth(addMonths(today, windowMonths));
-  const [currentMonth, setCurrentMonth] = useState(startOfMonth(today));
 
-  const days = eachDayOfInterval({
-    start: startOfMonth(currentMonth),
-    end: endOfMonth(currentMonth),
-  });
-
-  const startDayOfWeek = getDay(startOfMonth(currentMonth));
-
-  const canGoPrev = isSameMonth(currentMonth, today) ? false : true;
-  const canGoNext = isBefore(endOfMonth(currentMonth), maxDate);
+  // Generate array of months to display
+  const months = useMemo(() => {
+    const result = [];
+    let current = startOfMonth(today);
+    while (isBefore(current, maxDate) || current.getTime() === startOfMonth(maxDate).getTime()) {
+      result.push(current);
+      current = addMonths(current, 1);
+    }
+    return result;
+  }, [today, maxDate]);
 
   const confirmedDates = new Set(confirmedSessions.map((s) => s.date));
 
@@ -78,7 +76,7 @@ export function AvailabilityCalendar({
     });
   };
 
-  const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
   const FULL_DAYS = [
     "Sunday",
     "Monday",
@@ -90,154 +88,184 @@ export function AvailabilityCalendar({
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Bulk actions */}
-      <div className="bg-secondary rounded-lg p-4">
-        <p className="text-sm font-medium text-foreground mb-3">
+      <div className="bg-secondary rounded-lg p-3">
+        <p className="text-xs font-medium text-foreground mb-2">
           Quick Actions
         </p>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           {playDays.map((day) => (
             <div key={day} className="flex gap-1">
               <Button
                 size="sm"
                 variant="secondary"
                 onClick={() => bulkSetDay(day, true)}
-                className="text-xs"
+                className="text-xs h-7 px-2"
               >
-                All {FULL_DAYS[day]}s Available
+                All {FULL_DAYS[day]}s ✓
               </Button>
               <Button
                 size="sm"
                 variant="ghost"
                 onClick={() => bulkSetDay(day, false)}
-                className="text-xs"
+                className="text-xs h-7 px-2"
               >
-                Unavailable
+                ✗
               </Button>
             </div>
           ))}
         </div>
       </div>
 
-      {/* Calendar */}
-      <div className="bg-card rounded-lg border border-border p-4">
-        {/* Month navigation */}
-        <div className="flex items-center justify-between mb-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setCurrentMonth(subMonths(currentMonth, 1))}
-            disabled={!canGoPrev}
-          >
-            &larr; Prev
-          </Button>
-          <h3 className="text-lg font-semibold text-card-foreground">
-            {format(currentMonth, "MMMM yyyy")}
-          </h3>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setCurrentMonth(addMonths(currentMonth, 1))}
-            disabled={!canGoNext}
-          >
-            Next &rarr;
-          </Button>
+      {/* Multi-month calendar grid */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {months.map((month) => (
+          <MonthCalendar
+            key={format(month, "yyyy-MM")}
+            month={month}
+            playDays={playDays}
+            availability={availability}
+            confirmedDates={confirmedDates}
+            today={today}
+            onDayClick={handleDayClick}
+            weekdays={WEEKDAYS}
+          />
+        ))}
+      </div>
+
+      {/* Compact Legend */}
+      <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-green-500/20 dark:bg-green-500/30 border border-green-500/30" />
+          <span>Available</span>
         </div>
-
-        {/* Weekday headers */}
-        <div className="grid grid-cols-7 gap-1 mb-2">
-          {WEEKDAYS.map((day, i) => (
-            <div
-              key={day}
-              className={`text-center text-sm font-medium py-2 ${
-                playDays.includes(i)
-                  ? "text-card-foreground"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {day}
-            </div>
-          ))}
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-red-500/20 dark:bg-red-500/30 border border-red-500/30" />
+          <span>Unavailable</span>
         </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-card border border-border" />
+          <span>Not set</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded-sm bg-muted" />
+          <span>Not a play day</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px]">🎲</span>
+          <span>Confirmed</span>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-        {/* Calendar grid */}
-        <div className="grid grid-cols-7 gap-1">
-          {/* Empty cells for start of month offset */}
-          {Array.from({ length: startDayOfWeek }).map((_, i) => (
-            <div key={`empty-${i}`} className="aspect-square" />
-          ))}
+// Separate component for individual month to keep things clean
+interface MonthCalendarProps {
+  month: Date;
+  playDays: number[];
+  availability: Record<string, boolean>;
+  confirmedDates: Set<string>;
+  today: Date;
+  onDayClick: (date: Date) => void;
+  weekdays: string[];
+}
 
-          {/* Day cells */}
-          {days.map((date) => {
-            const dateStr = format(date, "yyyy-MM-dd");
-            const dayOfWeek = getDay(date);
-            const isPlayDay = playDays.includes(dayOfWeek);
-            const isPast = isBefore(date, today);
-            const isConfirmed = confirmedDates.has(dateStr);
-            const avail = availability[dateStr];
+function MonthCalendar({
+  month,
+  playDays,
+  availability,
+  confirmedDates,
+  today,
+  onDayClick,
+  weekdays,
+}: MonthCalendarProps) {
+  const days = eachDayOfInterval({
+    start: startOfMonth(month),
+    end: endOfMonth(month),
+  });
 
-            let bgColor = "bg-muted"; // Non-play day
-            let textColor = "text-muted-foreground";
-            let cursor = "cursor-default";
+  const startDayOfWeek = getDay(startOfMonth(month));
 
-            if (isPlayDay && !isPast) {
-              cursor = "cursor-pointer hover:ring-2 hover:ring-primary/50";
-              if (avail === true) {
-                bgColor = "bg-green-500/20 dark:bg-green-500/30";
-                textColor = "text-green-700 dark:text-green-400";
-              } else if (avail === false) {
-                bgColor = "bg-red-500/20 dark:bg-red-500/30";
-                textColor = "text-red-700 dark:text-red-400";
-              } else {
-                bgColor = "bg-card border border-border";
-                textColor = "text-card-foreground";
-              }
-            } else if (isPast) {
-              textColor = "text-muted-foreground/50";
+  return (
+    <div className="bg-card rounded-lg border border-border p-2">
+      {/* Month header */}
+      <h4 className="text-xs font-semibold text-card-foreground text-center mb-1.5">
+        {format(month, "MMM yyyy")}
+      </h4>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 gap-px mb-1">
+        {weekdays.map((day, i) => (
+          <div
+            key={`${day}-${i}`}
+            className={`text-center text-[10px] font-medium ${
+              playDays.includes(i)
+                ? "text-card-foreground"
+                : "text-muted-foreground"
+            }`}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-px">
+        {/* Empty cells for start of month offset */}
+        {Array.from({ length: startDayOfWeek }).map((_, i) => (
+          <div key={`empty-${i}`} className="w-full aspect-square" />
+        ))}
+
+        {/* Day cells */}
+        {days.map((date) => {
+          const dateStr = format(date, "yyyy-MM-dd");
+          const dayOfWeek = getDay(date);
+          const isPlayDay = playDays.includes(dayOfWeek);
+          const isPast = isBefore(date, today);
+          const isConfirmed = confirmedDates.has(dateStr);
+          const avail = availability[dateStr];
+
+          let bgColor = "bg-muted"; // Non-play day
+          let textColor = "text-muted-foreground";
+          let cursor = "cursor-default";
+
+          if (isPlayDay && !isPast) {
+            cursor = "cursor-pointer hover:ring-1 hover:ring-primary/50";
+            if (avail === true) {
+              bgColor = "bg-green-500/20 dark:bg-green-500/30";
+              textColor = "text-green-700 dark:text-green-400";
+            } else if (avail === false) {
+              bgColor = "bg-red-500/20 dark:bg-red-500/30";
+              textColor = "text-red-700 dark:text-red-400";
+            } else {
+              bgColor = "bg-card border border-border";
+              textColor = "text-card-foreground";
             }
+          } else if (isPast) {
+            textColor = "text-muted-foreground/50";
+          }
 
-            return (
-              <button
-                key={dateStr}
-                onClick={() => handleDayClick(date)}
-                disabled={!isPlayDay || isPast}
-                className={`aspect-square rounded-lg flex flex-col items-center justify-center text-sm transition-all ${bgColor} ${textColor} ${cursor} ${
-                  isToday(date) ? "ring-2 ring-primary" : ""
-                }`}
-              >
-                <span className={isToday(date) ? "font-bold" : ""}>
-                  {format(date, "d")}
-                </span>
-                {isConfirmed && <span className="text-xs">🎲</span>}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Legend */}
-        <div className="mt-4 flex flex-wrap gap-4 text-sm text-muted-foreground">
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 rounded bg-green-500/20 dark:bg-green-500/30 border border-green-500/30" />
-            <span>Available</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 rounded bg-red-500/20 dark:bg-red-500/30 border border-red-500/30" />
-            <span>Unavailable</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 rounded bg-card border border-border" />
-            <span>Not set</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 rounded bg-muted" />
-            <span>Not a play day</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span>🎲</span>
-            <span>Confirmed session</span>
-          </div>
-        </div>
+          return (
+            <button
+              key={dateStr}
+              onClick={() => onDayClick(date)}
+              disabled={!isPlayDay || isPast}
+              className={`w-full aspect-square rounded-sm flex items-center justify-center text-[10px] transition-all ${bgColor} ${textColor} ${cursor} ${
+                isToday(date) ? "ring-1 ring-primary font-bold" : ""
+              }`}
+              title={dateStr}
+            >
+              <span className="relative">
+                {format(date, "d")}
+                {isConfirmed && (
+                  <span className="absolute -top-1 -right-2 text-[8px]">🎲</span>
+                )}
+              </span>
+            </button>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
- Display all months in the scheduling window in a responsive grid (2 cols mobile, 3 cols tablet, 4 cols desktop)
- Reduce day cell sizes and use smaller fonts (10px) for compactness
- Remove pagination controls since all months are visible at once
- Use single-letter weekday abbreviations (S/M/T/W/T/F/S)
- Compact the quick actions and legend sections
- Extract MonthCalendar as separate component for cleaner code