### PR TITLE
Remove GitHub link from help menu and fix DST test

### DIFF
--- a/e2e/tests/home/help-menu.spec.ts
+++ b/e2e/tests/home/help-menu.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { TEST_TIMEOUTS } from '../../constants';
 
 test.describe('Help Menu', () => {
-  test('help dropdown shows bug report and feedback links', async ({ page }) => {
+  test('help dropdown shows how-to and feedback links', async ({ page }) => {
     await page.goto('/');
 
     // Wait for page to load
@@ -13,13 +13,10 @@ test.describe('Help Menu', () => {
     // Click help menu button
     await page.getByRole('button', { name: 'Help menu' }).click();
 
-    // Report Bug link should be visible with correct href
-    const bugLink = page.getByRole('link', { name: 'Report Bug' });
-    await expect(bugLink).toBeVisible();
-    await expect(bugLink).toHaveAttribute(
-      'href',
-      'https://github.com/evilscheme/gamenightscheduler/issues'
-    );
+    // How to Use link should be visible
+    const howToLink = page.getByRole('link', { name: 'How to Use' });
+    await expect(howToLink).toBeVisible();
+    await expect(howToLink).toHaveAttribute('href', '/help');
 
     // Send Feedback link should be visible with mailto href
     const feedbackLink = page.getByRole('link', { name: 'Send Feedback' });
@@ -36,12 +33,12 @@ test.describe('Help Menu', () => {
 
     // Open help menu
     await page.getByRole('button', { name: 'Help menu' }).click();
-    await expect(page.getByRole('link', { name: 'Report Bug' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'How to Use' })).toBeVisible();
 
     // Click outside the menu (on the page body)
     await page.locator('main').click();
 
     // Menu should close
-    await expect(page.getByRole('link', { name: 'Report Bug' })).not.toBeVisible();
+    await expect(page.getByRole('link', { name: 'How to Use' })).not.toBeVisible();
   });
 });

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,13 +3,12 @@
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { BookOpen, Bug, Mail } from 'lucide-react';
+import { BookOpen, Mail } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui';
 import { createClient } from '@/lib/supabase/client';
 import { fetchUserGameCount } from '@/lib/data';
 
-const GITHUB_ISSUES_URL = 'https://github.com/evilscheme/gamenightscheduler/issues';
 const FEEDBACK_EMAIL = process.env.NEXT_PUBLIC_FEEDBACK_EMAIL;
 
 function HelpDropdown() {
@@ -45,16 +44,6 @@ function HelpDropdown() {
             <BookOpen className="size-4" />
             How to Use
           </Link>
-          <a
-            href={GITHUB_ISSUES_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors whitespace-nowrap"
-            onClick={() => setIsOpen(false)}
-          >
-            <Bug className="size-4" />
-            Report Bug
-          </a>
           {FEEDBACK_EMAIL && (
             <a
               href={`mailto:${FEEDBACK_EMAIL}?subject=${encodeURIComponent('Can We Play? Feedback')}`}

--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -45,8 +45,8 @@ describe("formatTimezoneDisplay", () => {
 
   it("formats Europe/London with city name and abbreviation", () => {
     const result = formatTimezoneDisplay("Europe/London");
-    // GMT in winter, BST in summer
-    expect(result).toMatch(/^London \((GMT|BST)\)$/);
+    // GMT in winter, BST (or GMT+1) in summer depending on ICU/Node version
+    expect(result).toMatch(/^London \((GMT|BST|GMT\+1)\)$/);
   });
 
   it("falls back to the raw string for an invalid timezone", () => {


### PR DESCRIPTION
## Summary
- Remove the "Report Bug" GitHub Issues link from the navbar help dropdown, keeping only "How to Use" and "Send Feedback" (email)
- Fix a DST-dependent timezone test that broke when Europe/London entered BST — some Node.js/ICU versions return `GMT+1` instead of `BST`
- Update E2E help menu tests to match the new menu items

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] `timezone.test.ts` passes (28/28 tests)
- [ ] E2E help menu tests pass with updated assertions