### PR TITLE
Add delete game feature for GMs

### DIFF
--- a/e2e/tests/games/delete-game.spec.ts
+++ b/e2e/tests/games/delete-game.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame, addPlayerToGame, setAvailability, getPlayDates } from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Delete Game', () => {
+  test('GM sees Delete Game button', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-delete-view-${Date.now()}@e2e.local`,
+      name: 'Delete View GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Delete View Game',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.getByRole('button', { name: /delete game/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+
+  test('player does not see Delete Game button', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-no-delete-${Date.now()}@e2e.local`,
+      name: 'No Delete GM',
+      is_gm: true,
+    });
+
+    const player = await createTestUser(request, {
+      email: `player-no-delete-${Date.now()}@e2e.local`,
+      name: 'No Delete Player',
+      is_gm: false,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'No Delete Game',
+      play_days: [5, 6],
+    });
+
+    await addPlayerToGame(game.id, player.id);
+
+    await loginTestUser(page, {
+      email: player.email,
+      name: player.name,
+      is_gm: false,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    // Wait for page to load
+    await expect(page.getByText('No Delete Game')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Player should NOT see Delete Game button
+    await expect(page.getByRole('button', { name: /delete game/i })).not.toBeVisible();
+  });
+
+  test('GM can delete game via confirmation modal', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-delete-${Date.now()}@e2e.local`,
+      name: 'Delete GM',
+      is_gm: true,
+    });
+
+    const player = await createTestUser(request, {
+      email: `player-delete-${Date.now()}@e2e.local`,
+      name: 'Delete Player',
+      is_gm: false,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Game To Delete',
+      play_days: [5, 6],
+    });
+
+    await addPlayerToGame(game.id, player.id);
+
+    // Set some availability for the player
+    const playDates = getPlayDates([5, 6], 2);
+    await setAvailability(player.id, game.id, [
+      { date: playDates[0], is_available: true },
+    ]);
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    // Wait for page to load
+    await expect(page.getByRole('button', { name: /delete game/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Click Delete Game button
+    await page.getByRole('button', { name: /delete game/i }).click();
+
+    // Confirmation modal should appear
+    await expect(page.getByText(/are you sure you want to permanently delete/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+    await expect(page.getByRole('strong').getByText('Game To Delete')).toBeVisible();
+
+    // Confirm deletion - click the button inside the modal
+    const modal = page.locator('.fixed.inset-0');
+    await modal.getByRole('button', { name: /^delete game$/i }).click();
+
+    // Should be redirected to dashboard
+    await expect(page).toHaveURL(/\/dashboard/, {
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Game should no longer appear on dashboard
+    await expect(page.getByRole('heading', { name: 'Game To Delete' })).not.toBeVisible();
+  });
+
+  test('GM can cancel deleting game via modal', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cancel-delete-${Date.now()}@e2e.local`,
+      name: 'Cancel Delete GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Cancel Delete Game',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    // Wait for page to load
+    await expect(page.getByRole('button', { name: /delete game/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Click Delete Game button
+    await page.getByRole('button', { name: /delete game/i }).click();
+
+    // Modal should appear
+    await expect(page.getByText(/are you sure you want to permanently delete/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+
+    // Click Cancel
+    await page.getByRole('button', { name: /cancel/i }).click();
+
+    // Modal should close
+    await expect(page.getByText(/are you sure you want to permanently delete/i)).not.toBeVisible();
+
+    // Still on game page
+    await expect(page.getByText('Cancel Delete Game')).toBeVisible();
+  });
+
+  test('deleted game no longer appears on dashboard', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-dashboard-delete-${Date.now()}@e2e.local`,
+      name: 'Dashboard Delete GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Dashboard Delete Game',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    // First verify game appears on dashboard
+    await page.goto('/dashboard');
+    await expect(page.getByText('Dashboard Delete Game')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Go to game and delete it
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /delete game/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    await page.getByRole('button', { name: /delete game/i }).click();
+
+    await expect(page.getByText(/are you sure you want to permanently delete/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+
+    const modal = page.locator('.fixed.inset-0');
+    await modal.getByRole('button', { name: /^delete game$/i }).click();
+
+    // Should be redirected to dashboard
+    await expect(page).toHaveURL(/\/dashboard/, {
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Game should no longer appear
+    await expect(page.getByText('Dashboard Delete Game')).not.toBeVisible();
+  });
+});

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -41,6 +41,8 @@ export default function GameDetailPage() {
   const [playerToRemove, setPlayerToRemove] = useState<User | null>(null);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const isGm = game?.gm_id === profile?.id;
   const isMember = game?.members.some((m) => m.id === profile?.id);
@@ -332,6 +334,23 @@ export default function GameDetailPage() {
     setPlayerToRemove(null);
   };
 
+  const handleDeleteGame = async () => {
+    if (!gameId) return;
+
+    setIsDeleting(true);
+    const { error } = await supabase
+      .from('games')
+      .delete()
+      .eq('id', gameId);
+
+    if (!error) {
+      router.push('/dashboard');
+    } else {
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
   // Show spinner while auth is loading, data is loading, or profile hasn't loaded yet
   if (isLoading || loading || (session && !profile)) {
     return (
@@ -366,6 +385,9 @@ export default function GameDetailPage() {
                 </Button>
                 <Button onClick={copyInviteLink} variant="secondary">
                   {copied ? 'Copied!' : 'Copy Invite Link'}
+                </Button>
+                <Button onClick={() => setShowDeleteConfirm(true)} variant="danger">
+                  Delete Game
                 </Button>
               </>
             )}
@@ -566,6 +588,38 @@ export default function GameDetailPage() {
                 onClick={() => handleRemovePlayer(playerToRemove.id)}
               >
                 Remove Player
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Game Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg shadow-xl p-6 w-full max-w-md mx-4">
+            <h3 className="text-lg font-semibold text-card-foreground mb-2">
+              Delete Game?
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              Are you sure you want to permanently delete <strong>{game.name}</strong>? This will remove all players, availability data, and scheduled sessions. This action cannot be undone.
+            </p>
+            <div className="flex gap-3">
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                className="flex-1"
+                onClick={handleDeleteGame}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete Game'}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
  - Add Delete Game button in game header (visible only to GM)
  - Add confirmation modal warning about permanent deletion
  - Cascade deletes automatically clean up memberships, availability, and sessions

  ## Test plan
  - [ ] Log in as a GM and navigate to a game you own
  - [ ] Verify "Delete Game" button is visible
  - [ ] Click delete, verify confirmation modal appears
  - [ ] Cancel and verify modal closes without deleting
  - [ ] Delete and verify redirect to dashboard
  - [ ] Verify game no longer appears on dashboard
  - [ ] Log in as a player and verify "Delete Game" button is NOT visible

  🤖 Generated with [Claude Code](https://claude.com/claude-code)