### PR TITLE
Update admin game health scoring

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -37,7 +37,7 @@ interface GameWithEngagement {
   gm: { id: string; name: string; email: string } | null;
   playerCount: number;
   sessionCount: number;
-  confirmedSessionCount: number;
+  futureSessionCount: number;
   availabilityFillRate: number;
   lastActivity: string | null;
   healthScore: number;
@@ -278,7 +278,8 @@ function GamesTab({ games }: { games: GameWithEngagement[] }) {
                 <SortableHeader field="name" label="Game" currentSort={sortBy} sortDesc={sortDesc} onSort={handleSortChange} />
                 <th className="text-left py-3 px-2 font-medium text-muted-foreground">GM</th>
                 <th className="text-center py-3 px-2 font-medium text-muted-foreground">Players</th>
-                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Sessions</th>
+                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Total Sessions</th>
+                <th className="text-center py-3 px-2 font-medium text-muted-foreground">Upcoming Sessions</th>
                 <th className="text-center py-3 px-2 font-medium text-muted-foreground">Fill Rate</th>
                 <SortableHeader field="lastActivity" label="Last Activity" currentSort={sortBy} sortDesc={sortDesc} onSort={handleSortChange} />
                 <SortableHeader field="created" label="Created" currentSort={sortBy} sortDesc={sortDesc} onSort={handleSortChange} />
@@ -289,7 +290,7 @@ function GamesTab({ games }: { games: GameWithEngagement[] }) {
                 <tr key={game.id} className="border-b border-border/50 hover:bg-muted/50">
                   <td className="py-3 px-2 text-center">
                     <span
-                      className={`inline-block px-2 py-0.5 rounded-sm text-xs font-medium cursor-help ${HEALTH_GRADE_STYLES[game.healthGrade]}`}
+                      className={`inline-block whitespace-nowrap px-2 py-0.5 rounded-sm text-xs font-medium cursor-help ${HEALTH_GRADE_STYLES[game.healthGrade]}`}
                       title={`${game.healthLabel} (${game.healthScore}/100)\n${formatBreakdownTooltip(game.healthBreakdown)}`}
                     >
                       {game.healthGrade} {game.healthScore}
@@ -298,7 +299,8 @@ function GamesTab({ games }: { games: GameWithEngagement[] }) {
                   <td className="py-3 px-2 font-medium text-foreground">{game.name}</td>
                   <td className="py-3 px-2 text-muted-foreground">{game.gm?.name ?? 'Unknown'}</td>
                   <td className="py-3 px-2 text-center text-foreground">{game.playerCount}</td>
-                  <td className="py-3 px-2 text-center text-foreground">{game.confirmedSessionCount}</td>
+                  <td className="py-3 px-2 text-center text-foreground">{game.sessionCount}</td>
+                  <td className="py-3 px-2 text-center text-foreground">{game.futureSessionCount}</td>
                   <td className="py-3 px-2 text-center">
                     <span
                       className={`inline-block px-2 py-0.5 rounded-sm text-xs font-medium ${
@@ -318,7 +320,7 @@ function GamesTab({ games }: { games: GameWithEngagement[] }) {
               ))}
               {sortedGames.length === 0 && (
                 <tr>
-                  <td colSpan={8} className="py-8 text-center text-muted-foreground">
+                  <td colSpan={9} className="py-8 text-center text-muted-foreground">
                     {hideUnhealthy ? 'No healthy games found' : 'No games found'}
                   </td>
                 </tr>

--- a/src/app/api/admin/games/route.ts
+++ b/src/app/api/admin/games/route.ts
@@ -10,7 +10,7 @@ interface GameWithEngagement {
   gm: { id: string; name: string; email: string } | null;
   playerCount: number;
   sessionCount: number;
-  confirmedSessionCount: number;
+  futureSessionCount: number;
   availabilityFillRate: number;
   lastActivity: string | null;
   healthScore: number;
@@ -36,7 +36,7 @@ export async function GET(): Promise<Response> {
 
     const [memberships, sessions, availabilityRecords, gamePlayDates] = await Promise.all([
       paginate<{ game_id: string; user_id: string }>(admin, 'game_memberships', 'game_id, user_id'),
-      paginate<{ game_id: string; status: string; created_at: string; date: string }>(admin, 'sessions', 'game_id, status, created_at, date'),
+      paginate<{ game_id: string; created_at: string; date: string }>(admin, 'sessions', 'game_id, created_at, date'),
       paginate<{ game_id: string; user_id: string; date: string; updated_at: string }>(admin, 'availability', 'game_id, user_id, date, updated_at'),
       paginate<{ game_id: string; date: string }>(admin, 'game_play_dates', 'game_id, date'),
     ]);
@@ -51,14 +51,13 @@ export async function GET(): Promise<Response> {
     }
 
     const todayStr = new Date().toISOString().split('T')[0];
-    const sessionsByGame = new Map<string, { total: number; confirmed: number; future: number; lastActivity: string | null }>();
+    const sessionsByGame = new Map<string, { total: number; future: number; lastActivity: string | null }>();
     for (const s of sessions) {
       if (!sessionsByGame.has(s.game_id)) {
-        sessionsByGame.set(s.game_id, { total: 0, confirmed: 0, future: 0, lastActivity: null });
+        sessionsByGame.set(s.game_id, { total: 0, future: 0, lastActivity: null });
       }
       const stats = sessionsByGame.get(s.game_id)!;
       stats.total++;
-      if (s.status === 'confirmed') stats.confirmed++;
       if (s.date >= todayStr) stats.future++;
       if (!stats.lastActivity || s.created_at > stats.lastActivity) {
         stats.lastActivity = s.created_at;
@@ -89,7 +88,7 @@ export async function GET(): Promise<Response> {
     const gamesWithEngagement: GameWithEngagement[] = (games ?? []).map((game) => {
       const members = membershipsByGame.get(game.id) ?? new Set();
       const totalPlayers = members.size + 1; // +1 for GM
-      const sessionStats = sessionsByGame.get(game.id) ?? { total: 0, confirmed: 0, future: 0, lastActivity: null };
+      const sessionStats = sessionsByGame.get(game.id) ?? { total: 0, future: 0, lastActivity: null };
       const availabilityStats = availabilityByGame.get(game.id) ?? { records: [], lastActivity: null };
 
       // Fill rate: average completion percentage across all current players
@@ -129,7 +128,6 @@ export async function GET(): Promise<Response> {
       // Calculate health score
       const health = calculateGameHealth({
         playerCount: totalPlayers,
-        confirmedSessionCount: sessionStats.confirmed,
         futureSessionCount: sessionStats.future,
         availabilityFillRate: fillRate,
         lastActivity,
@@ -143,7 +141,7 @@ export async function GET(): Promise<Response> {
         gm: gm as GameWithEngagement['gm'],
         playerCount: totalPlayers,
         sessionCount: sessionStats.total,
-        confirmedSessionCount: sessionStats.confirmed,
+        futureSessionCount: sessionStats.future,
         availabilityFillRate: fillRate,
         lastActivity,
         healthScore: health.score,

--- a/src/lib/gameHealth.test.ts
+++ b/src/lib/gameHealth.test.ts
@@ -12,7 +12,6 @@ const referenceDate = new Date("2025-03-15T12:00:00Z");
 function makeInput(overrides: Partial<GameHealthInput> = {}): GameHealthInput {
   return {
     playerCount: 4,
-    confirmedSessionCount: 3,
     futureSessionCount: 1,
     availabilityFillRate: 60,
     lastActivity: "2025-03-12T10:00:00Z", // 3 days ago
@@ -27,7 +26,6 @@ describe("calculateGameHealth", () => {
       const result = calculateGameHealth(
         makeInput({
           playerCount: 6,
-          confirmedSessionCount: 10,
           futureSessionCount: 3,
           availabilityFillRate: 90,
           lastActivity: "2025-03-14T20:00:00Z", // yesterday
@@ -44,7 +42,6 @@ describe("calculateGameHealth", () => {
       const result = calculateGameHealth(
         makeInput({
           playerCount: 1,
-          confirmedSessionCount: 0,
           futureSessionCount: 0,
           availabilityFillRate: 0,
           lastActivity: null,
@@ -62,7 +59,6 @@ describe("calculateGameHealth", () => {
       const result = calculateGameHealth(
         makeInput({
           playerCount: 1, // solo GM
-          confirmedSessionCount: 0,
           futureSessionCount: 0,
           availabilityFillRate: 0,
           lastActivity: "2025-03-10T00:00:00Z",
@@ -80,7 +76,6 @@ describe("calculateGameHealth", () => {
       const result = calculateGameHealth(
         makeInput({
           playerCount: 1,
-          confirmedSessionCount: 0,
           futureSessionCount: 0,
           availabilityFillRate: 0,
           lastActivity: null,
@@ -103,28 +98,28 @@ describe("calculateGameHealth", () => {
       expect(result.breakdown.playerScore).toBe(0);
     });
 
-    it("gives 30 for 2 players", () => {
+    it("gives 33 for 2 players", () => {
       const result = calculateGameHealth(
         makeInput({ playerCount: 2 }),
         referenceDate
       );
-      expect(result.breakdown.playerScore).toBe(30);
+      expect(result.breakdown.playerScore).toBe(33);
     });
 
-    it("gives 60 for 3 players", () => {
+    it("gives 67 for 3 players", () => {
       const result = calculateGameHealth(
         makeInput({ playerCount: 3 }),
         referenceDate
       );
-      expect(result.breakdown.playerScore).toBe(60);
+      expect(result.breakdown.playerScore).toBe(67);
     });
 
-    it("gives 80 for 4 players", () => {
+    it("gives 100 for 4 players", () => {
       const result = calculateGameHealth(
         makeInput({ playerCount: 4 }),
         referenceDate
       );
-      expect(result.breakdown.playerScore).toBe(80);
+      expect(result.breakdown.playerScore).toBe(100);
     });
 
     it("gives 100 for 5+ players", () => {
@@ -145,46 +140,28 @@ describe("calculateGameHealth", () => {
   describe("session score dimension", () => {
     it("gives 0 for no sessions at all", () => {
       const result = calculateGameHealth(
-        makeInput({ confirmedSessionCount: 0, futureSessionCount: 0 }),
+        makeInput({ futureSessionCount: 0 }),
         referenceDate
       );
       expect(result.breakdown.sessionScore).toBe(0);
     });
 
-    it("gives 50 for future sessions but no past sessions", () => {
+    it("gives 100 for 2+ future sessions even with no past sessions", () => {
       const result = calculateGameHealth(
-        makeInput({ confirmedSessionCount: 0, futureSessionCount: 2 }),
-        referenceDate
-      );
-      // totalSignal = 0, futureSignal = 100, avg = 50
-      expect(result.breakdown.sessionScore).toBe(50);
-    });
-
-    it("gives 50 for past sessions but no future sessions", () => {
-      const result = calculateGameHealth(
-        makeInput({ confirmedSessionCount: 5, futureSessionCount: 0 }),
-        referenceDate
-      );
-      // totalSignal = 100, futureSignal = 0, avg = 50
-      expect(result.breakdown.sessionScore).toBe(50);
-    });
-
-    it("gives 100 for 5+ confirmed sessions with future sessions", () => {
-      const result = calculateGameHealth(
-        makeInput({ confirmedSessionCount: 8, futureSessionCount: 1 }),
+        makeInput({ futureSessionCount: 2 }),
         referenceDate
       );
       expect(result.breakdown.sessionScore).toBe(100);
     });
 
-    it("scales total signal linearly up to 5 sessions", () => {
+    it("gives 50 for 1 future session", () => {
       const result = calculateGameHealth(
-        makeInput({ confirmedSessionCount: 2, futureSessionCount: 1 }),
+        makeInput({ futureSessionCount: 1 }),
         referenceDate
       );
-      // totalSignal = (2/5)*100 = 40, futureSignal = 100, avg = 70
-      expect(result.breakdown.sessionScore).toBe(70);
+      expect(result.breakdown.sessionScore).toBe(50);
     });
+
   });
 
   describe("fill rate score dimension", () => {
@@ -222,36 +199,36 @@ describe("calculateGameHealth", () => {
       expect(result.breakdown.recencyScore).toBe(100);
     });
 
-    it("gives 75 for activity 7-14 days ago", () => {
+    it("gives 100 for activity 7-14 days ago", () => {
       const result = calculateGameHealth(
         makeInput({ lastActivity: "2025-03-05T00:00:00Z" }), // 10 days ago
         referenceDate
       );
-      expect(result.breakdown.recencyScore).toBe(75);
+      expect(result.breakdown.recencyScore).toBe(100);
     });
 
-    it("gives 50 for activity 14-30 days ago", () => {
+    it("decays smoothly after 14 days", () => {
       const result = calculateGameHealth(
         makeInput({ lastActivity: "2025-02-25T00:00:00Z" }), // 18 days ago
         referenceDate
       );
-      expect(result.breakdown.recencyScore).toBe(50);
+      expect(result.breakdown.recencyScore).toBe(91);
     });
 
-    it("gives 25 for activity 30-45 days ago", () => {
+    it("continues smooth decay 30-45 days ago", () => {
       const result = calculateGameHealth(
         makeInput({ lastActivity: "2025-02-08T00:00:00Z" }), // 35 days ago
         referenceDate
       );
-      expect(result.breakdown.recencyScore).toBe(25);
+      expect(result.breakdown.recencyScore).toBe(54);
     });
 
-    it("gives 10 for activity 45-60 days ago", () => {
+    it("continues smooth decay 45-60 days ago", () => {
       const result = calculateGameHealth(
         makeInput({ lastActivity: "2025-01-25T00:00:00Z" }), // 49 days ago
         referenceDate
       );
-      expect(result.breakdown.recencyScore).toBe(10);
+      expect(result.breakdown.recencyScore).toBe(24);
     });
 
     it("gives 0 for activity over 60 days ago", () => {
@@ -297,7 +274,6 @@ describe("calculateGameHealth", () => {
       const low = calculateGameHealth(
         makeInput({
           playerCount: 0,
-          confirmedSessionCount: 0,
           futureSessionCount: 0,
           availabilityFillRate: 0,
           lastActivity: null,
@@ -310,7 +286,6 @@ describe("calculateGameHealth", () => {
       const high = calculateGameHealth(
         makeInput({
           playerCount: 100,
-          confirmedSessionCount: 100,
           futureSessionCount: 50,
           availabilityFillRate: 100,
           lastActivity: "2025-03-15T00:00:00Z",

--- a/src/lib/gameHealth.ts
+++ b/src/lib/gameHealth.ts
@@ -2,7 +2,6 @@
 
 export interface GameHealthInput {
   playerCount: number;
-  confirmedSessionCount: number;
   futureSessionCount: number;
   availabilityFillRate: number; // 0-100
   lastActivity: string | null; // ISO timestamp
@@ -47,29 +46,21 @@ function daysBetween(dateStr: string, referenceDate: Date): number {
   );
 }
 
-/** 1 player = 0, 2 = 30, 3 = 60, 4 = 80, 5+ = 100 */
+/** Linear ramp: 1 player = 0, 4+ players = 100 */
 function calcPlayerScore(playerCount: number): number {
-  if (playerCount >= 5) return 100;
-  if (playerCount === 4) return 80;
-  if (playerCount === 3) return 60;
-  if (playerCount === 2) return 30;
-  return 0;
+  if (playerCount >= 4) return 100;
+  if (playerCount <= 1) return 0;
+  return Math.round(((playerCount - 1) / 3) * 100);
 }
 
-/**
- * Blend of total confirmed sessions (50%) and future sessions presence (50%).
- * 5+ confirmed sessions = max for the total sub-signal.
- */
+/** Smoothly score upcoming momentum: 0 future sessions = 0, 2+ = 100 */
 function calcSessionScore(
-  confirmedSessionCount: number,
   futureSessionCount: number
 ): number {
-  const totalSignal = Math.min(confirmedSessionCount / 5, 1) * 100;
-  const futureSignal = futureSessionCount > 0 ? 100 : 0;
-  return Math.round((totalSignal + futureSignal) / 2);
+  return Math.round(Math.min(futureSessionCount / 2, 1) * 100);
 }
 
-/** Aggressive decay: 0 at 60+ days */
+/** Full credit through 14 days, then linear decay to 0 at 60+ days */
 function calcRecencyScore(
   lastActivity: string | null,
   referenceDate: Date
@@ -77,12 +68,9 @@ function calcRecencyScore(
   if (!lastActivity) return 0;
   const days = daysBetween(lastActivity, referenceDate);
   if (days < 0) return 100; // future date, treat as very recent
-  if (days < 7) return 100;
-  if (days < 14) return 75;
-  if (days < 30) return 50;
-  if (days < 45) return 25;
-  if (days < 60) return 10;
-  return 0;
+  if (days <= 14) return 100;
+  if (days >= 60) return 0;
+  return Math.round(((60 - days) / (60 - 14)) * 100);
 }
 
 // ── Grade mapping ──────────────────────────────────────────
@@ -117,10 +105,7 @@ export function calculateGameHealth(
 ): GameHealthResult {
   const breakdown: HealthBreakdown = {
     playerScore: calcPlayerScore(input.playerCount),
-    sessionScore: calcSessionScore(
-      input.confirmedSessionCount,
-      input.futureSessionCount
-    ),
+    sessionScore: calcSessionScore(input.futureSessionCount),
     fillRateScore: Math.round(
       Math.max(0, Math.min(100, input.availabilityFillRate))
     ),


### PR DESCRIPTION
## Summary
- make admin game health scoring more generous and smoother
- score sessions using only upcoming sessions
- add Total Sessions and Upcoming Sessions columns to Admin > Games
- keep health badges from wrapping

## Verification
- npm test -- src/lib/gameHealth.test.ts
- npm run lint