### PR TITLE
Add admin dashboard for usage metrics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,9 @@
 - [X] players can view games they aren't a member of
 - [~] supabase URL is super sketchy, improve it! (probably can't do w/o paying)
 
+## Technical Debt / Cleanup
+- [ ] Remove unused `session_status` enum values from schema: 'suggested' and 'cancelled' are never used. Sessions are created directly as 'confirmed', and cancelled sessions are deleted rather than marked as cancelled. Either remove these values or implement the intended workflow.
+
 ## Possible future features
 - have the app publish a calendar URL that clients can subscribe to?
 - [X] allow for co-GMs?

--- a/e2e/helpers/test-auth.ts
+++ b/e2e/helpers/test-auth.ts
@@ -11,6 +11,7 @@ export interface TestUser {
   email: string;
   name: string;
   is_gm: boolean;
+  is_admin: boolean;
 }
 
 /**
@@ -26,15 +27,17 @@ export async function createTestUser(
     email?: string;
     name?: string;
     is_gm?: boolean;
+    is_admin?: boolean;
   } = {}
 ): Promise<TestUser> {
   const timestamp = Date.now();
   const email = options.email || `test-${timestamp}@e2e.local`;
   const name = options.name || `Test User ${timestamp}`;
   const is_gm = options.is_gm ?? false;
+  const is_admin = options.is_admin ?? false;
 
   const response = await request.post('http://localhost:3001/api/test-auth', {
-    data: { email, name, is_gm },
+    data: { email, name, is_gm, is_admin },
   });
 
   if (!response.ok()) {
@@ -59,6 +62,7 @@ export async function loginTestUser(
     email?: string;
     name?: string;
     is_gm?: boolean;
+    is_admin?: boolean;
   } = {},
   navigateAndReload = true
 ): Promise<TestUser> {
@@ -66,9 +70,10 @@ export async function loginTestUser(
   const email = options.email || `test-${timestamp}@e2e.local`;
   const name = options.name || `Test User ${timestamp}`;
   const is_gm = options.is_gm ?? false;
+  const is_admin = options.is_admin ?? false;
 
   const response = await page.request.post('http://localhost:3001/api/test-auth', {
-    data: { email, name, is_gm },
+    data: { email, name, is_gm, is_admin },
   });
 
   if (!response.ok()) {
@@ -114,6 +119,21 @@ export async function createTestPlayer(
     email: `player-${Date.now()}@e2e.local`,
     name: name || `Test Player ${Date.now()}`,
     is_gm: false,
+  });
+}
+
+/**
+ * Create an admin user for testing.
+ */
+export async function createTestAdmin(
+  request: APIRequestContext,
+  name?: string
+): Promise<TestUser> {
+  return createTestUser(request, {
+    email: `admin-${Date.now()}@e2e.local`,
+    name: name || `Test Admin ${Date.now()}`,
+    is_gm: false,
+    is_admin: true,
   });
 }
 

--- a/e2e/tests/admin/dashboard.spec.ts
+++ b/e2e/tests/admin/dashboard.spec.ts
@@ -1,0 +1,240 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame, addPlayerToGame, createTestSession } from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Admin Dashboard', () => {
+  test('non-admin user is redirected to dashboard', async ({ page, request }) => {
+    // Create a regular user (not admin)
+    const user = await createTestUser(request, {
+      email: `non-admin-${Date.now()}@e2e.local`,
+      name: 'Non Admin User',
+      is_gm: false,
+      is_admin: false,
+    });
+
+    await loginTestUser(page, {
+      email: user.email,
+      name: user.name,
+      is_gm: false,
+      is_admin: false,
+    });
+
+    // Try to visit admin page
+    await page.goto('/admin');
+
+    // Should be redirected to dashboard
+    await expect(page).toHaveURL('/dashboard', { timeout: TEST_TIMEOUTS.LONG });
+  });
+
+  test('admin user can access admin dashboard', async ({ page, request }) => {
+    // Create an admin user
+    const admin = await createTestUser(request, {
+      email: `admin-access-${Date.now()}@e2e.local`,
+      name: 'Admin User',
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+
+    // Visit admin page
+    await page.goto('/admin');
+
+    // Should see admin dashboard heading
+    await expect(page.getByRole('heading', { name: /admin dashboard/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Should see tabs
+    await expect(page.getByRole('button', { name: /overview/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /games/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /activity/i })).toBeVisible();
+  });
+
+  test('admin link appears in navbar for admin users', async ({ page, request }) => {
+    // Create an admin user
+    const admin = await createTestUser(request, {
+      email: `admin-nav-${Date.now()}@e2e.local`,
+      name: 'Admin Nav User',
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await page.goto('/dashboard');
+
+    // Should see Admin link in navbar
+    await expect(page.getByRole('link', { name: /^admin$/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+
+  test('admin link does not appear for non-admin users', async ({ page, request }) => {
+    // Create a regular user
+    const user = await createTestUser(request, {
+      email: `non-admin-nav-${Date.now()}@e2e.local`,
+      name: 'Non Admin Nav User',
+      is_gm: true, // GM but not admin
+      is_admin: false,
+    });
+
+    await loginTestUser(page, {
+      email: user.email,
+      name: user.name,
+      is_gm: true,
+      is_admin: false,
+    });
+
+    await page.goto('/dashboard');
+
+    // Wait for page to load
+    await expect(page.getByRole('heading', { name: /your games/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Should NOT see Admin link in navbar
+    await expect(page.getByRole('link', { name: /^admin$/i })).not.toBeVisible();
+  });
+
+  test('overview tab shows stats', async ({ page, request }) => {
+    // Create an admin user
+    const admin = await createTestUser(request, {
+      email: `admin-stats-${Date.now()}@e2e.local`,
+      name: 'Admin Stats User',
+      is_gm: true,
+      is_admin: true,
+    });
+
+    // Create a game and session to have some data
+    const game = await createTestGame({
+      gm_id: admin.id,
+      name: 'Stats Test Game',
+      play_days: [5, 6],
+    });
+
+    await createTestSession({
+      game_id: game.id,
+      date: '2025-06-15',
+      confirmed_by: admin.id,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: true,
+      is_admin: true,
+    });
+
+    await page.goto('/admin');
+
+    // Should be on Overview tab by default and see stats
+    await expect(page.getByText(/total users/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.getByText(/total games/i)).toBeVisible();
+    await expect(page.getByText(/confirmed sessions/i)).toBeVisible();
+  });
+
+  test('games tab shows game list with metrics', async ({ page, request }) => {
+    // Create an admin user
+    const admin = await createTestUser(request, {
+      email: `admin-games-${Date.now()}@e2e.local`,
+      name: 'Admin Games User',
+      is_gm: true,
+      is_admin: true,
+    });
+
+    // Create a player
+    const player = await createTestUser(request, {
+      email: `player-games-${Date.now()}@e2e.local`,
+      name: 'Test Player',
+      is_gm: false,
+      is_admin: false,
+    });
+
+    // Create a game
+    const game = await createTestGame({
+      gm_id: admin.id,
+      name: 'Games Tab Test Campaign',
+      play_days: [5, 6],
+    });
+
+    await addPlayerToGame(game.id, player.id);
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: true,
+      is_admin: true,
+    });
+
+    await page.goto('/admin');
+
+    // Click Games tab
+    await page.getByRole('button', { name: /games/i }).click();
+
+    // Should see the game in the list
+    await expect(page.getByText('Games Tab Test Campaign')).toBeVisible({
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+
+    // Should see metric columns
+    await expect(page.getByText(/players/i)).toBeVisible();
+    await expect(page.getByText(/fill rate/i)).toBeVisible();
+  });
+
+  test('activity tab shows recent users and games', async ({ page, request }) => {
+    // Create an admin user
+    const admin = await createTestUser(request, {
+      email: `admin-activity-${Date.now()}@e2e.local`,
+      name: 'Admin Activity User',
+      is_gm: true,
+      is_admin: true,
+    });
+
+    // Create a game to show in recent games
+    await createTestGame({
+      gm_id: admin.id,
+      name: 'Activity Test Game',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: true,
+      is_admin: true,
+    });
+
+    await page.goto('/admin');
+
+    // Click Activity tab
+    await page.getByRole('button', { name: /activity/i }).click();
+
+    // Should see recent users and games sections
+    await expect(page.getByRole('heading', { name: /recent users/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+    await expect(page.getByRole('heading', { name: /recent games/i })).toBeVisible();
+
+    // Should see the admin user in recent users (look within the Recent Users card)
+    const recentUsersCard = page.locator('div').filter({ hasText: /^Recent Users/ }).first();
+    await expect(recentUsersCard.getByText('Admin Activity User').first()).toBeVisible();
+
+    // Should see the game in recent games (look within the Recent Games card)
+    const recentGamesCard = page.locator('div').filter({ hasText: /^Recent Games/ }).first();
+    await expect(recentGamesCard.getByText('Activity Test Game')).toBeVisible();
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useAuthRedirect } from '@/hooks/useAuthRedirect';
+import { Card, CardContent, CardHeader, LoadingSpinner } from '@/components/ui';
+
+type Tab = 'overview' | 'games' | 'activity';
+
+interface AdminStats {
+  totalUsers: number;
+  totalGames: number;
+  totalSessions: number;
+  sessionsByStatus: {
+    suggested: number;
+    confirmed: number;
+    cancelled: number;
+  };
+  recentUsers: Array<{
+    id: string;
+    name: string;
+    email: string;
+    avatar_url: string | null;
+    is_gm: boolean;
+    is_admin: boolean;
+    created_at: string;
+  }>;
+  recentGames: Array<{
+    id: string;
+    name: string;
+    created_at: string;
+    gm: { name: string } | null;
+  }>;
+}
+
+interface GameWithEngagement {
+  id: string;
+  name: string;
+  created_at: string;
+  gm: { id: string; name: string; email: string } | null;
+  playerCount: number;
+  sessionCount: number;
+  confirmedSessionCount: number;
+  availabilityFillRate: number;
+  lastActivity: string | null;
+}
+
+export default function AdminPage() {
+  const { session, profile, isLoading: authLoading } = useAuth();
+  const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [games, setGames] = useState<GameWithEngagement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useAuthRedirect({ requireAdmin: true });
+
+  useEffect(() => {
+    async function fetchData() {
+      if (!profile?.is_admin) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [statsRes, gamesRes] = await Promise.all([
+          fetch('/api/admin/stats'),
+          fetch('/api/admin/games'),
+        ]);
+
+        if (!statsRes.ok || !gamesRes.ok) {
+          throw new Error('Failed to fetch admin data');
+        }
+
+        const statsData = await statsRes.json();
+        const gamesData = await gamesRes.json();
+
+        setStats(statsData);
+        setGames(gamesData.games);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+  }, [profile?.is_admin]);
+
+  // Show spinner while auth is loading or while we have a session but profile hasn't loaded yet
+  if (authLoading || (session && !profile)) {
+    return (
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  // If user isn't admin, the redirect will handle it
+  if (!profile?.is_admin) {
+    return (
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'games', label: 'Games' },
+    { id: 'activity', label: 'Activity' },
+  ];
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-2xl font-bold text-foreground mb-8">Admin Dashboard</h1>
+
+      {/* Tabs */}
+      <div className="border-b border-border mb-6">
+        <nav className="-mb-px flex space-x-8">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+                activeTab === tab.id
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <LoadingSpinner />
+        </div>
+      ) : error ? (
+        <div className="text-danger text-center py-12">{error}</div>
+      ) : (
+        <>
+          {activeTab === 'overview' && stats && <OverviewTab stats={stats} />}
+          {activeTab === 'games' && <GamesTab games={games} />}
+          {activeTab === 'activity' && stats && <ActivityTab stats={stats} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+function OverviewTab({ stats }: { stats: AdminStats }) {
+  return (
+    <div className="space-y-6">
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <StatCard title="Total Users" value={stats.totalUsers} />
+        <StatCard title="Total Games" value={stats.totalGames} />
+        <StatCard title="Confirmed Sessions" value={stats.totalSessions} />
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ title, value }: { title: string; value: number }) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-sm font-medium text-muted-foreground">{title}</p>
+        <p className="text-3xl font-bold text-foreground">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function GamesTab({ games }: { games: GameWithEngagement[] }) {
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return 'Never';
+    return new Date(dateStr).toLocaleDateString();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-card-foreground">All Games ({games.length})</h2>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Game</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">GM</th>
+                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Players</th>
+                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Confirmed Sessions</th>
+                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Fill Rate</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Last Activity</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {games.map((game) => (
+                <tr key={game.id} className="border-b border-border/50 hover:bg-muted/50">
+                  <td className="py-3 px-2 font-medium text-foreground">{game.name}</td>
+                  <td className="py-3 px-2 text-muted-foreground">{game.gm?.name ?? 'Unknown'}</td>
+                  <td className="py-3 px-2 text-center text-foreground">{game.playerCount}</td>
+                  <td className="py-3 px-2 text-center text-foreground">
+                    {game.sessionCount}
+                  </td>
+                  <td className="py-3 px-2 text-center">
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                        game.availabilityFillRate >= 75
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                          : game.availabilityFillRate >= 50
+                          ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                          : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                      }`}
+                    >
+                      {game.availabilityFillRate}%
+                    </span>
+                  </td>
+                  <td className="py-3 px-2 text-muted-foreground">{formatDate(game.lastActivity)}</td>
+                  <td className="py-3 px-2 text-muted-foreground">{formatDate(game.created_at)}</td>
+                </tr>
+              ))}
+              {games.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-muted-foreground">
+                    No games found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivityTab({ stats }: { stats: AdminStats }) {
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString();
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Recent Users */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-card-foreground">Recent Users</h2>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {stats.recentUsers.map((user) => (
+              <div
+                key={user.id}
+                className="flex items-center justify-between py-2 border-b border-border/50 last:border-0"
+              >
+                <div className="flex items-center gap-3">
+                  {user.avatar_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={user.avatar_url}
+                      alt={user.name}
+                      className="w-8 h-8 rounded-full"
+                    />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-sm font-medium">
+                      {user.name[0]?.toUpperCase() || '?'}
+                    </div>
+                  )}
+                  <div>
+                    <p className="font-medium text-foreground">
+                      {user.name}
+                      {user.is_admin && (
+                        <span className="ml-2 text-xs bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 px-1.5 py-0.5 rounded">
+                          Admin
+                        </span>
+                      )}
+                      {user.is_gm && (
+                        <span className="ml-1 text-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 px-1.5 py-0.5 rounded">
+                          GM
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-sm text-muted-foreground">{user.email}</p>
+                  </div>
+                </div>
+                <p className="text-sm text-muted-foreground">{formatDate(user.created_at)}</p>
+              </div>
+            ))}
+            {stats.recentUsers.length === 0 && (
+              <p className="text-muted-foreground text-center py-4">No users found</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Recent Games */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-card-foreground">Recent Games</h2>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {stats.recentGames.map((game) => (
+              <div
+                key={game.id}
+                className="flex items-center justify-between py-2 border-b border-border/50 last:border-0"
+              >
+                <div>
+                  <p className="font-medium text-foreground">{game.name}</p>
+                  <p className="text-sm text-muted-foreground">GM: {game.gm?.name ?? 'Unknown'}</p>
+                </div>
+                <p className="text-sm text-muted-foreground">{formatDate(game.created_at)}</p>
+              </div>
+            ))}
+            {stats.recentGames.length === 0 && (
+              <p className="text-muted-foreground text-center py-4">No games found</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/admin/games/route.ts
+++ b/src/app/api/admin/games/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+interface GameWithEngagement {
+  id: string;
+  name: string;
+  created_at: string;
+  gm: { id: string; name: string; email: string } | null;
+  playerCount: number;
+  sessionCount: number;
+  confirmedSessionCount: number;
+  availabilityFillRate: number;
+  lastActivity: string | null;
+}
+
+export async function GET(): Promise<Response> {
+  try {
+    // Verify the user is authenticated and is an admin
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Use admin client to check if user is admin and fetch data
+    const admin = createAdminClient();
+
+    // Check if user is admin
+    const { data: profile, error: profileError } = await admin
+      .from('users')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile?.is_admin) {
+      return NextResponse.json(
+        { error: 'Admin access required' },
+        { status: 403 }
+      );
+    }
+
+    // Fetch all games with GM info
+    const { data: games, error: gamesError } = await admin
+      .from('games')
+      .select('id, name, created_at, play_days, scheduling_window_months, gm_id, gm:users!games_gm_id_fkey(id, name, email)')
+      .order('created_at', { ascending: false });
+
+    if (gamesError) {
+      throw gamesError;
+    }
+
+    // Fetch all memberships, sessions, and availability
+    const [membershipsResult, sessionsResult, availabilityResult] = await Promise.all([
+      admin.from('game_memberships').select('game_id, user_id'),
+      admin.from('sessions').select('game_id, status, created_at'),
+      admin.from('availability').select('game_id, user_id, updated_at'),
+    ]);
+
+    // Build lookup maps
+    const membershipsByGame = new Map<string, Set<string>>();
+    membershipsResult.data?.forEach((m) => {
+      if (!membershipsByGame.has(m.game_id)) {
+        membershipsByGame.set(m.game_id, new Set());
+      }
+      membershipsByGame.get(m.game_id)!.add(m.user_id);
+    });
+
+    const sessionsByGame = new Map<string, { total: number; confirmed: number; lastActivity: string | null }>();
+    sessionsResult.data?.forEach((s) => {
+      if (!sessionsByGame.has(s.game_id)) {
+        sessionsByGame.set(s.game_id, { total: 0, confirmed: 0, lastActivity: null });
+      }
+      const stats = sessionsByGame.get(s.game_id)!;
+      stats.total++;
+      if (s.status === 'confirmed') stats.confirmed++;
+      if (!stats.lastActivity || s.created_at > stats.lastActivity) {
+        stats.lastActivity = s.created_at;
+      }
+    });
+
+    const availabilityByGame = new Map<string, { users: Set<string>; lastActivity: string | null }>();
+    availabilityResult.data?.forEach((a) => {
+      if (!availabilityByGame.has(a.game_id)) {
+        availabilityByGame.set(a.game_id, { users: new Set(), lastActivity: null });
+      }
+      const stats = availabilityByGame.get(a.game_id)!;
+      stats.users.add(a.user_id);
+      if (!stats.lastActivity || a.updated_at > stats.lastActivity) {
+        stats.lastActivity = a.updated_at;
+      }
+    });
+
+    // Build game list with engagement metrics
+    const gamesWithEngagement: GameWithEngagement[] = (games ?? []).map((game) => {
+      const members = membershipsByGame.get(game.id) ?? new Set();
+      const totalPlayers = members.size + 1; // +1 for GM
+      const sessionStats = sessionsByGame.get(game.id) ?? { total: 0, confirmed: 0, lastActivity: null };
+      const availabilityStats = availabilityByGame.get(game.id) ?? { users: new Set(), lastActivity: null };
+
+      // Fill rate: % of CURRENT players who have submitted any availability
+      // Only count availability from current members (not players who left)
+      const currentPlayerIds = new Set([...members, game.gm_id]);
+      const currentPlayersWithAvailability = [...availabilityStats.users].filter(
+        (userId) => currentPlayerIds.has(userId)
+      ).length;
+      const fillRate = totalPlayers > 0 ? Math.round((currentPlayersWithAvailability / totalPlayers) * 100) : 0;
+
+      // Last activity: most recent of session or availability activity
+      let lastActivity: string | null = null;
+      if (sessionStats.lastActivity && availabilityStats.lastActivity) {
+        lastActivity = sessionStats.lastActivity > availabilityStats.lastActivity
+          ? sessionStats.lastActivity
+          : availabilityStats.lastActivity;
+      } else {
+        lastActivity = sessionStats.lastActivity || availabilityStats.lastActivity;
+      }
+
+      // Handle gm field which may be an object or array from Supabase
+      const gmData = game.gm;
+      const gm = Array.isArray(gmData) ? gmData[0] ?? null : gmData;
+
+      return {
+        id: game.id,
+        name: game.name,
+        created_at: game.created_at,
+        gm: gm as GameWithEngagement['gm'],
+        playerCount: totalPlayers,
+        sessionCount: sessionStats.total,
+        confirmedSessionCount: sessionStats.confirmed,
+        availabilityFillRate: fillRate,
+        lastActivity,
+      };
+    });
+
+    return NextResponse.json({ games: gamesWithEngagement });
+  } catch (error) {
+    console.error('Admin games error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+export async function GET(): Promise<Response> {
+  try {
+    // Verify the user is authenticated and is an admin
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Use admin client to check if user is admin and fetch stats
+    const admin = createAdminClient();
+
+    // Check if user is admin
+    const { data: profile, error: profileError } = await admin
+      .from('users')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile?.is_admin) {
+      return NextResponse.json(
+        { error: 'Admin access required' },
+        { status: 403 }
+      );
+    }
+
+    // Fetch all stats in parallel
+    const [
+      usersResult,
+      gamesResult,
+      sessionsResult,
+      recentUsersResult,
+      recentGamesResult,
+    ] = await Promise.all([
+      admin.from('users').select('id', { count: 'exact', head: true }),
+      admin.from('games').select('id', { count: 'exact', head: true }),
+      admin.from('sessions').select('status'),
+      admin.from('users').select('id, name, email, avatar_url, is_gm, is_admin, created_at').order('created_at', { ascending: false }).limit(10),
+      admin.from('games').select('id, name, created_at, gm:users!games_gm_id_fkey(name)').order('created_at', { ascending: false }).limit(10),
+    ]);
+
+    // Count sessions by status
+    const sessionsByStatus = {
+      suggested: 0,
+      confirmed: 0,
+      cancelled: 0,
+    };
+    sessionsResult.data?.forEach((session) => {
+      if (session.status in sessionsByStatus) {
+        sessionsByStatus[session.status as keyof typeof sessionsByStatus]++;
+      }
+    });
+
+    return NextResponse.json({
+      totalUsers: usersResult.count ?? 0,
+      totalGames: gamesResult.count ?? 0,
+      totalSessions: sessionsResult.data?.length ?? 0,
+      sessionsByStatus,
+      recentUsers: recentUsersResult.data ?? [],
+      recentGames: recentGamesResult.data ?? [],
+    });
+  } catch (error) {
+    console.error('Admin stats error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/test-auth/route.ts
+++ b/src/app/api/test-auth/route.ts
@@ -22,6 +22,7 @@ interface TestUserRequest {
   email: string;
   name: string;
   is_gm?: boolean;
+  is_admin?: boolean;
 }
 
 interface TestUserResponse {
@@ -29,6 +30,7 @@ interface TestUserResponse {
   email: string;
   name: string;
   is_gm: boolean;
+  is_admin: boolean;
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -39,7 +41,7 @@ export async function POST(request: Request): Promise<Response> {
 
   try {
     const body = (await request.json()) as TestUserRequest;
-    const { email, name, is_gm = false } = body;
+    const { email, name, is_gm = false, is_admin = false } = body;
 
     if (!email || !name) {
       return NextResponse.json(
@@ -92,10 +94,10 @@ export async function POST(request: Request): Promise<Response> {
       userId = newUser.user!.id;
     }
 
-    // Update the user profile with is_gm if needed
+    // Update the user profile with is_gm and is_admin if needed
     const { error: updateError } = await admin
       .from('users')
-      .update({ name, is_gm })
+      .update({ name, is_gm, is_admin })
       .eq('id', userId);
 
     if (updateError) {
@@ -148,6 +150,7 @@ export async function POST(request: Request): Promise<Response> {
       email,
       name: profile?.name || name,
       is_gm: profile?.is_gm || is_gm,
+      is_admin: profile?.is_admin || is_admin,
     };
 
     // Create response with the session cookies

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -61,14 +61,24 @@ export function Navbar() {
               <Image src="/logo.png" alt="Can We Play?" width={44} height={44} className="shrink-0" />
               <span className="hidden sm:block font-bold text-xl text-foreground">Can We Play?</span>
             </Link>
-            {profile?.is_gm && (
+            {(profile?.is_gm || profile?.is_admin) && (
               <div className="hidden sm:ml-8 sm:flex sm:space-x-4">
-                <Link
-                  href="/games/new"
-                  className="text-muted-foreground hover:text-foreground px-3 py-2 text-sm font-medium transition-colors"
-                >
-                  New Game
-                </Link>
+                {profile?.is_gm && (
+                  <Link
+                    href="/games/new"
+                    className="text-muted-foreground hover:text-foreground px-3 py-2 text-sm font-medium transition-colors"
+                  >
+                    New Game
+                  </Link>
+                )}
+                {profile?.is_admin && (
+                  <Link
+                    href="/admin"
+                    className="text-muted-foreground hover:text-foreground px-3 py-2 text-sm font-medium transition-colors"
+                  >
+                    Admin
+                  </Link>
+                )}
               </div>
             )}
           </div>

--- a/src/hooks/useAuthRedirect.ts
+++ b/src/hooks/useAuthRedirect.ts
@@ -7,6 +7,8 @@ import { useAuth } from '@/contexts/AuthContext';
 interface UseAuthRedirectOptions {
   /** Require user to be a GM, redirect to dashboard if not */
   requireGM?: boolean;
+  /** Require user to be an admin, redirect to dashboard if not */
+  requireAdmin?: boolean;
   /** Custom redirect URL for unauthenticated users (default: /login) */
   redirectTo?: string;
 }
@@ -14,10 +16,10 @@ interface UseAuthRedirectOptions {
 /**
  * Hook to handle auth-based redirects for protected pages.
  * Redirects to login if not authenticated.
- * Optionally redirects non-GMs to dashboard.
+ * Optionally redirects non-GMs or non-admins to dashboard.
  */
 export function useAuthRedirect(options: UseAuthRedirectOptions = {}) {
-  const { requireGM = false, redirectTo = '/login' } = options;
+  const { requireGM = false, requireAdmin = false, redirectTo = '/login' } = options;
   const { session, profile, isLoading } = useAuth();
   const router = useRouter();
 
@@ -28,6 +30,9 @@ export function useAuthRedirect(options: UseAuthRedirectOptions = {}) {
     } else if (requireGM && !isLoading && profile && !profile.is_gm) {
       // If profile loaded but not a GM, redirect to dashboard
       router.push('/dashboard');
+    } else if (requireAdmin && !isLoading && profile && !profile.is_admin) {
+      // If profile loaded but not an admin, redirect to dashboard
+      router.push('/dashboard');
     }
-  }, [isLoading, session, profile, router, redirectTo, requireGM]);
+  }, [isLoading, session, profile, router, redirectTo, requireGM, requireAdmin]);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   name: string;
   avatar_url: string | null;
   is_gm: boolean;
+  is_admin: boolean;
   created_at: string;
 }
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE users (
   name TEXT NOT NULL,
   avatar_url TEXT,
   is_gm BOOLEAN DEFAULT FALSE,
+  is_admin BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -110,7 +111,7 @@ $$ LANGUAGE plpgsql SET search_path = '';
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER AS $$
 BEGIN
-  INSERT INTO public.users (id, email, name, avatar_url, is_gm)
+  INSERT INTO public.users (id, email, name, avatar_url, is_gm, is_admin)
   VALUES (
     NEW.id,
     NEW.email,
@@ -123,6 +124,7 @@ BEGIN
       NEW.raw_user_meta_data->>'avatar_url',
       NEW.raw_user_meta_data->>'picture'
     ),
+    false,
     false
   );
   RETURN NEW;


### PR DESCRIPTION
## Summary
- Add in-app admin dashboard at `/admin` to track usage metrics
- Overview tab: total users, games, and confirmed sessions
- Games tab: list all games with engagement metrics (player count, session count, availability fill rate, last activity)
- Activity tab: recent users and games
- Admin link in navbar (visible only to admins)
- Protected by `is_admin` flag on user profile

## Schema Change
- Added `is_admin BOOLEAN DEFAULT FALSE` to `users` table

## How to Use
1. Run migration: `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;`
2. Set yourself as admin: `UPDATE users SET is_admin = true WHERE email = 'your@email.com';`
3. Visit `/admin`

## Test plan
- [x] Non-admin user redirected to dashboard when visiting /admin
- [x] Admin user can access /admin and see all tabs
- [x] Admin link appears in navbar for admin users only
- [x] Overview shows correct stats
- [x] Games tab shows game list with metrics
- [x] Activity tab shows recent users and games
- [x] All E2E tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)