### PR TITLE
Add chronological sort toggle for session suggestions

### DIFF
--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -87,6 +87,17 @@ export function sortSuggestions(
   });
 }
 
+/**
+ * Sort suggestions purely by date (ascending), ignoring availability scores
+ */
+export function sortSuggestionsChronologically(
+  suggestions: DateSuggestion[]
+): DateSuggestion[] {
+  return [...suggestions].sort((a, b) =>
+    new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+}
+
 interface CalculateSuggestionsParams {
   playDates: Date[];
   players: User[];


### PR DESCRIPTION
Add ability to sort suggestions by "Best Match" (default, maximizes player availability) or "By Date" (pure chronological ordering).

The feature includes:
- Segmented control UI in the Date Suggestions card header
- Dynamic description text that updates based on selected sort mode
- Pure chronological sort function that ignores availability scores
- Comprehensive unit tests for the new sorting function
- E2E tests for toggle functionality and behavior

Sort preference resets to "Best Match" on page load (no persistence).