### PR TITLE
Improve mini-calendar tier coloring (weighted maybes, past state)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,10 @@
 
   --cal-available-bg: #22c55e;
   --cal-available-text: #ffffff;
+  --cal-available-medium-bg: #86efac;
+  --cal-available-medium-text: #ffffff;
+  --cal-empty-bg: #cbd5e1;
+  --cal-empty-text: #475569;
   --cal-maybe-bg: #f59e0b;
   --cal-maybe-text: #ffffff;
   --cal-unavailable-bg: #dc2626;
@@ -81,8 +85,12 @@
   --danger-muted: #ef4444;
   --scheduled: #38bdf8;
 
-  --cal-available-bg: #166534;
-  --cal-available-text: #86efac;
+  --cal-available-bg: #15803d;
+  --cal-available-text: #dcfce7;
+  --cal-available-medium-bg: #14532d;
+  --cal-available-medium-text: #4ade80;
+  --cal-empty-bg: #334155;
+  --cal-empty-text: #94a3b8;
   --cal-maybe-bg: #854d0e;
   --cal-maybe-text: #fde68a;
   --cal-unavailable-bg: #991b1b;
@@ -140,6 +148,10 @@
 
   --cal-available-bg: #22c55e;
   --cal-available-text: #ffffff;
+  --cal-available-medium-bg: #86efac;
+  --cal-available-medium-text: #ffffff;
+  --cal-empty-bg: #cbd5e1;
+  --cal-empty-text: #475569;
   --cal-maybe-bg: #f59e0b;
   --cal-maybe-text: #ffffff;
   --cal-unavailable-bg: #dc2626;
@@ -175,8 +187,12 @@
   --danger-muted: #ef4444;
   --scheduled: #a78bfa;
 
-  --cal-available-bg: #166534;
-  --cal-available-text: #86efac;
+  --cal-available-bg: #15803d;
+  --cal-available-text: #dcfce7;
+  --cal-available-medium-bg: #14532d;
+  --cal-available-medium-text: #4ade80;
+  --cal-empty-bg: #334155;
+  --cal-empty-text: #94a3b8;
   --cal-maybe-bg: #854d0e;
   --cal-maybe-text: #fde68a;
   --cal-unavailable-bg: #991b1b;
@@ -217,6 +233,10 @@
 
   --cal-available-bg: #22c55e;
   --cal-available-text: #ffffff;
+  --cal-available-medium-bg: #86efac;
+  --cal-available-medium-text: #ffffff;
+  --cal-empty-bg: #cbd5e1;
+  --cal-empty-text: #475569;
   --cal-maybe-bg: #f59e0b;
   --cal-maybe-text: #ffffff;
   --cal-unavailable-bg: #dc2626;
@@ -252,8 +272,12 @@
   --danger-muted: #ef4444;
   --scheduled: #4ade80;
 
-  --cal-available-bg: #166534;
-  --cal-available-text: #86efac;
+  --cal-available-bg: #15803d;
+  --cal-available-text: #dcfce7;
+  --cal-available-medium-bg: #14532d;
+  --cal-available-medium-text: #4ade80;
+  --cal-empty-bg: #334155;
+  --cal-empty-text: #94a3b8;
   --cal-maybe-bg: #854d0e;
   --cal-maybe-text: #fde68a;
   --cal-unavailable-bg: #991b1b;
@@ -294,6 +318,10 @@
 
   --cal-available-bg: #22c55e;
   --cal-available-text: #ffffff;
+  --cal-available-medium-bg: #86efac;
+  --cal-available-medium-text: #ffffff;
+  --cal-empty-bg: #cbd5e1;
+  --cal-empty-text: #475569;
   --cal-maybe-bg: #f59e0b;
   --cal-maybe-text: #ffffff;
   --cal-unavailable-bg: #dc2626;
@@ -329,8 +357,12 @@
   --danger-muted: #ef4444;
   --scheduled: #94a3b8;
 
-  --cal-available-bg: #166534;
-  --cal-available-text: #86efac;
+  --cal-available-bg: #15803d;
+  --cal-available-text: #dcfce7;
+  --cal-available-medium-bg: #14532d;
+  --cal-available-medium-text: #4ade80;
+  --cal-empty-bg: #334155;
+  --cal-empty-text: #94a3b8;
   --cal-maybe-bg: #854d0e;
   --cal-maybe-text: #fde68a;
   --cal-unavailable-bg: #991b1b;
@@ -371,6 +403,10 @@
 
   --cal-available-bg: #22c55e;
   --cal-available-text: #ffffff;
+  --cal-available-medium-bg: #86efac;
+  --cal-available-medium-text: #ffffff;
+  --cal-empty-bg: #cbd5e1;
+  --cal-empty-text: #475569;
   --cal-maybe-bg: #f59e0b;
   --cal-maybe-text: #ffffff;
   --cal-unavailable-bg: #dc2626;
@@ -406,8 +442,12 @@
   --danger-muted: #ef4444;
   --scheduled: #fb7185;
 
-  --cal-available-bg: #166534;
-  --cal-available-text: #86efac;
+  --cal-available-bg: #15803d;
+  --cal-available-text: #dcfce7;
+  --cal-available-medium-bg: #14532d;
+  --cal-available-medium-text: #4ade80;
+  --cal-empty-bg: #334155;
+  --cal-empty-text: #94a3b8;
   --cal-maybe-bg: #854d0e;
   --cal-maybe-text: #fde68a;
   --cal-unavailable-bg: #991b1b;
@@ -446,6 +486,10 @@
   /* Calendar colors */
   --color-cal-available-bg: var(--cal-available-bg);
   --color-cal-available-text: var(--cal-available-text);
+  --color-cal-available-medium-bg: var(--cal-available-medium-bg);
+  --color-cal-available-medium-text: var(--cal-available-medium-text);
+  --color-cal-empty-bg: var(--cal-empty-bg);
+  --color-cal-empty-text: var(--cal-empty-text);
   --color-cal-maybe-bg: var(--cal-maybe-bg);
   --color-cal-maybe-text: var(--cal-maybe-text);
   --color-cal-unavailable-bg: var(--cal-unavailable-bg);

--- a/src/components/games/schedule/CalendarCell.tsx
+++ b/src/components/games/schedule/CalendarCell.tsx
@@ -2,25 +2,19 @@
 
 import { CellTintTier } from '@/lib/scheduleView';
 import { useHoverSync } from './HoverSyncContext';
+import { CALENDAR_STYLES } from './calendarStyles';
 
 interface CalendarCellProps {
   date: string | null;
   day: number | null;
   isPlayDay: boolean;
   isScheduled: boolean;
+  isPast: boolean;
   tier: CellTintTier | null;
   onActivate?: (date: string) => void;
 }
 
-const TIER_BG: Record<CellTintTier, string> = {
-  high: 'bg-cal-available-bg text-cal-available-text',
-  medium: 'bg-cal-available-bg/60 text-cal-available-text',
-  maybe: 'bg-cal-maybe-bg text-cal-maybe-text',
-  warning: 'bg-cal-unavailable-bg/60 text-cal-unavailable-text',
-  empty: 'bg-muted/40 text-muted-foreground',
-};
-
-export function CalendarCell({ date, day, isPlayDay, isScheduled, tier, onActivate }: CalendarCellProps) {
+export function CalendarCell({ date, day, isPlayDay, isScheduled, isPast, tier, onActivate }: CalendarCellProps) {
   const { hoveredDate, setHoveredDate } = useHoverSync();
   const hovered = !!date && hoveredDate === date;
 
@@ -35,7 +29,7 @@ export function CalendarCell({ date, day, isPlayDay, isScheduled, tier, onActiva
         onClick={() => onActivate?.(date)}
         onMouseEnter={() => setHoveredDate(date)}
         onMouseLeave={() => setHoveredDate(null)}
-        className={`aspect-square rounded-sm flex items-center justify-center bg-cal-scheduled-bg text-cal-scheduled-text font-mono text-[10px] font-bold ${hovered ? 'outline outline-2 outline-primary' : ''}`}
+        className={`aspect-square rounded-sm flex items-center justify-center ${CALENDAR_STYLES.scheduled.className} font-mono text-[10px] font-bold ${hovered ? 'outline outline-2 outline-primary' : ''}`}
         aria-label={`Scheduled on ${date}`}
         data-testid="calendar-cell"
         data-date={date}
@@ -56,7 +50,9 @@ export function CalendarCell({ date, day, isPlayDay, isScheduled, tier, onActiva
     );
   }
 
-  const tintCls = tier ? TIER_BG[tier] : TIER_BG.empty;
+  const tintCls = isPast
+    ? CALENDAR_STYLES.past.className
+    : CALENDAR_STYLES[tier ?? 'empty'].className;
 
   return (
     <button

--- a/src/components/games/schedule/CalendarMonth.tsx
+++ b/src/components/games/schedule/CalendarMonth.tsx
@@ -17,6 +17,7 @@ interface CalendarMonthProps {
   playDayWeekdays: Set<number>;
   specialPlayDates: Set<string>;
   weekStartDay: number;
+  today: Date;
   onCellActivate: (date: string) => void;
 }
 
@@ -27,6 +28,7 @@ export function CalendarMonth({
   playDayWeekdays,
   specialPlayDates,
   weekStartDay,
+  today,
   onCellActivate,
 }: CalendarMonthProps) {
   const first = startOfMonth(monthStart);
@@ -49,12 +51,13 @@ export function CalendarMonth({
       </div>
       <div className="grid grid-cols-7 gap-0.75">
         {Array.from({ length: leadingBlanks }).map((_, i) => (
-          <CalendarCell key={`lead-${i}`} date={null} day={null} isPlayDay={false} isScheduled={false} tier={null} />
+          <CalendarCell key={`lead-${i}`} date={null} day={null} isPlayDay={false} isScheduled={false} isPast={false} tier={null} />
         ))}
         {days.map((d) => {
           const key = format(d, 'yyyy-MM-dd');
           const info = suggestionsByDate.get(key);
           const isPlayDay = playDayWeekdays.has(getDay(d)) || specialPlayDates.has(key);
+          const isPast = d < today;
           return (
             <CalendarCell
               key={key}
@@ -62,6 +65,7 @@ export function CalendarMonth({
               day={d.getDate()}
               isPlayDay={isPlayDay}
               isScheduled={scheduledDates.has(key)}
+              isPast={isPast}
               tier={info?.tier ?? null}
               onActivate={onCellActivate}
             />

--- a/src/components/games/schedule/MiniCalendar.tsx
+++ b/src/components/games/schedule/MiniCalendar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useMemo } from 'react';
-import { addMonths, startOfMonth, differenceInCalendarMonths } from 'date-fns';
+import { addMonths, startOfMonth, differenceInCalendarMonths, startOfDay } from 'date-fns';
 import type { DateSuggestion, GameSession } from '@/types';
 import { CalendarMonth } from './CalendarMonth';
 import { EyebrowLabel, Panel } from '@/components/ui';
 import { getCellTintTier, CellTintTier } from '@/lib/scheduleView';
+import { CALENDAR_STYLES, LEGEND_ORDER } from './calendarStyles';
 
 interface MiniCalendarProps {
   windowStart: Date;
@@ -52,6 +53,8 @@ export function MiniCalendar({
     [sessions]
   );
 
+  const today = useMemo(() => startOfDay(new Date()), []);
+
   const body = (
     <>
       {embedded ? (
@@ -72,15 +75,18 @@ export function MiniCalendar({
             playDayWeekdays={playDayWeekdays}
             specialPlayDates={specialPlayDates}
             weekStartDay={weekStartDay}
+            today={today}
             onCellActivate={onCellActivate}
           />
         ))}
       </div>
       <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
-        <span className="inline-flex items-center gap-1"><span className="size-2 rounded-sm bg-cal-available-bg" /> Most available</span>
-        <span className="inline-flex items-center gap-1"><span className="size-2 rounded-sm bg-cal-maybe-bg" /> Mixed</span>
-        <span className="inline-flex items-center gap-1"><span className="size-2 rounded-sm bg-cal-unavailable-bg/60" /> Low availability</span>
-        <span className="inline-flex items-center gap-1"><span className="size-2 rounded-sm bg-cal-scheduled-bg" /> ★ Scheduled</span>
+        {LEGEND_ORDER.map((state) => (
+          <span key={state} className="inline-flex items-center gap-1">
+            <span className={`size-2 rounded-sm ${CALENDAR_STYLES[state].className}`} />
+            {CALENDAR_STYLES[state].label}
+          </span>
+        ))}
       </div>
     </>
   );

--- a/src/components/games/schedule/calendarStyles.ts
+++ b/src/components/games/schedule/calendarStyles.ts
@@ -1,0 +1,23 @@
+import type { CellTintTier } from '@/lib/scheduleView';
+
+export type CalendarVisualState = CellTintTier | 'scheduled' | 'past';
+
+/**
+ * Single source of truth for mini-calendar cell appearance.
+ * - `className` is applied to both the cell and the legend swatch — text-* classes
+ *   are inert on an empty swatch, so combining bg + text keeps one entry per state.
+ * - Adding a new visual state means updating this map AND `LEGEND_ORDER` below.
+ */
+export const CALENDAR_STYLES: Record<CalendarVisualState, { className: string; label: string }> = {
+  high:      { className: 'bg-cal-available-bg text-cal-available-text', label: 'Most available' },
+  medium:    { className: 'bg-cal-available-medium-bg text-cal-available-medium-text', label: 'Some available' },
+  maybe:     { className: 'bg-cal-maybe-bg text-cal-maybe-text', label: 'Mixed' },
+  warning:   { className: 'bg-cal-unavailable-bg/60 text-cal-unavailable-text', label: 'Mostly unavailable' },
+  empty:     { className: 'bg-cal-empty-bg text-cal-empty-text', label: 'Awaiting responses' },
+  past:      { className: 'bg-cal-empty-bg/30 text-cal-empty-text/60', label: 'Past' },
+  scheduled: { className: 'bg-cal-scheduled-bg text-cal-scheduled-text', label: '★ Scheduled' },
+};
+
+export const LEGEND_ORDER: CalendarVisualState[] = [
+  'high', 'medium', 'maybe', 'warning', 'empty', 'past', 'scheduled',
+];

--- a/src/lib/scheduleView.test.ts
+++ b/src/lib/scheduleView.test.ts
@@ -28,29 +28,48 @@ const mkSuggestion = (overrides: Partial<DateSuggestion>): DateSuggestion => ({
 });
 
 describe('getCellTintTier', () => {
-  it('returns "high" when >= 80% available', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 4 }))).toBe('high');
-    expect(getCellTintTier(mkSuggestion({ availableCount: 5 }))).toBe('high');
+  it('returns "high" when weighted score >= 80%', () => {
+    // 4/5 available = 0.8
+    expect(getCellTintTier(mkSuggestion({ availableCount: 4, unavailableCount: 1 }))).toBe('high');
+    // 3 available + 2 maybe = (3 + 1)/5 = 0.8
+    expect(getCellTintTier(mkSuggestion({ availableCount: 3, maybeCount: 2 }))).toBe('high');
   });
-  it('returns "medium" when 60-79% available', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 3 }))).toBe('medium');
+
+  it('returns "medium" when weighted score is 60-79%', () => {
+    // 3/5 available = 0.6
+    expect(getCellTintTier(mkSuggestion({ availableCount: 3, unavailableCount: 2 }))).toBe('medium');
+    // 2 available + 2 maybe = (2 + 1)/5 = 0.6
+    expect(getCellTintTier(mkSuggestion({ availableCount: 2, maybeCount: 2, unavailableCount: 1 }))).toBe('medium');
   });
-  it('returns "maybe" when >= 40% available OR any maybe without majority', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 2 }))).toBe('maybe');
-    expect(getCellTintTier(mkSuggestion({ maybeCount: 3 }))).toBe('maybe');
+
+  it('returns "maybe" when weighted score is 40-59%', () => {
+    // 2/5 available = 0.4
+    expect(getCellTintTier(mkSuggestion({ availableCount: 2, unavailableCount: 3 }))).toBe('maybe');
+    // 4 maybe = (0 + 2)/5 = 0.4
+    expect(getCellTintTier(mkSuggestion({ maybeCount: 4, unavailableCount: 1 }))).toBe('maybe');
   });
-  it('returns "warning" when > 0 available but below maybe tier', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 1 }))).toBe('warning');
+
+  it('treats one maybe as 0.5 of a yes (not auto-amber)', () => {
+    // 5 players, 1 maybe, 4 pending → score 0.1, no majority-no → empty (gray), NOT amber
+    expect(getCellTintTier(mkSuggestion({ maybeCount: 1, pendingCount: 4 }))).toBe('empty');
+    // 5 players, 2 maybe, 3 pending → score 0.2 → empty (gray)
+    expect(getCellTintTier(mkSuggestion({ maybeCount: 2, pendingCount: 3 }))).toBe('empty');
   });
-  it('prefers "maybe" over "warning" when availableCount low but maybeCount > 0', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 1, maybeCount: 2 }))).toBe('maybe');
-  });
-  it('returns "warning" explicitly when maybeCount is 0 and 0 < availableCount < 0.4 * total', () => {
-    expect(getCellTintTier(mkSuggestion({ availableCount: 1, maybeCount: 0, unavailableCount: 4 }))).toBe('warning');
-  });
-  it('returns "warning" when 0 available and no maybe', () => {
+
+  it('returns "warning" only when a majority said no', () => {
+    // 5 players, 3 unavailable, 2 pending → unavailableRatio 0.6 → red
+    expect(getCellTintTier(mkSuggestion({ unavailableCount: 3, pendingCount: 2 }))).toBe('warning');
+    // All 5 said no → red
     expect(getCellTintTier(mkSuggestion({ unavailableCount: 5 }))).toBe('warning');
   });
+
+  it('returns "empty" (gray) when responses are mostly pending', () => {
+    // 5 players, all pending → gray, not red
+    expect(getCellTintTier(mkSuggestion({ pendingCount: 5 }))).toBe('empty');
+    // 5 players, 1 unavailable, 4 pending → unavailableRatio 0.2 → gray, not red
+    expect(getCellTintTier(mkSuggestion({ unavailableCount: 1, pendingCount: 4 }))).toBe('empty');
+  });
+
   it('returns "empty" when totalPlayers is 0', () => {
     expect(getCellTintTier(mkSuggestion({ totalPlayers: 0 }))).toBe('empty');
   });

--- a/src/lib/scheduleView.ts
+++ b/src/lib/scheduleView.ts
@@ -4,15 +4,20 @@ import { formatTimeShort } from '@/lib/formatting';
 export type CellTintTier = 'high' | 'medium' | 'maybe' | 'warning' | 'empty';
 
 /**
- * Returns the colour tier for a mini-calendar cell. Any `maybeCount > 0` bumps to `'maybe'` even when `availableCount` is low.
+ * Returns the colour tier for a mini-calendar cell.
+ * - Score weights "maybe" responses as half a yes: `(available + 0.5 * maybe) / total`.
+ * - Red ("warning") is reserved for majority-unavailable dates. Cells dominated
+ *   by pending responses fall through to "empty" (gray) rather than red, since
+ *   "unknown" is not the same signal as "definitely not".
  */
 export function getCellTintTier(s: DateSuggestion): CellTintTier {
   if (s.totalPlayers === 0) return 'empty';
-  const pct = s.availableCount / s.totalPlayers;
-  if (pct >= 0.8) return 'high';
-  if (pct >= 0.6) return 'medium';
-  if (pct >= 0.4 || s.maybeCount > 0) return 'maybe';
-  return 'warning';
+  const score = (s.availableCount + 0.5 * s.maybeCount) / s.totalPlayers;
+  if (score >= 0.8) return 'high';
+  if (score >= 0.6) return 'medium';
+  if (score >= 0.4) return 'maybe';
+  if (s.unavailableCount / s.totalPlayers >= 0.5) return 'warning';
+  return 'empty';
 }
 
 export function partitionByThreshold(items: DateSuggestion[]): {


### PR DESCRIPTION
## Summary

Reworks the schedule mini-calendar's color logic so the cells better reflect what player responses actually mean, and adds new visual states for cases that previously misled the reader.

### Tier formula
- **Weights "maybe" as half a yes:** `score = (available + 0.5 * maybe) / total`. A single maybe no longer forces the whole date to amber.
- **Red is now reserved for majority-unavailable.** Dates dominated by *pending* responses fall through to gray rather than red — "unknown" shouldn't look the same as "definitely not".

| Scenario (5-player game) | Before | After |
|---|---|---|
| 1 maybe, 4 pending | amber (alarmist) | gray (awaiting) |
| 5 pending | red | gray |
| 1 no, 4 pending | red | gray |
| 3 no, 2 pending | red | red (majority — still red) |

### New visual states
- **"Some available" (medium tier)** — distinct light-green color tokens (`--cal-available-medium-bg` / `-text`) so it doesn't visually merge with "Most available". Tuned per theme to keep clear separation in both light and dark mode.
- **"Awaiting responses" (empty tier)** — solid neutral gray via `--cal-empty-bg` / `-text`. Replaces the previous `bg-muted/40`, which disappeared against light cards because themed `--muted` tints are designed to *blend with* the card.
- **"Past"** — new state for dates that have already passed. Renders as the most muted of all (alpha-blends toward the card) so the eye slides past them, instead of being misread as "awaiting responses".

### Refactor
Extracts `CALENDAR_STYLES` and `LEGEND_ORDER` into `calendarStyles.ts` as the single source of truth for both the cell renderer and the legend. Previously the legend was hand-authored next to the cell color map in different files, which would drift on every color/label change.

## Test plan

- [ ] Unit tests cover the new tier formula and its edge cases (single maybe → gray, majority pending → gray, majority no → red, weighted score thresholds). All 393 tests pass locally.
- [ ] `npm run lint` clean, `npm run build` succeeds.
- [ ] Open the schedule tab on a game and confirm the mini-calendar:
  - Past play-days (any month containing dates before today) render as a faded gray, clearly distinct from current "awaiting responses" cells.
  - Dates with only "maybe" responses no longer show amber until at least 40% of weighted votes lean that way.
  - Confirmed sessions still show ★ regardless of whether they're past or future.
- [ ] Toggle dark mode and confirm:
  - High vs. medium green are clearly distinguishable (high is the bolder/brighter one).
  - Empty cells read as a solid neutral gray, not a tinted blue.
  - Past cells are the most muted state on the calendar.
- [ ] Sanity-check the **availability tab** calendar in dark mode — "yes" cells use the same `--cal-available-bg` token, which is now `#15803d` (slightly brighter than the old `#166534`). Should look like a positive change, but worth a glance.