### PR TITLE
Add subject line to feedback email link

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -47,7 +47,7 @@ function HelpDropdown() {
           </a>
           {FEEDBACK_EMAIL && (
             <a
-              href={`mailto:${FEEDBACK_EMAIL}`}
+              href={`mailto:${FEEDBACK_EMAIL}?subject=${encodeURIComponent('Can We Play? Feedback')}`}
               className="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors whitespace-nowrap"
               onClick={() => setIsOpen(false)}
             >


### PR DESCRIPTION
## Summary
Updated the feedback email link in the help dropdown to include a pre-filled subject line, improving the user experience when sending feedback.

## Changes
- Modified the mailto link for the feedback email to include a `subject` parameter with "Can We Play? Feedback" as the pre-filled subject
- Used `encodeURIComponent()` to properly encode the subject line for URL safety

## Details
This change ensures that when users click the feedback link, their email client will automatically populate the subject line with "Can We Play? Feedback", making it easier for users to send feedback and helping organize incoming feedback emails by subject.

https://claude.ai/code/session_012ZxV6cpbEYWtjSXgLZ4o2T