### PR TITLE
Add calendar subscription feeds for games

### DIFF
--- a/e2e/tests/games/game-detail.spec.ts
+++ b/e2e/tests/games/game-detail.spec.ts
@@ -163,10 +163,36 @@ test.describe('Game Detail Page', () => {
     });
 
     await page.goto(`/games/${game.id}`);
-    
+
     // Should show both GM and player in members list (wait for page to load)
     // Use the member list section specifically to avoid matching navbar
     await expect(page.getByRole('list').getByText(/members test gm/i)).toBeVisible();
     await expect(page.getByRole('list').getByText(/test player member/i)).toBeVisible();
+  });
+
+  test('shows calendar subscription button', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-calendar-${Date.now()}@e2e.local`,
+      name: 'Calendar Test GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Calendar Test Campaign',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    // Should see calendar subscription section in Game Details
+    await expect(page.getByText(/calendar subscription/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /copy calendar url/i })).toBeVisible();
   });
 });

--- a/e2e/tests/scheduling/calendar-feed.spec.ts
+++ b/e2e/tests/scheduling/calendar-feed.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+import { createTestUser } from '../../helpers/test-auth';
+import { createTestGame, createTestSession, getPlayDates } from '../../helpers/seed';
+
+test.describe('Calendar Subscription Feed', () => {
+  test('returns valid ICS for game with confirmed sessions', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cal-feed-${Date.now()}@e2e.local`,
+      name: 'Calendar Feed GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Calendar Feed Campaign',
+      play_days: [5, 6],
+      default_start_time: '18:00',
+      default_end_time: '22:00',
+    });
+
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '23:00',
+    });
+
+    // Fetch the calendar feed directly
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('text/calendar');
+
+    const icsContent = await response.text();
+
+    // Verify iCalendar structure
+    expect(icsContent).toContain('BEGIN:VCALENDAR');
+    expect(icsContent).toContain('END:VCALENDAR');
+    expect(icsContent).toContain('VERSION:2.0');
+    expect(icsContent).toContain('BEGIN:VEVENT');
+    expect(icsContent).toContain('END:VEVENT');
+
+    // Verify event details
+    expect(icsContent).toContain('Calendar Feed Campaign');
+    expect(icsContent).toMatch(/DTSTART/);
+    expect(icsContent).toMatch(/DTEND/);
+  });
+
+  test('returns empty calendar for game with no confirmed sessions', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cal-empty-${Date.now()}@e2e.local`,
+      name: 'Calendar Empty GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Empty Calendar Campaign',
+      play_days: [5, 6],
+    });
+
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+
+    expect(response.status()).toBe(200);
+
+    const icsContent = await response.text();
+
+    // Should be valid but empty calendar
+    expect(icsContent).toContain('BEGIN:VCALENDAR');
+    expect(icsContent).toContain('END:VCALENDAR');
+    expect(icsContent).not.toContain('BEGIN:VEVENT');
+  });
+
+  test('returns 404 for invalid invite code', async ({ request }) => {
+    const response = await request.get('/api/games/calendar/invalid-code-123');
+
+    expect(response.status()).toBe(404);
+  });
+
+  test('includes multiple sessions in feed', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cal-multi-${Date.now()}@e2e.local`,
+      name: 'Calendar Multi GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Multi Session Campaign',
+      play_days: [5, 6],
+    });
+
+    const playDates = getPlayDates([5, 6], 4);
+
+    // Create multiple sessions
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+    });
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[1],
+      confirmed_by: gm.id,
+    });
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[2],
+      confirmed_by: gm.id,
+    });
+
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+
+    expect(response.status()).toBe(200);
+
+    const icsContent = await response.text();
+
+    // Count VEVENT occurrences (should be 3)
+    const eventCount = (icsContent.match(/BEGIN:VEVENT/g) || []).length;
+    expect(eventCount).toBe(3);
+  });
+
+  test('uses default times when session has no times', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cal-default-${Date.now()}@e2e.local`,
+      name: 'Calendar Default GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Default Times Campaign',
+      play_days: [5, 6],
+      default_start_time: '20:00',
+      default_end_time: '00:00',
+    });
+
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '20:00',
+      end_time: '00:00',
+    });
+
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+
+    expect(response.status()).toBe(200);
+
+    const icsContent = await response.text();
+
+    // Should contain timed event with default times (200000 = 20:00:00)
+    expect(icsContent).toMatch(/DTSTART.*T200000/);
+  });
+
+  test('has correct content-disposition header', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-cal-header-${Date.now()}@e2e.local`,
+      name: 'Calendar Header GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Test Game!@#$',
+      play_days: [5, 6],
+    });
+
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+
+    expect(response.status()).toBe(200);
+
+    const contentDisposition = response.headers()['content-disposition'];
+    expect(contentDisposition).toContain('attachment');
+    expect(contentDisposition).toContain('.ics');
+    // Should sanitize special characters in filename
+    expect(contentDisposition).toMatch(/Test_Game/);
+  });
+});

--- a/src/app/api/games/calendar/[code]/route.ts
+++ b/src/app/api/games/calendar/[code]/route.ts
@@ -1,0 +1,80 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { generateICS } from '@/lib/ics';
+import type { Game, GameSession } from '@/types';
+
+/**
+ * Public endpoint for calendar subscription feeds.
+ * Returns an ICS file with confirmed game sessions.
+ * Calendar clients can subscribe to this URL to get automatic updates.
+ *
+ * URL format: /api/games/calendar/[inviteCode]
+ * Webcal URL: webcal://hostname/api/games/calendar/[inviteCode]
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ code: string }> }
+): Promise<Response> {
+  try {
+    const { code } = await params;
+
+    if (!code) {
+      return new Response('Invite code is required', { status: 400 });
+    }
+
+    const admin = createAdminClient();
+
+    // Fetch game by invite code
+    const { data: game, error: gameError } = await admin
+      .from('games')
+      .select('id, name, description, default_start_time, default_end_time')
+      .eq('invite_code', code)
+      .single();
+
+    if (gameError || !game) {
+      return new Response('Game not found', { status: 404 });
+    }
+
+    const typedGame = game as Pick<Game, 'id' | 'name' | 'description' | 'default_start_time' | 'default_end_time'>;
+
+    // Fetch confirmed sessions for this game
+    const { data: sessions, error: sessionsError } = await admin
+      .from('sessions')
+      .select('id, date, start_time, end_time, status')
+      .eq('game_id', typedGame.id)
+      .eq('status', 'confirmed')
+      .order('date', { ascending: true });
+
+    if (sessionsError) {
+      console.error('Error fetching sessions:', sessionsError);
+      return new Response('Error fetching sessions', { status: 500 });
+    }
+
+    const typedSessions = (sessions || []) as Pick<GameSession, 'id' | 'date' | 'start_time' | 'end_time' | 'status'>[];
+
+    // Convert sessions to calendar events
+    const events = typedSessions.map((session) => ({
+      date: session.date,
+      startTime: session.start_time || typedGame.default_start_time || undefined,
+      endTime: session.end_time || typedGame.default_end_time || undefined,
+      title: typedGame.name,
+      description: typedGame.description || undefined,
+    }));
+
+    // Generate ICS content
+    const icsContent = generateICS(events);
+
+    // Return ICS file with proper headers for calendar subscription
+    return new Response(icsContent, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${typedGame.name.replace(/[^a-zA-Z0-9]/g, '_')}.ics"`,
+        // Cache for 5 minutes to allow calendar clients to refresh
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+  } catch (error) {
+    console.error('Calendar feed error:', error);
+    return new Response('Internal server error', { status: 500 });
+  }
+}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -59,6 +59,7 @@ export default function GameDetailPage() {
   const [sessions, setSessions] = useState<GameSession[]>([]);
   const [suggestions, setSuggestions] = useState<DateSuggestion[]>([]);
   const [copied, setCopied] = useState(false);
+  const [calendarCopied, setCalendarCopied] = useState(false);
   const [playerToRemove, setPlayerToRemove] = useState<User | null>(null);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
@@ -382,6 +383,15 @@ export default function GameDetailPage() {
     navigator.clipboard.writeText(link);
     setCopied(true);
     setTimeout(() => setCopied(false), TIMEOUTS.NOTIFICATION);
+  };
+
+  const copyCalendarUrl = () => {
+    if (!game) return;
+    // Use webcal:// protocol for calendar subscription
+    const webcalUrl = `webcal://${window.location.host}/api/games/calendar/${game.invite_code}`;
+    navigator.clipboard.writeText(webcalUrl);
+    setCalendarCopied(true);
+    setTimeout(() => setCalendarCopied(false), TIMEOUTS.NOTIFICATION);
   };
 
   const handleLeaveGame = async () => {
@@ -756,6 +766,21 @@ export default function GameDetailPage() {
                   </ul>
                 </div>
               )}
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Calendar Subscription
+                </p>
+                <p className="text-xs text-muted-foreground mt-1 mb-2">
+                  Subscribe to get confirmed sessions in your calendar app
+                </p>
+                <Button
+                  onClick={copyCalendarUrl}
+                  variant="secondary"
+                  className="text-sm"
+                >
+                  {calendarCopied ? "Copied!" : "Copy Calendar URL"}
+                </Button>
+              </div>
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
- Add /api/games/calendar/[code] endpoint that returns ICS format
- Uses invite code for public access (calendar clients can't authenticate)
- Includes all confirmed sessions with game name and times
- Add "Copy Calendar URL" button to game details page
- Add E2E tests for calendar feed endpoint