### PR TITLE
Fix ICS calendar subscriptions importing only first session

### DIFF
--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -281,4 +281,62 @@ describe("generateICS", () => {
     expect(result).toContain("DTEND;VALUE=DATE:20250120");
     expect(result).not.toContain("TZID");
   });
+
+  it("includes VTIMEZONE component when timezone is used", () => {
+    const result = generateICS([
+      {
+        date: "2025-01-20",
+        startTime: "18:00",
+        endTime: "22:00",
+        title: "Game Night",
+        timezone: "America/Los_Angeles",
+      },
+    ]);
+
+    // Must include VTIMEZONE for calendar apps to parse correctly
+    expect(result).toContain("BEGIN:VTIMEZONE");
+    expect(result).toContain("TZID:America/Los_Angeles");
+    expect(result).toContain("END:VTIMEZONE");
+    expect(result).toContain("BEGIN:STANDARD");
+    expect(result).toContain("END:STANDARD");
+    expect(result).toContain("BEGIN:DAYLIGHT");
+    expect(result).toContain("END:DAYLIGHT");
+    expect(result).toContain("TZNAME:PST");
+    expect(result).toContain("TZNAME:PDT");
+  });
+
+  it("includes only one VTIMEZONE per unique timezone", () => {
+    const result = generateICS([
+      {
+        date: "2025-01-20",
+        startTime: "18:00",
+        endTime: "22:00",
+        title: "Event 1",
+        timezone: "America/Los_Angeles",
+      },
+      {
+        date: "2025-01-21",
+        startTime: "18:00",
+        endTime: "22:00",
+        title: "Event 2",
+        timezone: "America/Los_Angeles",
+      },
+    ]);
+
+    // Should only include one VTIMEZONE block even with multiple events
+    expect(result.match(/BEGIN:VTIMEZONE/g)?.length).toBe(1);
+  });
+
+  it("does not include VTIMEZONE when no timezone used", () => {
+    const result = generateICS([
+      {
+        date: "2025-01-20",
+        startTime: "18:00",
+        endTime: "22:00",
+        title: "Game Night",
+      },
+    ]);
+
+    expect(result).not.toContain("BEGIN:VTIMEZONE");
+  });
 });

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -12,7 +12,109 @@ interface CalendarEvent {
   timezone?: string; // IANA timezone identifier (e.g., 'America/Los_Angeles')
 }
 
+/**
+ * Generate VTIMEZONE component for a given timezone.
+ * Calendar apps require VTIMEZONE definitions when TZID is used in DTSTART/DTEND.
+ */
+function generateVTimezone(tzid: string): string[] {
+  // Common US timezone definitions with DST rules
+  const timezones: Record<string, { std: { offset: string; abbr: string; month: number; day: string }; dst: { offset: string; abbr: string; month: number; day: string } }> = {
+    'America/Los_Angeles': {
+      std: { offset: '-0800', abbr: 'PST', month: 11, day: '1SU' },
+      dst: { offset: '-0700', abbr: 'PDT', month: 3, day: '2SU' },
+    },
+    'America/Denver': {
+      std: { offset: '-0700', abbr: 'MST', month: 11, day: '1SU' },
+      dst: { offset: '-0600', abbr: 'MDT', month: 3, day: '2SU' },
+    },
+    'America/Chicago': {
+      std: { offset: '-0600', abbr: 'CST', month: 11, day: '1SU' },
+      dst: { offset: '-0500', abbr: 'CDT', month: 3, day: '2SU' },
+    },
+    'America/New_York': {
+      std: { offset: '-0500', abbr: 'EST', month: 11, day: '1SU' },
+      dst: { offset: '-0400', abbr: 'EDT', month: 3, day: '2SU' },
+    },
+    'America/Phoenix': {
+      // Arizona doesn't observe DST
+      std: { offset: '-0700', abbr: 'MST', month: 1, day: '1SU' },
+      dst: { offset: '-0700', abbr: 'MST', month: 1, day: '1SU' },
+    },
+    'Pacific/Honolulu': {
+      // Hawaii doesn't observe DST
+      std: { offset: '-1000', abbr: 'HST', month: 1, day: '1SU' },
+      dst: { offset: '-1000', abbr: 'HST', month: 1, day: '1SU' },
+    },
+    'America/Anchorage': {
+      std: { offset: '-0900', abbr: 'AKST', month: 11, day: '1SU' },
+      dst: { offset: '-0800', abbr: 'AKDT', month: 3, day: '2SU' },
+    },
+    'Europe/London': {
+      std: { offset: '+0000', abbr: 'GMT', month: 10, day: '-1SU' },
+      dst: { offset: '+0100', abbr: 'BST', month: 3, day: '-1SU' },
+    },
+    'Europe/Paris': {
+      std: { offset: '+0100', abbr: 'CET', month: 10, day: '-1SU' },
+      dst: { offset: '+0200', abbr: 'CEST', month: 3, day: '-1SU' },
+    },
+    'UTC': {
+      std: { offset: '+0000', abbr: 'UTC', month: 1, day: '1SU' },
+      dst: { offset: '+0000', abbr: 'UTC', month: 1, day: '1SU' },
+    },
+  };
+
+  const tz = timezones[tzid];
+  if (!tz) {
+    // Unknown timezone - return empty (events will use floating time interpretation)
+    return [];
+  }
+
+  const lines: string[] = [
+    'BEGIN:VTIMEZONE',
+    `TZID:${tzid}`,
+    `X-LIC-LOCATION:${tzid}`,
+  ];
+
+  // Add DAYLIGHT component (DST)
+  if (tz.dst.offset !== tz.std.offset) {
+    const dstOffsetFrom = tz.std.offset;
+    lines.push(
+      'BEGIN:DAYLIGHT',
+      `TZOFFSETFROM:${dstOffsetFrom}`,
+      `TZOFFSETTO:${tz.dst.offset}`,
+      `TZNAME:${tz.dst.abbr}`,
+      `DTSTART:19700101T020000`,
+      `RRULE:FREQ=YEARLY;BYMONTH=${tz.dst.month};BYDAY=${tz.dst.day}`,
+      'END:DAYLIGHT',
+    );
+  }
+
+  // Add STANDARD component
+  const stdOffsetFrom = tz.dst.offset !== tz.std.offset ? tz.dst.offset : tz.std.offset;
+  lines.push(
+    'BEGIN:STANDARD',
+    `TZOFFSETFROM:${stdOffsetFrom}`,
+    `TZOFFSETTO:${tz.std.offset}`,
+    `TZNAME:${tz.std.abbr}`,
+    `DTSTART:19700101T020000`,
+    `RRULE:FREQ=YEARLY;BYMONTH=${tz.std.month};BYDAY=${tz.std.day}`,
+    'END:STANDARD',
+  );
+
+  lines.push('END:VTIMEZONE');
+
+  return lines;
+}
+
 export function generateICS(events: CalendarEvent[]): string {
+  // Collect unique timezones used by events
+  const timezones = new Set<string>();
+  events.forEach((event) => {
+    if (event.timezone && event.startTime && event.endTime) {
+      timezones.add(event.timezone);
+    }
+  });
+
   const lines: string[] = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
@@ -20,6 +122,11 @@ export function generateICS(events: CalendarEvent[]): string {
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
   ];
+
+  // Add VTIMEZONE components for all used timezones
+  timezones.forEach((tz) => {
+    lines.push(...generateVTimezone(tz));
+  });
 
   events.forEach((event, index) => {
     const dateStr = event.date.replace(/-/g, '');


### PR DESCRIPTION
Calendar apps require VTIMEZONE components when TZID is used in DTSTART/DTEND properties. Without timezone definitions, they fail to parse subsequent events in subscriptions. Added VTIMEZONE generation with DST rules for common US and European timezones to fix calendar import issues.

## Changes
- Added `generateVTimezone()` function with timezone definitions for US and European timezones
- Modified `generateICS()` to collect unique timezones and insert VTIMEZONE blocks after calendar header
- Added comprehensive tests for VTIMEZONE behavior

## Testing
All 28 existing and new ICS tests pass.