### PR TITLE
feat: optional location and notes on scheduled sessions

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -194,6 +194,8 @@ export async function createTestSession(options: {
   confirmed_by: string;
   start_time?: string;
   end_time?: string;
+  location?: string | null;
+  notes?: string | null;
 }): Promise<{ id: string }> {
   const admin = getAdminClient();
 
@@ -204,6 +206,8 @@ export async function createTestSession(options: {
     confirmed_by: options.confirmed_by,
     start_time: options.start_time || '18:00',
     end_time: options.end_time || '22:00',
+    location: options.location ?? null,
+    notes: options.notes ?? null,
   };
 
   const { data, error } = await admin

--- a/e2e/tests/availability/time-constraints.spec.ts
+++ b/e2e/tests/availability/time-constraints.spec.ts
@@ -232,14 +232,14 @@ test.describe('Time Availability Constraints', () => {
 
     // Click "Schedule game" on the first (auto-expanded) suggestion
     await page.getByRole('button', { name: /schedule game/i }).first().click();
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
 
     // Start time should be pre-filled with 19:00 (later of default 18:00 and constraint 19:00)
-    const startTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').first();
+    const startTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').first();
     await expect(startTimeInput).toHaveValue('19:00');
 
     // End time should stay at default 23:00 (no end constraint)
-    const endTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').nth(1);
+    const endTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').nth(1);
     await expect(endTimeInput).toHaveValue('23:00');
   });
 

--- a/e2e/tests/games/co-gm.spec.ts
+++ b/e2e/tests/games/co-gm.spec.ts
@@ -217,8 +217,8 @@ test.describe('Co-GM Feature', () => {
 
       // Co-GM should be able to confirm a session
       await page.getByRole('button', { name: /schedule game/i }).first().click();
-      await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
-      await page.locator('[data-testid="confirm-session-submit"]').click();
+      await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+      await page.locator('[data-testid="session-details-submit"]').click();
 
       // Should see confirmed session
       await expect(page.getByText(/upcoming sessions/i)).toBeVisible({

--- a/e2e/tests/multi-user/session-visibility.spec.ts
+++ b/e2e/tests/multi-user/session-visibility.spec.ts
@@ -68,8 +68,8 @@ test.describe('Multi-User Session Visibility', () => {
       });
 
       await gmPage.getByRole('button', { name: /schedule game/i }).first().click();
-      await expect(gmPage.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
-      await gmPage.locator('[data-testid="confirm-session-submit"]').click();
+      await expect(gmPage.locator('[data-testid="session-details-modal"]')).toBeVisible();
+      await gmPage.locator('[data-testid="session-details-submit"]').click();
 
       // GM sees confirmed session
       await expect(gmPage.getByText(/upcoming sessions/i)).toBeVisible({

--- a/e2e/tests/scheduling/cancellation.spec.ts
+++ b/e2e/tests/scheduling/cancellation.spec.ts
@@ -13,7 +13,7 @@ import { TEST_TIMEOUTS } from '../../constants';
  * expand the row before reaching those actions.
  */
 async function expandScheduledRow(row: Locator) {
-  const toggle = row.locator('button[aria-expanded="false"]').first();
+  const toggle = row.locator('[aria-expanded="false"]').first();
   if (await toggle.count()) {
     await toggle.click();
   }

--- a/e2e/tests/scheduling/confirmation.spec.ts
+++ b/e2e/tests/scheduling/confirmation.spec.ts
@@ -51,15 +51,15 @@ test.describe('Session Confirmation', () => {
     await lockInButton.click();
 
     // Modal should appear (identified by data-testid)
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
 
     // Should have start and end time inputs
-    await expect(page.locator('[data-testid="schedule-session-modal"] input[type="time"]').first()).toBeVisible();
-    await expect(page.locator('[data-testid="schedule-session-modal"] input[type="time"]').nth(1)).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"] input[type="time"]').first()).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"] input[type="time"]').nth(1)).toBeVisible();
 
     // Should have confirm and cancel buttons in modal
-    await expect(page.locator('[data-testid="confirm-session-submit"]')).toBeVisible();
-    await expect(page.locator('[data-testid="schedule-session-modal"]').getByRole('button', { name: /cancel/i })).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-submit"]')).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]').getByRole('button', { name: /cancel/i })).toBeVisible();
   });
 
   test('GM can set custom times and confirm session', async ({ page, request }) => {
@@ -100,11 +100,11 @@ test.describe('Session Confirmation', () => {
     await page.getByRole('button', { name: /schedule game/i }).first().click();
 
     // Wait for modal
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
 
     // Set custom times: 7 PM to 11 PM
-    const startTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').first();
-    const endTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').nth(1);
+    const startTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').first();
+    const endTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').nth(1);
 
     await startTimeInput.clear();
     await startTimeInput.fill('19:00');
@@ -112,10 +112,10 @@ test.describe('Session Confirmation', () => {
     await endTimeInput.fill('23:00');
 
     // Submit the confirmation
-    await page.locator('[data-testid="confirm-session-submit"]').click();
+    await page.locator('[data-testid="session-details-submit"]').click();
 
     // Modal should close
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]')).not.toBeVisible();
 
     // Session should appear in confirmed sessions section
     await expect(page.getByText(/upcoming sessions/i)).toBeVisible({
@@ -166,8 +166,8 @@ test.describe('Session Confirmation', () => {
 
     // Confirm a session
     await page.getByRole('button', { name: /schedule game/i }).first().click();
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
-    await page.locator('[data-testid="confirm-session-submit"]').click();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+    await page.locator('[data-testid="session-details-submit"]').click();
 
     // Now confirmed sessions should be visible
     await expect(page.getByText(/upcoming sessions/i)).toBeVisible({
@@ -270,11 +270,11 @@ test.describe('Session Confirmation', () => {
     await page.getByRole('button', { name: /schedule game/i }).first().click();
 
     // Wait for modal
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
 
     // Check that the time inputs are pre-filled with game's default times
-    const startTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').first();
-    const endTimeInput = page.locator('[data-testid="schedule-session-modal"] input[type="time"]').nth(1);
+    const startTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').first();
+    const endTimeInput = page.locator('[data-testid="session-details-modal"] input[type="time"]').nth(1);
 
     await expect(startTimeInput).toHaveValue('19:30');
     await expect(endTimeInput).toHaveValue('23:30');

--- a/e2e/tests/scheduling/export.spec.ts
+++ b/e2e/tests/scheduling/export.spec.ts
@@ -48,7 +48,7 @@ test.describe('Session Export', () => {
     await page
       .locator('[data-testid="scheduled-row"]')
       .first()
-      .locator('button[aria-expanded="false"]')
+      .locator('[aria-expanded="false"]')
       .first()
       .click();
 
@@ -174,7 +174,7 @@ test.describe('Session Export', () => {
     await page
       .locator('[data-testid="scheduled-row"]')
       .first()
-      .locator('button[aria-expanded="false"]')
+      .locator('[aria-expanded="false"]')
       .first()
       .click();
 

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -55,8 +55,8 @@ test.describe('Schedule Tab Redesign', () => {
     await scheduleButton.click();
 
     // Confirm the session via the modal
-    await expect(page.locator('[data-testid="schedule-session-modal"]')).toBeVisible();
-    await page.locator('[data-testid="confirm-session-submit"]').click();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+    await page.locator('[data-testid="session-details-submit"]').click();
 
     // Toast should appear
     await expect(page.getByRole('status')).toContainText(/scheduled/i, {

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -192,7 +192,7 @@ test.describe('Schedule Tab Redesign', () => {
     await page
       .locator('[data-testid="scheduled-row"]')
       .first()
-      .locator('button[aria-expanded="false"]')
+      .locator('[aria-expanded="false"]')
       .first()
       .click();
 

--- a/e2e/tests/scheduling/session-details.spec.ts
+++ b/e2e/tests/scheduling/session-details.spec.ts
@@ -42,7 +42,7 @@ test.describe('Session Location & Notes', () => {
 
     // Expand the scheduled row to see details
     const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
-    await scheduledRow.click();
+    await scheduledRow.getByRole('button', { name: /show session details/i }).click();
 
     await expect(scheduledRow).toContainText("Tom's basement");
     await expect(scheduledRow).toContainText('Bring printed character sheets and dice.');
@@ -76,7 +76,7 @@ test.describe('Session Location & Notes', () => {
     await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
 
     const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
-    await scheduledRow.click();
+    await scheduledRow.getByRole('button', { name: /show session details/i }).click();
     await page.locator('[data-testid="session-edit-details"]').click();
     await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
 
@@ -155,7 +155,7 @@ test.describe('Session Location & Notes', () => {
     await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
 
     const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
-    await scheduledRow.click();
+    await scheduledRow.getByRole('button', { name: /show session details/i }).click();
 
     await expect(scheduledRow).toContainText("Tom's basement");
     await expect(scheduledRow).toContainText('Bring snacks');
@@ -227,7 +227,7 @@ test.describe('Session Location & Notes', () => {
     await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
 
     const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
-    await scheduledRow.click();
+    await scheduledRow.getByRole('button', { name: /show session details/i }).click();
 
     const toggle = page.locator('[data-testid="session-notes-toggle"]').first();
     await expect(toggle).toBeVisible();

--- a/e2e/tests/scheduling/session-details.spec.ts
+++ b/e2e/tests/scheduling/session-details.spec.ts
@@ -1,0 +1,271 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  addPlayerToGame,
+  setAvailability,
+  createTestSession,
+  getPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Session Location & Notes', () => {
+  test('GM can schedule a session with location and notes', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-create-${Date.now()}@e2e.local`,
+      name: 'Details GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Details Campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(gm.id, game.id, [{ date: playDates[0], is_available: true }]);
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.getByRole('button', { name: /schedule/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+    await page.getByRole('button', { name: /schedule game/i }).first().click();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+
+    await page.locator('[data-testid="session-details-location"]').fill("Tom's basement");
+    await page.locator('[data-testid="session-details-notes"]').fill('Bring printed character sheets and dice.');
+    await page.locator('[data-testid="session-details-submit"]').click();
+
+    await expect(page.locator('[data-testid="session-details-modal"]')).not.toBeVisible();
+
+    // Expand the scheduled row to see details
+    const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
+    await scheduledRow.click();
+
+    await expect(scheduledRow).toContainText("Tom's basement");
+    await expect(scheduledRow).toContainText('Bring printed character sheets and dice.');
+  });
+
+  test('GM can edit an existing session location and notes', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-edit-${Date.now()}@e2e.local`,
+      name: 'Edit GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Edit Campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '22:00',
+      location: 'Old place',
+      notes: 'old notes',
+    });
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+    const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
+    await scheduledRow.click();
+    await page.locator('[data-testid="session-edit-details"]').click();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+
+    const locationInput = page.locator('[data-testid="session-details-location"]');
+    await locationInput.fill('New place, 999 Main St');
+    await page.locator('[data-testid="session-details-submit"]').click();
+
+    await expect(page.locator('[data-testid="session-details-modal"]')).not.toBeVisible();
+    await expect(scheduledRow).toContainText('New place, 999 Main St');
+  });
+
+  test('Location and notes appear on the Overview tab UpcomingSessionsCard', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-overview-${Date.now()}@e2e.local`,
+      name: 'Overview GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Overview Campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '22:00',
+      location: "Tom's basement",
+      notes: 'Bring snacks',
+    });
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+
+    const upcomingCard = page.locator('text=/upcoming sessions/i').first();
+    await expect(upcomingCard).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+    const overviewRegion = page.locator('main');
+    await expect(overviewRegion).toContainText("Tom's basement");
+    await expect(overviewRegion).toContainText('Bring snacks');
+  });
+
+  test('Non-GM player sees details but not Edit button', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-perm-${Date.now()}@e2e.local`,
+      name: 'Perm GM',
+      is_gm: true,
+    });
+    const player = await createTestUser(request, {
+      email: `player-sd-perm-${Date.now()}@e2e.local`,
+      name: 'Perm Player',
+      is_gm: false,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Perm Campaign',
+      play_days: [5, 6],
+    });
+    await addPlayerToGame(game.id, player.id);
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '22:00',
+      location: "Tom's basement",
+      notes: 'Bring snacks',
+    });
+
+    await loginTestUser(page, { email: player.email, name: player.name, is_gm: false });
+    await page.goto(`/games/${game.id}`);
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+    const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
+    await scheduledRow.click();
+
+    await expect(scheduledRow).toContainText("Tom's basement");
+    await expect(scheduledRow).toContainText('Bring snacks');
+    await expect(page.locator('[data-testid="session-edit-details"]')).toHaveCount(0);
+  });
+
+  test('Char limit prevents oversized location and notes', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-limits-${Date.now()}@e2e.local`,
+      name: 'Limits GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Limits Campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(gm.id, game.id, [{ date: playDates[0], is_available: true }]);
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /schedule game/i }).first().click();
+    await expect(page.locator('[data-testid="session-details-modal"]')).toBeVisible();
+
+    const tooLong = 'x'.repeat(250);
+    await page.locator('[data-testid="session-details-location"]').fill(tooLong);
+    const locValue = await page.locator('[data-testid="session-details-location"]').inputValue();
+    expect(locValue.length).toBe(200);
+
+    const tooLongNotes = 'y'.repeat(600);
+    await page.locator('[data-testid="session-details-notes"]').fill(tooLongNotes);
+    const notesValue = await page.locator('[data-testid="session-details-notes"]').inputValue();
+    expect(notesValue.length).toBe(500);
+  });
+
+  test('Mobile: long notes clamp to 2 lines with Show more toggle', async ({ page, request }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    const gm = await createTestUser(request, {
+      email: `gm-sd-mobile-${Date.now()}@e2e.local`,
+      name: 'Mobile GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Mobile Campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    const longNote =
+      'Bring printed character sheets and dice. We are picking up after the windmill fight ' +
+      'from last session — Sarah is trying a new feat. Brendan said he will bring pizza. ' +
+      'Carpool meets at the diner at 6:45 PM.';
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '22:00',
+      notes: longNote,
+    });
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+    const scheduledRow = page.locator('[data-testid="scheduled-row"]').first();
+    await scheduledRow.click();
+
+    const toggle = page.locator('[data-testid="session-notes-toggle"]').first();
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveText(/show more/i);
+
+    await toggle.click();
+    await expect(toggle).toHaveText(/show less/i);
+  });
+
+  test('Calendar subscribe feed includes LOCATION and DESCRIPTION for sessions with details', async ({ request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sd-feed-${Date.now()}@e2e.local`,
+      name: 'Feed GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Feed Campaign',
+      description: 'Curse of Strahd campaign',
+      play_days: [5, 6],
+    });
+    const playDates = getPlayDates([5, 6], 4);
+    await createTestSession({
+      game_id: game.id,
+      date: playDates[0],
+      confirmed_by: gm.id,
+      start_time: '19:00',
+      end_time: '22:00',
+      location: "Tom's basement",
+      notes: 'Bring dice',
+    });
+
+    const response = await request.get(`/api/games/calendar/${game.invite_code}`);
+    expect(response.status()).toBe(200);
+    const ics = await response.text();
+
+    expect(ics).toContain("LOCATION:Tom's basement");
+    // composeIcsDescription joins with \n\n; escapeICS replaces each \n → \\n, so \n\n → \\n\\n
+    expect(ics).toContain('DESCRIPTION:Curse of Strahd campaign\\n\\nBring dice');
+  });
+});

--- a/src/app/api/games/calendar/[code]/route.ts
+++ b/src/app/api/games/calendar/[code]/route.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from '@/lib/supabase/admin';
-import { generateICS } from '@/lib/ics';
+import { generateICS, composeIcsDescription } from '@/lib/ics';
 import type { Game, GameSession } from '@/types';
 
 /**
@@ -46,7 +46,7 @@ export async function GET(
     // Fetch confirmed sessions for this game
     const { data: sessions, error: sessionsError } = await admin
       .from('sessions')
-      .select('id, date, start_time, end_time, status')
+      .select('id, date, start_time, end_time, status, location, notes')
       .eq('game_id', typedGame.id)
       .eq('status', 'confirmed')
       .order('date', { ascending: true });
@@ -56,7 +56,10 @@ export async function GET(
       return new Response('Error fetching sessions', { status: 500 });
     }
 
-    const typedSessions = (sessions || []) as Pick<GameSession, 'id' | 'date' | 'start_time' | 'end_time' | 'status'>[];
+    const typedSessions = (sessions || []) as Pick<
+      GameSession,
+      'id' | 'date' | 'start_time' | 'end_time' | 'status' | 'location' | 'notes'
+    >[];
 
     // Convert sessions to calendar events
     const events = typedSessions.map((session) => ({
@@ -64,7 +67,8 @@ export async function GET(
       startTime: session.start_time || typedGame.default_start_time || undefined,
       endTime: session.end_time || typedGame.default_end_time || undefined,
       title: typedGame.name,
-      description: typedGame.description || undefined,
+      description: composeIcsDescription(typedGame.description, session.notes),
+      location: session.location || undefined,
       timezone: typedGame.timezone || undefined,
     }));
 

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -52,7 +52,7 @@ export default function GameDetailPage() {
   const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, removePlayerData } = availabilityHook;
 
   const sessionsHook = useSessions(gameId, ready);
-  const { sessions, confirmSession: confirmSessionRaw, cancelSession } = sessionsHook;
+  const { sessions, confirmSession: confirmSessionRaw, updateSession, cancelSession } = sessionsHook;
 
   const playDatesHook = usePlayDates(gameId, ready);
   const { gamePlayDates, toggleExtraDate: toggleExtraDateRaw, updatePlayDateNote } = playDatesHook;
@@ -234,8 +234,13 @@ export default function GameDetailPage() {
   const copyFromGame = (sourceGameId: string) =>
     copyFromGameRaw(sourceGameId, extraDateStrings);
 
-  const confirmSession = (date: string, startTime: string, endTime: string) =>
-    confirmSessionRaw(date, startTime, endTime, profile?.id ?? "");
+  const confirmSession = (
+    date: string,
+    startTime: string,
+    endTime: string,
+    location: string | null,
+    notes: string | null,
+  ) => confirmSessionRaw(date, startTime, endTime, profile?.id ?? "", location, notes);
 
   if (authStatus === 'loading' || loading) {
     return (
@@ -394,6 +399,7 @@ export default function GameDetailPage() {
           gmId={game.gm_id}
           isGm={canDoGmActions}
           gameName={game.name}
+          gameDescription={game.description}
           playDays={game.play_days}
           windowStart={windowStart}
           windowEnd={windowEnd}
@@ -409,6 +415,7 @@ export default function GameDetailPage() {
           completionByUserId={completionByUserId}
           subscribeUrl={subscribeUrl}
           onConfirm={confirmSession}
+          onUpdateSession={updateSession}
           onCancel={cancelSession}
         />
       )}

--- a/src/components/games/overview/UpcomingSessionsCard.tsx
+++ b/src/components/games/overview/UpcomingSessionsCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import { format, parseISO, startOfDay, isBefore, differenceInCalendarDays } from 'date-fns';
-import { Calendar, Link2, Star } from 'lucide-react';
+import { Calendar, Link2, MapPin, Star, StickyNote } from 'lucide-react';
 import { Button, EyebrowLabel } from '@/components/ui';
 import type { GameSession } from '@/types';
 import { formatTime } from '@/lib/formatting';
@@ -22,6 +23,32 @@ function relativeLabel(daysFromNow: number): string {
   if (daysFromNow < 14) return 'next week';
   if (daysFromNow < 30) return `in ${Math.round(daysFromNow / 7)} weeks`;
   return `in ${Math.round(daysFromNow / 30)} months`;
+}
+
+function ClampedNotes({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const showToggle = text.length > 80;
+  return (
+    <div>
+      <p
+        className={`wrap-break-word ${!expanded && showToggle ? 'line-clamp-2 md:line-clamp-none' : ''}`}
+        data-testid="session-notes-text"
+      >
+        {text}
+      </p>
+      {showToggle && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="mt-0.5 py-1 text-[11px] font-semibold text-primary md:hidden"
+          data-testid="session-notes-toggle"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </div>
+  );
 }
 
 export function UpcomingSessionsCard({
@@ -108,6 +135,22 @@ export function UpcomingSessionsCard({
                   {timeWindow && <span aria-hidden>·</span>}
                   <span>{relativeLabel(daysFromNow)}</span>
                 </p>
+                {(s.location || s.notes) && (
+                  <div className="mt-2 space-y-1 border-t border-dashed border-border pt-2">
+                    {s.location && (
+                      <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                        <MapPin className="mt-0.5 size-3 shrink-0" />
+                        <span className="wrap-break-word" data-testid="session-location-text">{s.location}</span>
+                      </div>
+                    )}
+                    {s.notes && (
+                      <div className="flex items-start gap-2 text-xs text-card-foreground">
+                        <StickyNote className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
+                        <ClampedNotes text={s.notes} />
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
               <Button
                 size="sm"

--- a/src/components/games/overview/UpcomingSessionsCard.tsx
+++ b/src/components/games/overview/UpcomingSessionsCard.tsx
@@ -39,7 +39,10 @@ function ClampedNotes({ text }: { text: string }) {
       {showToggle && (
         <button
           type="button"
-          onClick={() => setExpanded((v) => !v)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
           aria-expanded={expanded}
           className="mt-0.5 py-1 text-[11px] font-semibold text-primary md:hidden"
           data-testid="session-notes-toggle"

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -222,6 +222,7 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
               onDownloadIcs={handleDownloadIcs}
               onDownloadAllIcs={handleDownloadAllIcs}
               onRequestCancel={(s) => setCancelFor(s)}
+              onEditDetails={(s) => setEditFor(s)}
             />
 
             <RankedList

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -9,7 +9,7 @@ import { RankedList } from './RankedList';
 import { MiniCalendar } from './MiniCalendar';
 import { ResponseStatus } from './ResponseStatus';
 import { ScheduledList } from './ScheduledList';
-import { ScheduleSessionModal } from './ScheduleSessionModal';
+import { SessionDetailsModal } from './SessionDetailsModal';
 import { CancelSessionModal } from './CancelSessionModal';
 import { CalendarHoverPopover } from './CalendarHoverPopover';
 import { generateICS, slugifyGameName, triggerICSDownload } from '@/lib/ics';
@@ -231,7 +231,7 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
           </aside>
         </div>
 
-        <ScheduleSessionModal
+        <SessionDetailsModal
           open={scheduleFor !== null}
           date={scheduleFor}
           suggestion={scheduleFor ? suggestions.find((s) => s.date === scheduleFor) : undefined}

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -66,6 +66,8 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
   const toast = useToast();
   const [scheduleFor, setScheduleFor] = useState<string | null>(null);
   const [cancelFor, setCancelFor] = useState<GameSession | null>(null);
+  // editFor is set via onEditDetails in ScheduledList (added in a later task);
+  // the edit-mode modal is rendered here so it's ready when that wiring lands.
   const [editFor, setEditFor] = useState<GameSession | null>(null);
   const [autoExpandDate, setAutoExpandDate] = useState<string | null>(null);
 

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -12,7 +12,7 @@ import { ScheduledList } from './ScheduledList';
 import { SessionDetailsModal } from './SessionDetailsModal';
 import { CancelSessionModal } from './CancelSessionModal';
 import { CalendarHoverPopover } from './CalendarHoverPopover';
-import { generateICS, slugifyGameName, triggerICSDownload } from '@/lib/ics';
+import { generateICS, slugifyGameName, triggerICSDownload, composeIcsDescription } from '@/lib/ics';
 import { splitUpcomingPast } from '@/lib/scheduleView';
 import { useToast } from '@/components/ui/Toast';
 import { Button, EyebrowLabel, Panel } from '@/components/ui';
@@ -25,6 +25,7 @@ export interface ScheduleTabContentProps {
   gmId: string;
   isGm: boolean;
   gameName: string;
+  gameDescription?: string | null;
   playDays: number[];
   windowStart: Date;
   windowEnd: Date;
@@ -39,22 +40,33 @@ export interface ScheduleTabContentProps {
   minPlayersNeeded?: number;
   completionByUserId: Map<string, { answered: number; total: number }>;
   subscribeUrl: string;
-  onConfirm: (date: string, startTime: string, endTime: string) => Promise<{ success: boolean; error?: string }>;
+  onConfirm: (
+    date: string,
+    startTime: string,
+    endTime: string,
+    location: string | null,
+    notes: string | null,
+  ) => Promise<{ success: boolean; error?: string }>;
+  onUpdateSession: (
+    sessionId: string,
+    patch: { start_time?: string; end_time?: string; location?: string | null; notes?: string | null },
+  ) => Promise<{ success: boolean; error?: string }>;
   onCancel: (date: string) => Promise<{ success: boolean; error?: string }>;
 }
 
 export function ScheduleTabContent(props: ScheduleTabContentProps) {
   const {
-    suggestions, sessions, members, gmId, isGm, gameName, playDays,
-    windowStart, windowEnd, specialPlayDates, playDateNotes,
+    suggestions, sessions, members, gmId, isGm, gameName, gameDescription,
+    playDays, windowStart, windowEnd, specialPlayDates, playDateNotes,
     defaultStartTime, defaultEndTime, timezone, userTimezone,
     use24h = false, weekStartDay, minPlayersNeeded = 0,
-    completionByUserId, subscribeUrl, onConfirm, onCancel,
+    completionByUserId, subscribeUrl, onConfirm, onUpdateSession, onCancel,
   } = props;
 
   const toast = useToast();
   const [scheduleFor, setScheduleFor] = useState<string | null>(null);
   const [cancelFor, setCancelFor] = useState<GameSession | null>(null);
+  const [editFor, setEditFor] = useState<GameSession | null>(null);
   const [autoExpandDate, setAutoExpandDate] = useState<string | null>(null);
 
   const coGmIds = useMemo(
@@ -85,10 +97,29 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
 
   const monthRange = `${format(windowStart, 'MMM')} – ${format(windowEnd, 'MMM yyyy')}`;
 
-  const handleConfirm = async (date: string, start: string, end: string) => {
-    const res = await onConfirm(date, start, end);
+  const handleConfirm = async (values: {
+    start: string; end: string; location: string | null; notes: string | null;
+  }) => {
+    if (!scheduleFor) return { success: false, error: 'No date selected' };
+    const res = await onConfirm(scheduleFor, values.start, values.end, values.location, values.notes);
     if (res.success) {
-      toast.show(`Scheduled ${format(parseISO(date), 'MMM d')}.`);
+      toast.show(`Scheduled ${format(parseISO(scheduleFor), 'MMM d')}.`);
+    }
+    return res;
+  };
+
+  const handleEdit = async (values: {
+    start: string; end: string; location: string | null; notes: string | null;
+  }) => {
+    if (!editFor) return { success: false, error: 'No session selected' };
+    const res = await onUpdateSession(editFor.id, {
+      start_time: values.start,
+      end_time: values.end,
+      location: values.location,
+      notes: values.notes,
+    });
+    if (res.success) {
+      toast.show(`Updated ${format(parseISO(editFor.date), 'MMM d')}.`);
     }
     return res;
   };
@@ -109,6 +140,8 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
       startTime: session.start_time || undefined,
       endTime: session.end_time || undefined,
       title: gameName,
+      location: session.location || undefined,
+      description: composeIcsDescription(gameDescription, session.notes),
       timezone: timezone || undefined,
     }]);
     triggerICSDownload(ics, `${slugifyGameName(gameName)}-${session.date}.ics`);
@@ -123,6 +156,8 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
       startTime: s.start_time || undefined,
       endTime: s.end_time || undefined,
       title: gameName,
+      location: s.location || undefined,
+      description: composeIcsDescription(gameDescription, s.notes),
       timezone: timezone || undefined,
     }));
     const ics = generateICS(events);
@@ -234,11 +269,21 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
         <SessionDetailsModal
           open={scheduleFor !== null}
           date={scheduleFor}
+          mode="schedule"
           suggestion={scheduleFor ? suggestions.find((s) => s.date === scheduleFor) : undefined}
           gameDefaultStart={defaultStartTime}
           gameDefaultEnd={defaultEndTime}
           onClose={() => setScheduleFor(null)}
-          onConfirm={handleConfirm}
+          onSubmit={handleConfirm}
+        />
+
+        <SessionDetailsModal
+          open={editFor !== null}
+          date={editFor?.date ?? null}
+          mode="edit"
+          session={editFor ?? undefined}
+          onClose={() => setEditFor(null)}
+          onSubmit={handleEdit}
         />
 
         <CancelSessionModal

--- a/src/components/games/schedule/ScheduledList.tsx
+++ b/src/components/games/schedule/ScheduledList.tsx
@@ -20,11 +20,12 @@ interface ScheduledListProps {
   onDownloadIcs: (session: GameSession) => void;
   onDownloadAllIcs: () => void;
   onRequestCancel: (session: GameSession) => void;
+  onEditDetails: (session: GameSession) => void;
 }
 
 export function ScheduledList({
   sessions, suggestions, timezone, userTimezone, use24h, isGm, gmId, coGmIds, playDateNotes,
-  onDownloadIcs, onDownloadAllIcs, onRequestCancel,
+  onDownloadIcs, onDownloadAllIcs, onRequestCancel, onEditDetails,
 }: ScheduledListProps) {
   const [showPast, setShowPast] = useState(false);
   const confirmed = sessions.filter((s) => s.status === 'confirmed');
@@ -63,6 +64,7 @@ export function ScheduledList({
                 playDateNote={playDateNotes?.get(s.date) ?? null}
                 onDownloadIcs={onDownloadIcs}
                 onRequestCancel={onRequestCancel}
+                onEditDetails={onEditDetails}
               />
             ))}
           </ul>

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -136,35 +136,26 @@ export function ScheduledRow({
       data-testid={past ? 'past-session-row' : 'scheduled-row'}
       className={`rounded-xl border border-border bg-card p-4 ${past ? 'opacity-70' : ''}`}
     >
-      {expandable ? (
-        <div
-          role="button"
-          tabIndex={0}
-          aria-expanded={expanded}
-          onClick={() => setExpanded((v) => !v)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setExpanded((v) => !v);
-            }
-          }}
-          className="flex w-full cursor-pointer items-start gap-3 text-left"
-          title={expanded ? 'Hide details' : 'Show details'}
-        >
-          <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
-          <div className="min-w-0 flex-1">{infoContent}</div>
-          <ChevronRight
-            className={`mt-0.5 size-4 shrink-0 self-center text-muted-foreground transition-transform ${
-              expanded ? 'rotate-90' : ''
-            }`}
-          />
-        </div>
-      ) : (
-        <div className="flex items-start gap-3">
-          <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
-          <div className="min-w-0 flex-1">{infoContent}</div>
-        </div>
-      )}
+      <div className="flex items-start gap-3">
+        <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
+        <div className="min-w-0 flex-1">{infoContent}</div>
+        {expandable && (
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Hide session details' : 'Show session details'}
+            onClick={() => setExpanded((v) => !v)}
+            className="self-center p-1"
+            title={expanded ? 'Hide details' : 'Show details'}
+          >
+            <ChevronRight
+              className={`size-4 text-muted-foreground transition-transform ${
+                expanded ? 'rotate-90' : ''
+              }`}
+            />
+          </button>
+        )}
+      </div>
 
       {expandable && expanded && (
         <div className="mt-3 space-y-3 border-t border-border pt-3">

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -25,7 +25,10 @@ function ClampedNotes({ text }: { text: string }) {
       {showToggle && (
         <button
           type="button"
-          onClick={() => setExpanded((v) => !v)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
           aria-expanded={expanded}
           className="mt-0.5 py-1 text-[11px] font-semibold text-primary md:hidden"
           data-testid="session-notes-toggle"
@@ -134,11 +137,18 @@ export function ScheduledRow({
       className={`rounded-xl border border-border bg-card p-4 ${past ? 'opacity-70' : ''}`}
     >
       {expandable ? (
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={0}
           aria-expanded={expanded}
           onClick={() => setExpanded((v) => !v)}
-          className="flex w-full items-start gap-3 text-left"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setExpanded((v) => !v);
+            }
+          }}
+          className="flex w-full cursor-pointer items-start gap-3 text-left"
           title={expanded ? 'Hide details' : 'Show details'}
         >
           <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
@@ -148,7 +158,7 @@ export function ScheduledRow({
               expanded ? 'rotate-90' : ''
             }`}
           />
-        </button>
+        </div>
       ) : (
         <div className="flex items-start gap-3">
           <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { format, parseISO } from 'date-fns';
-import { Calendar, ChevronRight, X } from 'lucide-react';
+import { Calendar, ChevronRight, MapPin, Pencil, StickyNote, X } from 'lucide-react';
 import type { DateSuggestion, GameSession } from '@/types';
 import { Button, EyebrowLabel } from '@/components/ui';
 import { formatTime } from '@/lib/formatting';
@@ -23,11 +23,12 @@ interface ScheduledRowProps {
   past?: boolean;
   onDownloadIcs: (session: GameSession) => void;
   onRequestCancel: (session: GameSession) => void;
+  onEditDetails?: (session: GameSession) => void;
 }
 
 export function ScheduledRow({
   session, suggestion, timezone, userTimezone, use24h, isGm, gmId, coGmIds,
-  playDateNote, past = false, onDownloadIcs, onRequestCancel,
+  playDateNote, past = false, onDownloadIcs, onRequestCancel, onEditDetails,
 }: ScheduledRowProps) {
   const [expanded, setExpanded] = useState(false);
   // Expandable when there's something in the expanded section worth showing:
@@ -70,6 +71,24 @@ export function ScheduledRow({
       <p className="font-mono text-xs text-muted-foreground">{timeLine()}</p>
       {playDateNote && (
         <p className="mt-0.5 text-xs italic text-muted-foreground">{playDateNote}</p>
+      )}
+      {(session.location || session.notes) && (
+        <div className="mt-2 space-y-1 border-t border-dashed border-border pt-2">
+          {session.location && (
+            <div className="flex items-start gap-2 text-xs text-muted-foreground">
+              <MapPin className="mt-0.5 size-3 shrink-0" />
+              <span className="wrap-break-word" data-testid="session-location-text">{session.location}</span>
+            </div>
+          )}
+          {session.notes && (
+            <div className="flex items-start gap-2 text-xs text-card-foreground">
+              <StickyNote className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
+              <span className="wrap-break-word" data-testid="session-notes-text">
+                {session.notes}
+              </span>
+            </div>
+          )}
+        </div>
       )}
       {visibleAvatars.length > 0 && (
         <div className="mt-2 flex items-center gap-2">
@@ -131,6 +150,17 @@ export function ScheduledRow({
               >
                 <Calendar className="mr-1.5 size-4" /> Add to calendar
               </Button>
+              {isGm && onEditDetails && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onEditDetails(session)}
+                  data-testid="session-edit-details"
+                  title="Edit times, location, and notes for this session"
+                >
+                  <Pencil className="mr-1 size-4" /> Edit details
+                </Button>
+              )}
               {isGm && (
                 <Button
                   size="sm"

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -10,6 +10,32 @@ import { convertTimeForDisplay } from '@/lib/timezone';
 import { PartyBreakdown } from './PartyBreakdown';
 import { PlayerAvatarCluster, type PlayerAvatarItem } from './PlayerAvatarCluster';
 
+function ClampedNotes({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  // Auto-detect: only show toggle if rendered content exceeds ~80 chars (heuristic for 2 lines on mobile).
+  const showToggle = text.length > 80;
+  return (
+    <div>
+      <p
+        className={`wrap-break-word ${!expanded && showToggle ? 'line-clamp-2 md:line-clamp-none' : ''}`}
+        data-testid="session-notes-text"
+      >
+        {text}
+      </p>
+      {showToggle && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-0.5 text-[11px] font-semibold text-primary md:hidden"
+          data-testid="session-notes-toggle"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </div>
+  );
+}
+
 interface ScheduledRowProps {
   session: GameSession;
   suggestion: DateSuggestion | undefined;
@@ -83,9 +109,7 @@ export function ScheduledRow({
           {session.notes && (
             <div className="flex items-start gap-2 text-xs text-card-foreground">
               <StickyNote className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
-              <span className="wrap-break-word" data-testid="session-notes-text">
-                {session.notes}
-              </span>
+              <ClampedNotes text={session.notes} />
             </div>
           )}
         </div>

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -26,7 +26,8 @@ function ClampedNotes({ text }: { text: string }) {
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="mt-0.5 text-[11px] font-semibold text-primary md:hidden"
+          aria-expanded={expanded}
+          className="mt-0.5 py-1 text-[11px] font-semibold text-primary md:hidden"
           data-testid="session-notes-toggle"
         >
           {expanded ? 'Show less' : 'Show more'}

--- a/src/components/games/schedule/SessionDetailsModal.tsx
+++ b/src/components/games/schedule/SessionDetailsModal.tsx
@@ -5,7 +5,7 @@ import { format, parseISO } from 'date-fns';
 import { Modal, Button, Input, Textarea, EyebrowLabel } from '@/components/ui';
 import type { DateSuggestion, GameSession } from '@/types';
 import { computeDefaultSessionTimes } from '@/lib/scheduleView';
-import { SESSION_DEFAULTS } from '@/lib/constants';
+import { SESSION_DEFAULTS, TEXT_LIMITS } from '@/lib/constants';
 
 export type SessionDetailsMode = 'schedule' | 'edit';
 
@@ -28,8 +28,8 @@ interface SessionDetailsModalProps {
   }) => Promise<{ success: boolean; error?: string }>;
 }
 
-const LOCATION_MAX = 200;
-const NOTES_MAX = 500;
+const LOCATION_MAX = TEXT_LIMITS.SESSION_LOCATION;
+const NOTES_MAX = TEXT_LIMITS.SESSION_NOTES;
 const LOCATION_WARN = 150;
 const NOTES_WARN = 400;
 
@@ -76,8 +76,8 @@ export function SessionDetailsModal({
   // In edit mode, the submit button is disabled until at least one field differs.
   const hasChanges = useMemo(() => {
     if (mode !== 'edit' || !session) return true;
-    const startChanged = start !== (session.start_time ?? '').slice(0, 5);
-    const endChanged = end !== (session.end_time ?? '').slice(0, 5);
+    const startChanged = start !== (session.start_time ?? SESSION_DEFAULTS.START_TIME).slice(0, 5);
+    const endChanged = end !== (session.end_time ?? SESSION_DEFAULTS.END_TIME).slice(0, 5);
     const locationChanged = normalize(location) !== (session.location ?? null);
     const notesChanged = normalize(notes) !== (session.notes ?? null);
     return startChanged || endChanged || locationChanged || notesChanged;
@@ -106,7 +106,7 @@ export function SessionDetailsModal({
   const title = format(parseISO(date), 'EEEE, MMMM d, yyyy');
   const eyebrow = isSchedule ? 'Schedule session' : 'Edit session details';
   const submitLabel = isSchedule
-    ? busy ? 'Confirming…' : '★ Confirm session'
+    ? busy ? 'Confirming…' : 'Confirm session'
     : busy ? 'Saving…' : 'Save changes';
 
   const locationCounterClass =

--- a/src/components/games/schedule/SessionDetailsModal.tsx
+++ b/src/components/games/schedule/SessionDetailsModal.tsx
@@ -7,7 +7,7 @@ import type { DateSuggestion } from '@/types';
 import { computeDefaultSessionTimes } from '@/lib/scheduleView';
 import { SESSION_DEFAULTS } from '@/lib/constants';
 
-interface ScheduleSessionModalProps {
+interface SessionDetailsModalProps {
   open: boolean;
   date: string | null;
   suggestion: DateSuggestion | undefined;
@@ -17,9 +17,9 @@ interface ScheduleSessionModalProps {
   onConfirm: (date: string, start: string, end: string) => Promise<{ success: boolean; error?: string }>;
 }
 
-export function ScheduleSessionModal({
+export function SessionDetailsModal({
   open, date, suggestion, gameDefaultStart, gameDefaultEnd, onClose, onConfirm,
-}: ScheduleSessionModalProps) {
+}: SessionDetailsModalProps) {
   const [start, setStart] = useState<string>(SESSION_DEFAULTS.START_TIME);
   const [end, setEnd] = useState<string>(SESSION_DEFAULTS.END_TIME);
   const [busy, setBusy] = useState(false);

--- a/src/components/games/schedule/SessionDetailsModal.tsx
+++ b/src/components/games/schedule/SessionDetailsModal.tsx
@@ -1,96 +1,203 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { format, parseISO } from 'date-fns';
-import { Modal, Button, Input, EyebrowLabel } from '@/components/ui';
-import type { DateSuggestion } from '@/types';
+import { Modal, Button, Input, Textarea, EyebrowLabel } from '@/components/ui';
+import type { DateSuggestion, GameSession } from '@/types';
 import { computeDefaultSessionTimes } from '@/lib/scheduleView';
 import { SESSION_DEFAULTS } from '@/lib/constants';
+
+export type SessionDetailsMode = 'schedule' | 'edit';
 
 interface SessionDetailsModalProps {
   open: boolean;
   date: string | null;
-  suggestion: DateSuggestion | undefined;
-  gameDefaultStart: string | null | undefined;
-  gameDefaultEnd: string | null | undefined;
+  mode: SessionDetailsMode;
+  // schedule-mode inputs:
+  suggestion?: DateSuggestion;
+  gameDefaultStart?: string | null;
+  gameDefaultEnd?: string | null;
+  // edit-mode input:
+  session?: GameSession;
   onClose: () => void;
-  onConfirm: (date: string, start: string, end: string) => Promise<{ success: boolean; error?: string }>;
+  onSubmit: (values: {
+    start: string;
+    end: string;
+    location: string | null;
+    notes: string | null;
+  }) => Promise<{ success: boolean; error?: string }>;
+}
+
+const LOCATION_MAX = 200;
+const NOTES_MAX = 500;
+const LOCATION_WARN = 150;
+const NOTES_WARN = 400;
+
+function normalize(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
 }
 
 export function SessionDetailsModal({
-  open, date, suggestion, gameDefaultStart, gameDefaultEnd, onClose, onConfirm,
+  open, date, mode, suggestion, gameDefaultStart, gameDefaultEnd, session, onClose, onSubmit,
 }: SessionDetailsModalProps) {
   const [start, setStart] = useState<string>(SESSION_DEFAULTS.START_TIME);
   const [end, setEnd] = useState<string>(SESSION_DEFAULTS.END_TIME);
+  const [location, setLocation] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Compute initial values whenever the modal opens or its key inputs change.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!open || !date) return;
-    const defaults = computeDefaultSessionTimes({
-      earliestStartTime: suggestion?.earliestStartTime ?? null,
-      latestEndTime: suggestion?.latestEndTime ?? null,
-      gameDefaultStart: gameDefaultStart?.slice(0, 5) || SESSION_DEFAULTS.START_TIME,
-      gameDefaultEnd: gameDefaultEnd?.slice(0, 5) || SESSION_DEFAULTS.END_TIME,
-    });
-    setStart(defaults.start);
-    setEnd(defaults.end);
+    if (mode === 'edit' && session) {
+      setStart((session.start_time ?? SESSION_DEFAULTS.START_TIME).slice(0, 5));
+      setEnd((session.end_time ?? SESSION_DEFAULTS.END_TIME).slice(0, 5));
+      setLocation(session.location ?? '');
+      setNotes(session.notes ?? '');
+    } else {
+      const defaults = computeDefaultSessionTimes({
+        earliestStartTime: suggestion?.earliestStartTime ?? null,
+        latestEndTime: suggestion?.latestEndTime ?? null,
+        gameDefaultStart: gameDefaultStart?.slice(0, 5) || SESSION_DEFAULTS.START_TIME,
+        gameDefaultEnd: gameDefaultEnd?.slice(0, 5) || SESSION_DEFAULTS.END_TIME,
+      });
+      setStart(defaults.start);
+      setEnd(defaults.end);
+      setLocation('');
+      setNotes('');
+    }
     setError(null);
-  }, [open, date, suggestion, gameDefaultStart, gameDefaultEnd]);
+  }, [open, date, mode, session, suggestion, gameDefaultStart, gameDefaultEnd]);
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  // In edit mode, the submit button is disabled until at least one field differs.
+  const hasChanges = useMemo(() => {
+    if (mode !== 'edit' || !session) return true;
+    const startChanged = start !== (session.start_time ?? '').slice(0, 5);
+    const endChanged = end !== (session.end_time ?? '').slice(0, 5);
+    const locationChanged = normalize(location) !== (session.location ?? null);
+    const notesChanged = normalize(notes) !== (session.notes ?? null);
+    return startChanged || endChanged || locationChanged || notesChanged;
+  }, [mode, session, start, end, location, notes]);
 
   if (!date) return null;
 
   const submit = async () => {
     setBusy(true);
     setError(null);
-    const res = await onConfirm(date, start, end);
+    const res = await onSubmit({
+      start,
+      end,
+      location: normalize(location),
+      notes: normalize(notes),
+    });
     setBusy(false);
     if (!res.success) {
-      setError(res.error ?? 'Failed to schedule session');
+      setError(res.error ?? 'Failed to save session');
       return;
     }
     onClose();
   };
 
+  const isSchedule = mode === 'schedule';
+  const title = format(parseISO(date), 'EEEE, MMMM d, yyyy');
+  const eyebrow = isSchedule ? 'Schedule session' : 'Edit session details';
+  const submitLabel = isSchedule
+    ? busy ? 'Confirming…' : '★ Confirm session'
+    : busy ? 'Saving…' : 'Save changes';
+
+  const locationCounterClass =
+    location.length > LOCATION_MAX ? 'text-destructive'
+      : location.length >= LOCATION_WARN ? 'text-primary'
+      : 'text-muted-foreground';
+  const notesCounterClass =
+    notes.length > NOTES_MAX ? 'text-destructive'
+      : notes.length >= NOTES_WARN ? 'text-primary'
+      : 'text-muted-foreground';
+
   return (
     <Modal
       open={open}
       onClose={onClose}
-      eyebrow={<EyebrowLabel>Schedule session</EyebrowLabel>}
-      title={format(parseISO(date), 'EEEE, MMMM d, yyyy')}
-      data-testid="schedule-session-modal"
+      eyebrow={<EyebrowLabel>{eyebrow}</EyebrowLabel>}
+      title={title}
+      data-testid="session-details-modal"
       footer={
         <>
           <Button
             variant="secondary"
             onClick={onClose}
             disabled={busy}
-            title="Close this dialog without scheduling"
+            title="Close this dialog without saving"
           >
             Cancel
           </Button>
           <Button
             onClick={submit}
-            disabled={busy}
-            data-testid="confirm-session-submit"
-            title="Schedule a session on this date"
+            disabled={busy || !hasChanges}
+            data-testid="session-details-submit"
+            title={isSchedule ? 'Schedule a session on this date' : 'Save changes to this session'}
           >
-            {busy ? 'Confirming…' : '★ Confirm session'}
+            {submitLabel}
           </Button>
         </>
       }
     >
-      <div>
-        <label htmlFor="sch-start" className="mb-1 block text-sm font-medium text-card-foreground">Start time</label>
-        <Input id="sch-start" type="time" value={start} onChange={(e) => setStart(e.target.value)} />
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="sd-start" className="mb-1 block text-sm font-medium text-card-foreground">Start</label>
+          <Input id="sd-start" type="time" value={start} onChange={(e) => setStart(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="sd-end" className="mb-1 block text-sm font-medium text-card-foreground">End</label>
+          <Input id="sd-end" type="time" value={end} onChange={(e) => setEnd(e.target.value)} />
+        </div>
       </div>
-      <div>
-        <label htmlFor="sch-end" className="mb-1 block text-sm font-medium text-card-foreground">End time</label>
-        <Input id="sch-end" type="time" value={end} onChange={(e) => setEnd(e.target.value)} />
+
+      <div className="mt-3">
+        <label htmlFor="sd-location" className="mb-1 block text-sm font-medium text-card-foreground">
+          Location <span className="font-normal text-muted-foreground">(optional)</span>
+        </label>
+        <Input
+          id="sd-location"
+          type="text"
+          maxLength={LOCATION_MAX}
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="e.g. Tom's basement, online (Discord), 123 Main St"
+          data-testid="session-details-location"
+        />
+        {location.length >= LOCATION_WARN && (
+          <p className={`mt-1 text-right text-[11px] ${locationCounterClass}`}>
+            {location.length} / {LOCATION_MAX}
+          </p>
+        )}
       </div>
-      {error && <p className="text-sm text-danger">{error}</p>}
+
+      <div className="mt-3">
+        <label htmlFor="sd-notes" className="mb-1 block text-sm font-medium text-card-foreground">
+          Notes <span className="font-normal text-muted-foreground">(optional)</span>
+        </label>
+        <Textarea
+          id="sd-notes"
+          rows={3}
+          maxLength={NOTES_MAX}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Optional: bring snacks, character sheets, this week we're starting Chapter 5"
+          data-testid="session-details-notes"
+        />
+        {notes.length >= NOTES_WARN && (
+          <p className={`mt-1 text-right text-[11px] ${notesCounterClass}`}>
+            {notes.length} / {NOTES_MAX}
+          </p>
+        )}
+      </div>
+
+      {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
     </Modal>
   );
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -6,6 +6,7 @@ import {
   fetchGameSessions,
   confirmSession as confirmSessionQuery,
   cancelSession as cancelSessionQuery,
+  updateSession as updateSessionQuery,
 } from '@/lib/data';
 import { USAGE_LIMITS } from '@/lib/constants';
 
@@ -19,6 +20,17 @@ export interface UseSessionsReturn {
     startTime: string,
     endTime: string,
     confirmedBy: string,
+    location?: string | null,
+    notes?: string | null,
+  ) => Promise<{ success: boolean; error?: string }>;
+  updateSession: (
+    sessionId: string,
+    patch: {
+      start_time?: string;
+      end_time?: string;
+      location?: string | null;
+      notes?: string | null;
+    },
   ) => Promise<{ success: boolean; error?: string }>;
   cancelSession: (date: string) => Promise<{ success: boolean; error?: string }>;
   refresh: () => Promise<void>;
@@ -46,6 +58,8 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
       startTime: string,
       endTime: string,
       confirmedBy: string,
+      location: string | null = null,
+      notes: string | null = null,
     ): Promise<{ success: boolean; error?: string }> => {
       if (!gameId || !confirmedBy) return { success: false, error: 'Not authenticated' };
 
@@ -72,6 +86,8 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
         start_time: startTime,
         end_time: endTime,
         confirmed_by: confirmedBy,
+        location,
+        notes,
       });
 
       if (error) {
@@ -102,6 +118,38 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
     [gameId, sessions],
   );
 
+  const updateSession = useCallback(
+    async (
+      sessionId: string,
+      patch: {
+        start_time?: string;
+        end_time?: string;
+        location?: string | null;
+        notes?: string | null;
+      },
+    ): Promise<{ success: boolean; error?: string }> => {
+      const { data, error } = await updateSessionQuery(supabase, sessionId, patch);
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          // Row was deleted by another GM in another tab.
+          await fetchAll();
+          return { success: false, error: 'This session no longer exists.' };
+        }
+        if (error.code === '42501') {
+          return { success: false, error: "You don't have permission to edit this session." };
+        }
+        return { success: false, error: 'Failed to update session. Please try again.' };
+      }
+
+      if (data) {
+        setSessions((prev) => prev.map((s) => (s.id === data.id ? data : s)));
+      }
+      return { success: true };
+    },
+    [fetchAll],
+  );
+
   const cancelSession = useCallback(
     async (date: string): Promise<{ success: boolean; error?: string }> => {
       if (!gameId) return { success: false, error: 'Not authenticated' };
@@ -113,5 +161,5 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
     [gameId],
   );
 
-  return { sessions, loading, confirmSession, cancelSession, refresh: fetchAll };
+  return { sessions, loading, confirmSession, updateSession, cancelSession, refresh: fetchAll };
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -128,6 +128,7 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
         notes?: string | null;
       },
     ): Promise<{ success: boolean; error?: string }> => {
+      if (!gameId) return { success: false, error: 'Not authenticated' };
       const { data, error } = await updateSessionQuery(supabase, sessionId, patch);
 
       if (error) {
@@ -147,7 +148,7 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
       }
       return { success: true };
     },
-    [fetchAll],
+    [fetchAll, gameId],
   );
 
   const cancelSession = useCallback(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -42,6 +42,8 @@ export const TEXT_LIMITS = {
   PLAY_DATE_NOTE: 200,
   USER_DISPLAY_NAME: 50,
   AVAILABILITY_COMMENT: 500,
+  SESSION_LOCATION: 200,
+  SESSION_NOTES: 500,
 } as const;
 
 // Default timezone for new games (used when browser detection fails)

--- a/src/lib/data/sessions.test.ts
+++ b/src/lib/data/sessions.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { confirmSession, updateSession } from "./sessions";
+
+function makeMockSupabase() {
+  const upsert = vi.fn().mockReturnThis();
+  const update = vi.fn().mockReturnThis();
+  const select = vi.fn().mockReturnThis();
+  const eq = vi.fn().mockReturnThis();
+  const single = vi.fn().mockResolvedValue({ data: null, error: null });
+  const from = vi.fn().mockReturnValue({ upsert, update, select, eq, single });
+  return { from, upsert, update, select, eq, single };
+}
+
+describe("confirmSession", () => {
+  it("upserts on (game_id, date) with status=confirmed and the given times", async () => {
+    const mock = makeMockSupabase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await confirmSession(mock as any, {
+      game_id: "g1",
+      date: "2026-06-14",
+      start_time: "19:00",
+      end_time: "22:30",
+      confirmed_by: "u1",
+    });
+    expect(mock.from).toHaveBeenCalledWith("sessions");
+    expect(mock.upsert).toHaveBeenCalledWith(
+      {
+        game_id: "g1",
+        date: "2026-06-14",
+        start_time: "19:00",
+        end_time: "22:30",
+        confirmed_by: "u1",
+        status: "confirmed",
+      },
+      { onConflict: "game_id,date" },
+    );
+  });
+
+  it("includes location and notes in the upsert payload when provided", async () => {
+    const mock = makeMockSupabase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await confirmSession(mock as any, {
+      game_id: "g1",
+      date: "2026-06-14",
+      start_time: "19:00",
+      end_time: "22:30",
+      confirmed_by: "u1",
+      location: "Tom's basement",
+      notes: "bring dice",
+    });
+    expect(mock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "Tom's basement",
+        notes: "bring dice",
+      }),
+      { onConflict: "game_id,date" },
+    );
+  });
+
+  it("passes through null values for location and notes (used to clear them)", async () => {
+    const mock = makeMockSupabase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await confirmSession(mock as any, {
+      game_id: "g1",
+      date: "2026-06-14",
+      start_time: "19:00",
+      end_time: "22:30",
+      confirmed_by: "u1",
+      location: null,
+      notes: null,
+    });
+    expect(mock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ location: null, notes: null }),
+      { onConflict: "game_id,date" },
+    );
+  });
+});
+
+describe("updateSession", () => {
+  it("calls update(patch).eq('id', sessionId).select().single()", async () => {
+    const mock = makeMockSupabase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await updateSession(mock as any, "session-abc", {
+      location: "new spot",
+      notes: "new notes",
+      start_time: "20:00",
+      end_time: "23:00",
+    });
+    expect(mock.from).toHaveBeenCalledWith("sessions");
+    expect(mock.update).toHaveBeenCalledWith({
+      location: "new spot",
+      notes: "new notes",
+      start_time: "20:00",
+      end_time: "23:00",
+    });
+    expect(mock.eq).toHaveBeenCalledWith("id", "session-abc");
+    expect(mock.select).toHaveBeenCalled();
+    expect(mock.single).toHaveBeenCalled();
+  });
+
+  it("supports partial patches (only some fields)", async () => {
+    const mock = makeMockSupabase();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await updateSession(mock as any, "session-abc", { notes: "new" });
+    expect(mock.update).toHaveBeenCalledWith({ notes: "new" });
+  });
+});

--- a/src/lib/data/sessions.ts
+++ b/src/lib/data/sessions.ts
@@ -17,6 +17,8 @@ export async function confirmSession(
     start_time: string;
     end_time: string;
     confirmed_by: string;
+    location?: string | null;
+    notes?: string | null;
   }
 ) {
   return supabase
@@ -47,4 +49,22 @@ export async function fetchFutureSessions(
     .select('date')
     .eq('game_id', gameId)
     .gte('date', fromDate);
+}
+
+export async function updateSession(
+  supabase: SupabaseClient,
+  sessionId: string,
+  patch: {
+    start_time?: string;
+    end_time?: string;
+    location?: string | null;
+    notes?: string | null;
+  }
+) {
+  return supabase
+    .from('sessions')
+    .update(patch)
+    .eq('id', sessionId)
+    .select()
+    .single<GameSession>();
 }

--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -505,6 +505,61 @@ describe("generateICS", () => {
     expect(result).toContain("SUMMARY:Mystery Game Night");
     expect(result).toContain("END:VEVENT");
   });
+
+  it("emits a LOCATION line when location is set", () => {
+    const ics = generateICS([
+      { date: "2026-06-14", title: "Game Night", location: "Tom's basement" },
+    ]);
+    expect(ics).toContain("LOCATION:Tom's basement");
+  });
+
+  it("emits a DESCRIPTION line when description is set", () => {
+    const ics = generateICS([
+      { date: "2026-06-14", title: "Game Night", description: "bring dice" },
+    ]);
+    expect(ics).toContain("DESCRIPTION:bring dice");
+  });
+
+  it("emits both LOCATION and DESCRIPTION when both are set", () => {
+    const ics = generateICS([
+      {
+        date: "2026-06-14",
+        title: "Game Night",
+        location: "Tom's basement",
+        description: "bring dice",
+      },
+    ]);
+    expect(ics).toContain("LOCATION:Tom's basement");
+    expect(ics).toContain("DESCRIPTION:bring dice");
+  });
+
+  it("escapes commas, semicolons, and newlines in LOCATION", () => {
+    const ics = generateICS([
+      {
+        date: "2026-06-14",
+        title: "Game Night",
+        location: "123 Main St, Apt 4;\nring buzzer",
+      },
+    ]);
+    expect(ics).toContain("LOCATION:123 Main St\\, Apt 4\\;\\nring buzzer");
+  });
+
+  it("escapes special chars in DESCRIPTION", () => {
+    const ics = generateICS([
+      {
+        date: "2026-06-14",
+        title: "Game Night",
+        description: "line1\nline2; line3, line4",
+      },
+    ]);
+    expect(ics).toContain("DESCRIPTION:line1\\nline2\\; line3\\, line4");
+  });
+
+  it("omits LOCATION and DESCRIPTION lines when fields are absent", () => {
+    const ics = generateICS([{ date: "2026-06-14", title: "Game Night" }]);
+    expect(ics).not.toContain("LOCATION:");
+    expect(ics).not.toContain("DESCRIPTION:");
+  });
 });
 
 describe("composeIcsDescription", () => {

--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { generateICS, escapeICS, slugifyGameName } from "./ics";
+import { generateICS, escapeICS, slugifyGameName, composeIcsDescription } from "./ics";
 
 describe("slugifyGameName", () => {
   it("lowercases the name", () => {
@@ -504,5 +504,35 @@ describe("generateICS", () => {
     expect(result).toContain("BEGIN:VEVENT");
     expect(result).toContain("SUMMARY:Mystery Game Night");
     expect(result).toContain("END:VEVENT");
+  });
+});
+
+describe("composeIcsDescription", () => {
+  it("returns undefined when both inputs are null/empty", () => {
+    expect(composeIcsDescription(null, null)).toBeUndefined();
+    expect(composeIcsDescription(undefined, undefined)).toBeUndefined();
+    expect(composeIcsDescription("", "")).toBeUndefined();
+  });
+
+  it("returns game description alone when notes are absent", () => {
+    expect(composeIcsDescription("D&D campaign", null)).toBe("D&D campaign");
+    expect(composeIcsDescription("D&D campaign", "")).toBe("D&D campaign");
+  });
+
+  it("returns notes alone when game description is absent", () => {
+    expect(composeIcsDescription(null, "bring dice")).toBe("bring dice");
+    expect(composeIcsDescription("", "bring dice")).toBe("bring dice");
+  });
+
+  it("appends notes to game description with a blank-line separator", () => {
+    expect(composeIcsDescription("D&D campaign", "bring dice")).toBe(
+      "D&D campaign\n\nbring dice",
+    );
+  });
+
+  it("trims whitespace from each input before composing", () => {
+    expect(composeIcsDescription("  campaign  ", "  notes  ")).toBe(
+      "campaign\n\nnotes",
+    );
   });
 });

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -360,6 +360,18 @@ export function slugifyGameName(name: string): string {
   return name.toLowerCase().replace(/\s+/g, '-');
 }
 
+export function composeIcsDescription(
+  gameDescription: string | null | undefined,
+  sessionNotes: string | null | undefined,
+): string | undefined {
+  const g = (gameDescription ?? "").trim();
+  const n = (sessionNotes ?? "").trim();
+  if (!g && !n) return undefined;
+  if (!g) return n;
+  if (!n) return g;
+  return `${g}\n\n${n}`;
+}
+
 export function triggerICSDownload(content: string, filename: string): void {
   const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
   const url = URL.createObjectURL(blob);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,8 @@ export interface GameSession {
   end_time: string | null; // HH:MM:SS format
   status: SessionStatus;
   confirmed_by: string | null;
+  location: string | null;
+  notes: string | null;
   created_at: string;
 }
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -92,6 +92,8 @@ CREATE TABLE sessions (
   end_time TIME,
   status session_status DEFAULT 'confirmed',
   confirmed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  location TEXT CHECK (location IS NULL OR char_length(location) <= 200),
+  notes    TEXT CHECK (notes    IS NULL OR char_length(notes)    <= 500),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(game_id, date)
 );


### PR DESCRIPTION
## Summary

- GMs and co-GMs can attach an optional **location** and **notes** to each scheduled session. Surfaced on the schedule tab, the overview tab's upcoming sessions card, and all calendar exports (per-session `.ics`, all-sessions `.ics`, and the public `webcal://` subscribe feed).
- New unified `SessionDetailsModal` replaces the old `ScheduleSessionModal` — supports both schedule and edit modes; the same modal pops via an "Edit details" pencil button on each upcoming session card.
- Long notes clamp to 2 lines on mobile with a "Show more" toggle; location and notes appear inline with `MapPin` and `StickyNote` icons in a dashed-hairline detail block.

## Implementation notes

- **20 commits** organized one logical commit per concern (schema → types → helper → data → hook → modal → wiring → row rendering → mobile clamp → overview tab → subscribe feed → e2e + constants refactor + a11y fixes).
- **Tests:** 410 unit + 43 scheduling e2e all green. 7 new e2e scenarios in ``e2e/tests/scheduling/session-details.spec.ts`` cover create, edit, overview rendering, non-GM permissions, char limits, mobile clamp, and the ICS subscribe-feed wire format.
- **Accessibility:** the scheduled-row expand control is now a dedicated chevron `<button>` (was previously the whole row wrapped in a `<button>`, which became invalid HTML once the row's notes block gained its own Show more `<button>`). The chevron has ``aria-label`` and ``aria-expanded``; ``infoContent`` and its embedded toggle now live as siblings of any interactive control rather than as descendants.
- **Limits:** ``location ≤ 200`` chars, ``notes ≤ 500`` chars. Enforced at three layers: DB CHECK constraints, ``<Input maxLength>`` / ``<Textarea maxLength>``, and a ``normalize()`` that trims and converts empty strings to ``NULL`` before submit. Limits centralized in ``TEXT_LIMITS.SESSION_LOCATION`` / ``SESSION_NOTES``.

## Privacy note (matches existing behavior)

Per-session notes and location flow into the public ICS subscribe feed alongside the existing game ``description``. The invite code is the de-facto access control — same posture as today's calendar subscription. Documented in the design doc as an explicit non-goal of a "private notes" toggle.

## ⚠️ Required pre-deploy step — apply DB migration

The branch updates ``supabase/schema.sql`` directly (which CI applies via the ``00000000000000_initial_schema.sql`` symlink). For production, **the operator must apply this SQL to the production Supabase project before deploying** (e.g., via the Supabase Studio SQL editor or ``supabase db push``):

\`\`\`sql
ALTER TABLE sessions
  ADD COLUMN IF NOT EXISTS location TEXT
  CHECK (location IS NULL OR char_length(location) <= 200);

ALTER TABLE sessions
  ADD COLUMN IF NOT EXISTS notes TEXT
  CHECK (notes IS NULL OR char_length(notes) <= 500);
\`\`\`

If skipped, app writes will fail loudly (PostgREST rejects unknown columns); reads continue to work.

## Test plan

- [ ] Apply the SQL migration above against the target environment
- [ ] CI runs unit + e2e on the branch (should be all green)
- [ ] Smoke: log in as GM, schedule a session with location + notes, confirm it renders on both the schedule and overview tabs
- [ ] Smoke: click ``Edit details`` on a scheduled session, change the location, save — confirm the new value renders
- [ ] Smoke: download the per-session ``.ics`` and confirm ``LOCATION:`` and ``DESCRIPTION:`` lines appear
- [ ] Smoke: subscribe via webcal in Google Calendar / Apple Calendar — confirm location shows on the event
- [ ] Mobile (≤768px) smoke: confirm notes clamp to 2 lines on a long note + "Show more" toggle expands

## Future cleanup (separate tickets)

- Extract the ``ClampedNotes`` component currently duplicated in ``ScheduledRow.tsx`` and ``UpcomingSessionsCard.tsx`` into a shared ``src/components/ui/ClampedText.tsx``.
- The "click anywhere on row to expand" UX is gone (replaced by chevron-only). If we want it back, do it with a click handler that ignores clicks originating from interactive descendants (``event.target.closest('button, [role="button"]')``-style guard).