### PR TITLE
Add chronological sort toggle to suggested dates

### DIFF
--- a/docs/plans/2026-05-20-suggested-dates-sort-toggle-design.md
+++ b/docs/plans/2026-05-20-suggested-dates-sort-toggle-design.md
@@ -1,0 +1,156 @@
+# Suggested Dates: Chronological Sort Toggle — Design
+
+**Status:** Approved, ready for implementation plan
+**Date:** 2026-05-20
+
+## Background
+
+The Schedule tab's "Suggested dates" section currently always sorts dates by an availability score (most available players first, ties broken by maybe count, then pending count, then date). This is the right default for "when should we play?" but it's awkward for "what's our next play day?" — a GM scanning chronologically has to mentally reorder.
+
+We're adding an optional sort toggle: **By availability** (current behavior) or **By date** (chronological).
+
+## Scope
+
+- `src/components/games/schedule/RankedList.tsx` — add toggle UI + branch on sort mode
+- `src/components/games/schedule/RankedRow.tsx` — accept a `showRank` prop; hide rank badge in chronological mode
+- `src/hooks/useLocalStoragePref.ts` — **new**: reusable typed localStorage hook
+- Unit tests for the hook and updated `RankedList.test.tsx`
+- One E2E happy-path test in the schedule suite
+
+Out of scope:
+
+- Persisting the preference in the user profile (DB). localStorage is sufficient.
+- Additional sort modes (by maybe count, shuffle, etc.).
+- Restructuring `RankedList` into separate sort vs. render units. Boundary is fine for two modes.
+
+## UI
+
+Segmented control inline with the "Suggested dates" eyebrow label:
+
+```
+SUGGESTED DATES                       [ Availability | Date ]
+```
+
+- Two buttons, current selection highlighted with `bg-primary/10 text-primary` (matching the existing semantic theme classes documented in CLAUDE.md).
+- Mobile: same control, but allowed to wrap below the label if horizontal space is tight.
+- Hidden when `suggestions.length === 0` (the empty state already covers that case).
+- `role="radiogroup"` with two `role="radio"` buttons + `aria-checked` for accessibility.
+
+## Behavior by mode
+
+### Availability mode (default)
+
+Unchanged from today:
+
+1. `sortSuggestions(suggestions)` — orders by `meetsThreshold` → `availableCount` → `maybeCount` → `pendingCount` → date.
+2. `partitionByThreshold(...)` — splits into `viable` and `belowThreshold`.
+3. Render viable as a numbered list (rank badges 1..n).
+4. Render below-threshold in a collapsible section underneath ("Below threshold · N · Show/Hide"), continuing rank numbering.
+
+### Chronological mode
+
+1. `sortSuggestionsChronologically(suggestions)` — single date-ascending list. (Helper already exists at [src/lib/suggestions.ts:106](src/lib/suggestions.ts:106).)
+2. **No partition.** Below-threshold rows appear in their date-correct position.
+3. **No rank badges.** Pass `showRank={false}` to `RankedRow`; the badge slot collapses.
+4. Below-threshold rows keep their existing muted visual treatment (the prop `belowThreshold={true}` on `RankedRow` already handles this — we just compute it from `s.meetsThreshold` per-row instead of from the partition).
+
+## Persistence
+
+A new generic hook `useLocalStoragePref<T>` modeled after the pattern in `ThemeContext`:
+
+```ts
+function useLocalStoragePref<T>(
+  key: string,
+  defaultValue: T,
+  isValid: (v: unknown) => v is T
+): [T, (next: T) => void];
+```
+
+Behavior:
+
+- First render returns `defaultValue` (SSR-safe, no hydration mismatch).
+- A `useEffect` on mount reads `localStorage[key]`, runs `isValid`, and updates state if valid.
+- Setter writes through to `localStorage` and updates state.
+- Storage key: `gns:schedule-sort`. Values: `'availability'` | `'chronological'`.
+
+Why a hook (vs. inline state in `RankedList`): the SSR-safe hydration dance is non-trivial enough that bundling it once avoids subtle hydration bugs the next time we add a UI preference. Generic shape so future prefs reuse it.
+
+## Data flow
+
+```
+suggestions (DateSuggestion[])
+        │
+        ▼
+   RankedList
+        │
+        ├── sortMode (from useLocalStoragePref)
+        │
+        ▼
+  sortMode === 'availability'?
+     /              \
+   yes               no
+    │                 │
+sortSuggestions   sortSuggestionsChronologically
+    │                 │
+partitionByThreshold  │ (no partition; flat list)
+    │                 │
+    ▼                 ▼
+ RankedRow (showRank=true)   RankedRow (showRank=false,
+                              belowThreshold=!s.meetsThreshold)
+```
+
+The two existing pure helpers in `src/lib/suggestions.ts` aren't modified.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| `localStorage` has garbage value | `isValid` rejects, fall back to `'availability'`. |
+| User disables localStorage / SSR | Hook stays on `defaultValue`; setter still updates in-memory state, just doesn't persist. |
+| `suggestions.length === 0` | Toggle hidden; empty state renders as today. |
+| `autoExpandDate` (after confirming a session) in chronological mode | `showBelow` section doesn't exist, so the existing `setShowBelow(true)` effect is gated to availability mode only. The row's own auto-scroll trigger via `autoScrollTrigger` prop still works because the row exists in the flat list. |
+| User switches modes while a below-threshold row is expanded | Expansion state lives on `RankedRow`, keyed by `s.date`. Switching modes doesn't unmount the rows that are present in both modes, so expansion is preserved for those. Rows that only existed under the collapsible "Below threshold" section in availability mode are now always rendered in chronological mode, so they appear collapsed by default — acceptable. |
+
+## Testing
+
+### Unit
+
+- **`useLocalStoragePref` test (new):**
+  - Returns default on first render.
+  - Hydrates from storage when a valid value exists.
+  - Ignores and falls back when storage holds an invalid value.
+  - Persists through the setter.
+- **`RankedList.test.tsx` (extend):**
+  - Chronological mode: rows render in date order, no "Below threshold" collapsible button, no rank ordinals.
+  - Below-threshold rows in chronological mode still get the muted visual treatment.
+  - Toggle hidden when `suggestions` is empty.
+  - Persistence: simulating a localStorage value of `'chronological'` causes the chronological view on (effect-hydrated) re-render.
+
+### E2E
+
+One happy-path test added to the schedule suite:
+
+1. Load schedule tab for a seeded game with multiple suggestions.
+2. Default view shows availability-ordered list.
+3. Click "Date" segment → list reorders chronologically, rank badges gone.
+4. Reload the page → still in chronological mode.
+5. Click "Availability" segment → back to ranked view with badges.
+
+## Risks / open questions
+
+- **Visual treatment of the rank slot when hidden.** Two options:
+  - Just don't render the badge — adjacent content shifts left slightly.
+  - Render an invisible placeholder so row layout stays identical.
+  Pick at implementation time based on how the rows actually look; default to "don't render" for less visual weight.
+- **`partitionByThreshold` only runs in availability mode.** That's intentional and matches the design, but means if we ever add a third sort (e.g., "by maybe count") we'll need to revisit whether partitioning should be orthogonal to sort. Not a blocker.
+
+## Files
+
+| Change | File |
+|--------|------|
+| New | `src/hooks/useLocalStoragePref.ts` |
+| New | `src/hooks/useLocalStoragePref.test.ts` |
+| Modified | `src/components/games/schedule/RankedList.tsx` |
+| Modified | `src/components/games/schedule/RankedList.test.tsx` |
+| Modified | `src/components/games/schedule/RankedRow.tsx` (add `showRank` prop) |
+| New | `e2e/tests/scheduling/suggestions-sort-toggle.spec.ts` (alongside the existing `schedule-tab-redesign.spec.ts`) |

--- a/docs/plans/2026-05-20-suggested-dates-sort-toggle-plan.md
+++ b/docs/plans/2026-05-20-suggested-dates-sort-toggle-plan.md
@@ -1,0 +1,777 @@
+# Suggested Dates Sort Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional chronological sort to the "Suggested dates" list on the Schedule tab, persisted per-user via localStorage, alongside the existing availability-based ranking.
+
+**Architecture:** Introduce a reusable `useLocalStoragePref<T>` hook (SSR-safe hydration on mount). In `RankedList`, branch on a `sortMode` state from that hook: availability mode keeps current `sortSuggestions` + `partitionByThreshold` behavior; chronological mode uses the already-exported `sortSuggestionsChronologically` to render a flat list with no partition and no rank badges. `RankedRow` gains a `showRank` prop so the ordinal collapses in chronological mode.
+
+**Tech Stack:** Next.js 16 App Router, React (client components), Vitest + Testing Library for unit tests, Playwright for e2e, Tailwind with semantic theme classes.
+
+**Spec:** [docs/plans/2026-05-20-suggested-dates-sort-toggle-design.md](2026-05-20-suggested-dates-sort-toggle-design.md)
+
+---
+
+## File Structure
+
+| Change | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/hooks/useLocalStoragePref.ts` | Generic SSR-safe localStorage-backed React state hook |
+| Create | `src/hooks/useLocalStoragePref.test.ts` | Unit tests for the hook |
+| Modify | `src/components/games/schedule/RankedRow.tsx` | Add `showRank` prop; hide `RankCircle` slot when false |
+| Modify | `src/components/games/schedule/RankedList.tsx` | Read `sortMode` from hook; branch sort/partition; render segmented control |
+| Modify | `src/components/games/schedule/RankedList.test.tsx` | Add tests for chronological mode + toggle visibility |
+| Create | `e2e/tests/scheduling/suggestions-sort-toggle.spec.ts` | E2E: toggle reorders list and persists across reload |
+
+---
+
+## Task 1: `useLocalStoragePref` hook
+
+**Files:**
+- Create: `src/hooks/useLocalStoragePref.ts`
+- Create: `src/hooks/useLocalStoragePref.test.ts`
+
+- [ ] **Step 1.1: Write failing test for default value before hydration**
+
+Create `src/hooks/useLocalStoragePref.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useLocalStoragePref } from './useLocalStoragePref';
+
+const isMode = (v: unknown): v is 'a' | 'b' => v === 'a' || v === 'b';
+
+describe('useLocalStoragePref', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns the default value on first render and after hydration when storage is empty', () => {
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+  });
+
+  it('hydrates from localStorage when a valid value is stored', () => {
+    window.localStorage.setItem('k', JSON.stringify('b'));
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('b');
+  });
+
+  it('ignores invalid stored values and uses the default', () => {
+    window.localStorage.setItem('k', JSON.stringify('garbage'));
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+  });
+
+  it('persists through the setter', () => {
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    act(() => {
+      result.current[1]('b');
+    });
+    expect(result.current[0]).toBe('b');
+    expect(window.localStorage.getItem('k')).toBe(JSON.stringify('b'));
+  });
+
+  it('does not throw when localStorage access fails', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `npm run test:run -- src/hooks/useLocalStoragePref.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 1.3: Implement the hook**
+
+Create `src/hooks/useLocalStoragePref.ts`:
+
+```ts
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * SSR-safe localStorage-backed React state.
+ *
+ * Returns `defaultValue` on first render so the server and the initial client
+ * render match. After mount, hydrates from `localStorage[key]` if the stored
+ * value passes `isValid`. The setter updates both state and storage.
+ */
+export function useLocalStoragePref<T>(
+  key: string,
+  defaultValue: T,
+  isValid: (v: unknown) => v is T
+): [T, (next: T) => void] {
+  const [value, setValue] = useState<T>(defaultValue);
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw === null) return;
+      const parsed: unknown = JSON.parse(raw);
+      if (isValid(parsed)) {
+        setValue(parsed);
+      }
+    } catch {
+      // Ignore: localStorage may be unavailable or contain invalid JSON.
+    }
+    // We intentionally read storage once on mount and don't track key changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const setPersisted = useCallback(
+    (next: T) => {
+      setValue(next);
+      try {
+        window.localStorage.setItem(key, JSON.stringify(next));
+      } catch {
+        // Ignore write failures (private browsing, quota, etc.).
+      }
+    },
+    [key]
+  );
+
+  return [value, setPersisted];
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `npm run test:run -- src/hooks/useLocalStoragePref.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/hooks/useLocalStoragePref.ts src/hooks/useLocalStoragePref.test.ts
+git commit -m "feat: add useLocalStoragePref hook"
+```
+
+---
+
+## Task 2: `RankedRow` — optional rank badge
+
+**Files:**
+- Modify: `src/components/games/schedule/RankedRow.tsx`
+
+- [ ] **Step 2.1: Add `showRank` prop with default `true`**
+
+In `src/components/games/schedule/RankedRow.tsx`, update the `RankedRowProps` interface and destructure to include `showRank`. The badge is the `<RankCircle rank={rank} highlighted={highlighted} />` element on the inner grid; gate that and the "highlighted" treatment on `showRank`.
+
+Replace the props interface block:
+
+```tsx
+interface RankedRowProps {
+  rank: number;
+  suggestion: DateSuggestion;
+  isGm: boolean;
+  gmId: string;
+  coGmIds: Set<string>;
+  use24h: boolean;
+  belowThreshold: boolean;
+  defaultExpanded: boolean;
+  minPlayersNeeded: number;
+  playDateNote?: string | null;
+  onLockIn: (date: string) => void;
+  autoScrollTrigger?: string | null;
+  /** When false, the rank ordinal slot is hidden and no row is visually highlighted as "rank #1". */
+  showRank?: boolean;
+}
+```
+
+And the destructure:
+
+```tsx
+export function RankedRow({
+  rank,
+  suggestion,
+  isGm,
+  gmId,
+  coGmIds,
+  use24h,
+  belowThreshold,
+  defaultExpanded,
+  minPlayersNeeded,
+  playDateNote,
+  onLockIn,
+  autoScrollTrigger,
+  showRank = true,
+}: RankedRowProps) {
+```
+
+- [ ] **Step 2.2: Gate the highlight + RankCircle on `showRank`**
+
+In the same file, update the `highlighted` calculation:
+
+```tsx
+const highlighted = showRank && rank === 1 && !belowThreshold;
+```
+
+And change the inner grid to a 3-column layout when the rank is hidden. Replace the `<button …>` opening tag and its first child:
+
+```tsx
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        className={`grid w-full items-center gap-3 text-left ${
+          showRank ? 'grid-cols-[auto_1fr_auto_auto]' : 'grid-cols-[1fr_auto_auto]'
+        }`}
+      >
+        {showRank && <RankCircle rank={rank} highlighted={highlighted} />}
+```
+
+- [ ] **Step 2.3: Verify the file still compiles**
+
+Run: `npm run lint -- src/components/games/schedule/RankedRow.tsx`
+Expected: no errors.
+
+Also run the existing test suite for RankedList to confirm nothing regressed:
+
+Run: `npm run test:run -- src/components/games/schedule/RankedList.test.tsx`
+Expected: PASS (existing test still passes because default `showRank=true` preserves behavior).
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add src/components/games/schedule/RankedRow.tsx
+git commit -m "feat: add optional showRank prop to RankedRow"
+```
+
+---
+
+## Task 3: `RankedList` — sort-mode state + branched rendering
+
+**Files:**
+- Modify: `src/components/games/schedule/RankedList.tsx`
+
+- [ ] **Step 3.1: Add the sort-mode type, storage key, and validator**
+
+At the top of `src/components/games/schedule/RankedList.tsx`, beneath the existing imports, add:
+
+```tsx
+import { useLocalStoragePref } from '@/hooks/useLocalStoragePref';
+import { sortSuggestionsChronologically } from '@/lib/suggestions';
+
+type SortMode = 'availability' | 'chronological';
+const SORT_STORAGE_KEY = 'gns:schedule-sort';
+const isSortMode = (v: unknown): v is SortMode =>
+  v === 'availability' || v === 'chronological';
+```
+
+- [ ] **Step 3.2: Read `sortMode` from the hook inside the component**
+
+Inside `RankedList`, immediately above the existing `useState`/`useMemo`, add:
+
+```tsx
+const [sortMode, setSortMode] = useLocalStoragePref<SortMode>(
+  SORT_STORAGE_KEY,
+  'availability',
+  isSortMode
+);
+```
+
+- [ ] **Step 3.3: Replace the `useMemo` block to compute view rows from `sortMode`**
+
+Replace the existing `useMemo` returning `{ viable, belowThreshold }` and the `useEffect` that auto-expands the below-threshold section with this combined block:
+
+```tsx
+const { viable, belowThreshold, chronological } = useMemo(() => {
+  if (sortMode === 'chronological') {
+    return {
+      viable: [] as typeof suggestions,
+      belowThreshold: [] as typeof suggestions,
+      chronological: sortSuggestionsChronologically(suggestions),
+    };
+  }
+  const { viable, belowThreshold } = partitionByThreshold(suggestions);
+  return { viable, belowThreshold, chronological: [] as typeof suggestions };
+}, [suggestions, sortMode]);
+
+/* eslint-disable react-hooks/set-state-in-effect */
+useEffect(() => {
+  if (
+    sortMode === 'availability' &&
+    autoExpandDate &&
+    belowThreshold.some((s) => s.date === autoExpandDate)
+  ) {
+    setShowBelow(true);
+  }
+}, [autoExpandDate, belowThreshold, sortMode]);
+/* eslint-enable react-hooks/set-state-in-effect */
+```
+
+(`suggestions` is already imported via the props; `sortSuggestionsChronologically` was imported in step 3.1.)
+
+- [ ] **Step 3.4: Replace the JSX to add the segmented control and branched list**
+
+Replace the entire `return (...)` block (the one starting `<div className="space-y-3">`) with:
+
+```tsx
+return (
+  <div className="space-y-3">
+    <div className="flex items-center justify-between gap-3 flex-wrap">
+      <EyebrowLabel className="block">Suggested dates</EyebrowLabel>
+      <div
+        role="radiogroup"
+        aria-label="Sort suggested dates"
+        className="inline-flex rounded-md border border-border bg-card p-0.5 text-[11px] font-mono"
+        data-testid="suggestions-sort-toggle"
+      >
+        <button
+          type="button"
+          role="radio"
+          aria-checked={sortMode === 'availability'}
+          onClick={() => setSortMode('availability')}
+          className={`px-2 py-1 rounded ${
+            sortMode === 'availability'
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          data-testid="sort-by-availability"
+        >
+          Availability
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={sortMode === 'chronological'}
+          onClick={() => setSortMode('chronological')}
+          className={`px-2 py-1 rounded ${
+            sortMode === 'chronological'
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          data-testid="sort-by-date"
+        >
+          Date
+        </button>
+      </div>
+    </div>
+
+    {sortMode === 'chronological' ? (
+      <ul className="space-y-3" data-testid="ranked-list">
+        {chronological.map((s) => (
+          <RankedRow
+            key={s.date}
+            rank={0}
+            suggestion={s}
+            isGm={isGm}
+            gmId={gmId}
+            coGmIds={coGmIds}
+            use24h={use24h}
+            belowThreshold={!s.meetsThreshold}
+            defaultExpanded={false}
+            minPlayersNeeded={minPlayersNeeded}
+            playDateNote={playDateNotes?.get(s.date) ?? null}
+            onLockIn={onLockIn}
+            autoScrollTrigger={autoExpandDate}
+            showRank={false}
+          />
+        ))}
+      </ul>
+    ) : (
+      <>
+        <ul className="space-y-3" data-testid="ranked-list">
+          {viable.map((s, idx) => (
+            <RankedRow
+              key={s.date}
+              rank={idx + 1}
+              suggestion={s}
+              isGm={isGm}
+              gmId={gmId}
+              coGmIds={coGmIds}
+              use24h={use24h}
+              belowThreshold={false}
+              defaultExpanded={idx === 0}
+              minPlayersNeeded={minPlayersNeeded}
+              playDateNote={playDateNotes?.get(s.date) ?? null}
+              onLockIn={onLockIn}
+              autoScrollTrigger={autoExpandDate}
+            />
+          ))}
+        </ul>
+
+        {belowThreshold.length > 0 && (
+          <div className="pt-2">
+            <button
+              type="button"
+              aria-expanded={showBelow}
+              onClick={() => setShowBelow((v) => !v)}
+              className="flex w-full items-center justify-between py-2"
+              title={showBelow ? "Hide dates that don't meet the minimum player threshold" : "Show dates that don't meet the minimum player threshold"}
+            >
+              <EyebrowLabel variant="muted">Below threshold · {belowThreshold.length}</EyebrowLabel>
+              <span className="font-mono text-[11px] text-muted-foreground">{showBelow ? 'Hide' : 'Show'}</span>
+            </button>
+            {showBelow && (
+              <ul className="mt-2 space-y-3" data-testid="below-threshold-list">
+                {belowThreshold.map((s, idx) => (
+                  <RankedRow
+                    key={s.date}
+                    rank={viable.length + idx + 1}
+                    suggestion={s}
+                    isGm={isGm}
+                    gmId={gmId}
+                    coGmIds={coGmIds}
+                    use24h={use24h}
+                    belowThreshold={true}
+                    defaultExpanded={false}
+                    minPlayersNeeded={minPlayersNeeded}
+                    playDateNote={playDateNotes?.get(s.date) ?? null}
+                    onLockIn={onLockIn}
+                    autoScrollTrigger={autoExpandDate}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </>
+    )}
+  </div>
+);
+```
+
+- [ ] **Step 3.5: Hide the toggle when there are no suggestions**
+
+The early return `if (suggestions.length === 0)` already exits before any toggle is rendered, so no change is needed. Confirm by reading the file — the `EmptyState` branch must remain above the `return (...)` block.
+
+- [ ] **Step 3.6: Run the existing test to confirm it still passes**
+
+Run: `npm run test:run -- src/components/games/schedule/RankedList.test.tsx`
+Expected: PASS (the existing test runs in default availability mode).
+
+- [ ] **Step 3.7: Run lint on the file**
+
+Run: `npm run lint -- src/components/games/schedule/RankedList.tsx`
+Expected: no errors.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/components/games/schedule/RankedList.tsx
+git commit -m "feat: add chronological sort toggle to suggested dates"
+```
+
+---
+
+## Task 4: Unit tests for chronological mode
+
+**Files:**
+- Modify: `src/components/games/schedule/RankedList.test.tsx`
+
+- [ ] **Step 4.1: Extend the test file with chronological-mode cases**
+
+Replace the entire contents of `src/components/games/schedule/RankedList.test.tsx` with:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RankedList } from './RankedList';
+import { HoverSyncProvider } from './HoverSyncContext';
+import type { DateSuggestion } from '@/types';
+
+const mk = (overrides: Partial<DateSuggestion>): DateSuggestion => ({
+  date: '2026-05-01',
+  dayOfWeek: 4,
+  availableCount: 4,
+  maybeCount: 0,
+  unavailableCount: 0,
+  pendingCount: 0,
+  totalPlayers: 5,
+  availablePlayers: [],
+  maybePlayers: [],
+  unavailablePlayers: [],
+  pendingPlayers: [],
+  earliestStartTime: null,
+  latestEndTime: null,
+  meetsThreshold: true,
+  ...overrides,
+});
+
+const renderList = (suggestions: DateSuggestion[]) =>
+  render(
+    <HoverSyncProvider>
+      <RankedList
+        suggestions={suggestions}
+        isGm={false}
+        gmId="g"
+        coGmIds={new Set()}
+        use24h={false}
+        minPlayersNeeded={3}
+        onLockIn={() => {}}
+        autoExpandDate={null}
+      />
+    </HoverSyncProvider>
+  );
+
+describe('RankedList', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders viable rows and hides below-threshold by default in availability mode', () => {
+    const items = [
+      mk({ date: '2026-05-01', meetsThreshold: true }),
+      mk({ date: '2026-05-02', meetsThreshold: false }),
+    ];
+    renderList(items);
+    expect(screen.getByTestId('ranked-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('below-threshold-list')).not.toBeInTheDocument();
+    expect(screen.getByText(/Fri, May 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sat, May 2/)).not.toBeInTheDocument();
+  });
+
+  it('switching to chronological mode shows all rows in date order with no below-threshold section', async () => {
+    const user = userEvent.setup();
+    const items = [
+      mk({ date: '2026-05-03', availableCount: 4, meetsThreshold: true }),
+      mk({ date: '2026-05-01', availableCount: 1, meetsThreshold: false }),
+      mk({ date: '2026-05-02', availableCount: 5, meetsThreshold: true }),
+    ];
+    renderList(items);
+    await user.click(screen.getByTestId('sort-by-date'));
+
+    const rows = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row');
+    expect(rows.map((r) => r.getAttribute('data-date'))).toEqual([
+      '2026-05-01',
+      '2026-05-02',
+      '2026-05-03',
+    ]);
+    expect(screen.queryByTestId('below-threshold-list')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Below threshold/i })).not.toBeInTheDocument();
+  });
+
+  it('chronological mode preserves the below-threshold visual marker in-place', async () => {
+    const user = userEvent.setup();
+    const items = [
+      mk({ date: '2026-05-01', meetsThreshold: false }),
+      mk({ date: '2026-05-02', meetsThreshold: true }),
+    ];
+    renderList(items);
+    await user.click(screen.getByTestId('sort-by-date'));
+
+    const firstRow = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row')[0];
+    expect(firstRow).toHaveAttribute('data-date', '2026-05-01');
+    expect(within(firstRow).getByText(/Below threshold/i)).toBeInTheDocument();
+  });
+
+  it('persists the selected sort mode in localStorage', async () => {
+    const user = userEvent.setup();
+    renderList([mk({ date: '2026-05-01' })]);
+    await user.click(screen.getByTestId('sort-by-date'));
+    expect(window.localStorage.getItem('gns:schedule-sort')).toBe(
+      JSON.stringify('chronological')
+    );
+  });
+
+  it('hydrates from localStorage on mount', () => {
+    window.localStorage.setItem('gns:schedule-sort', JSON.stringify('chronological'));
+    const items = [
+      mk({ date: '2026-05-02', meetsThreshold: true }),
+      mk({ date: '2026-05-01', meetsThreshold: false }),
+    ];
+    renderList(items);
+    const rows = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row');
+    expect(rows.map((r) => r.getAttribute('data-date'))).toEqual([
+      '2026-05-01',
+      '2026-05-02',
+    ]);
+  });
+
+  it('does not render the toggle when there are no suggestions', () => {
+    renderList([]);
+    expect(screen.queryByTestId('suggestions-sort-toggle')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 4.2: Install the `user-event` testing dependency**
+
+`@testing-library/user-event` is not yet in `package.json` (only `@testing-library/react` is). Install it:
+
+```bash
+npm install --save-dev @testing-library/user-event
+```
+
+- [ ] **Step 4.3: Run the tests to verify they pass**
+
+Run: `npm run test:run -- src/components/games/schedule/RankedList.test.tsx`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/components/games/schedule/RankedList.test.tsx package.json package-lock.json
+git commit -m "test: cover chronological sort mode for RankedList"
+```
+
+---
+
+## Task 5: E2E test
+
+**Files:**
+- Create: `e2e/tests/scheduling/suggestions-sort-toggle.spec.ts`
+
+- [ ] **Step 5.1: Write the e2e test**
+
+Create `e2e/tests/scheduling/suggestions-sort-toggle.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  setAvailability,
+  getPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Suggested dates sort toggle', () => {
+  test('toggling to Date reorders chronologically and persists across reload', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sort-toggle-${Date.now()}@e2e.local`,
+      name: 'Sort Toggle GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Sort Toggle Campaign',
+      play_days: [5, 6],
+    });
+
+    // Mark the GM available on a few play dates so we get multiple suggestions.
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(
+      gm.id,
+      game.id,
+      playDates.slice(0, 4).map((date) => ({ date, is_available: true }))
+    );
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /schedule/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /schedule/i }).click();
+
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.locator('[data-testid="ranked-list"]')).toBeVisible();
+
+    // Toggle should be visible and default to availability.
+    const toggle = page.locator('[data-testid="suggestions-sort-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(page.locator('[data-testid="sort-by-availability"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Switch to Date sort.
+    await page.locator('[data-testid="sort-by-date"]').click();
+    await expect(page.locator('[data-testid="sort-by-date"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Rows should be in ascending date order.
+    const dates = await page.locator('[data-testid="ranked-row"]').evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-date'))
+    );
+    const sorted = [...dates].sort();
+    expect(dates).toEqual(sorted);
+
+    // Reload — selection persists.
+    await page.reload();
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="ranked-list"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.locator('[data-testid="sort-by-date"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Switching back to Availability works.
+    await page.locator('[data-testid="sort-by-availability"]').click();
+    await expect(page.locator('[data-testid="sort-by-availability"]')).toHaveAttribute('aria-checked', 'true');
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the e2e test**
+
+Run: `npx playwright test e2e/tests/scheduling/suggestions-sort-toggle.spec.ts --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add e2e/tests/scheduling/suggestions-sort-toggle.spec.ts
+git commit -m "test(e2e): sort toggle reorders suggestions and persists"
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** (no source changes)
+
+- [ ] **Step 6.1: Manual UI check at desktop + mobile**
+
+Per CLAUDE.md, validate UI locally:
+
+```bash
+npm run db:start
+npm run dev:local
+```
+
+Open http://localhost:3000/dev-login, log in as "Dev GM", create or open a game with a play-day schedule, mark some availability, then visit the Schedule tab. Verify at desktop and at a mobile viewport (e.g., Chrome devtools iPhone 12) that:
+
+- The "Availability | Date" segmented control sits inline with "Suggested dates" and wraps cleanly on narrow screens.
+- Clicking "Date" reorders the list chronologically, hides rank circles, removes the "Below threshold · N" collapsible.
+- Below-threshold dates appear in-place with the "Below threshold" warning eyebrow.
+- A page reload preserves the chosen mode.
+
+- [ ] **Step 6.2: Run lint and build**
+
+Per the project memory rule:
+
+Run: `npm run lint`
+Expected: no errors.
+
+Run: `npm run build`
+Expected: success.
+
+- [ ] **Step 6.3: Run the full unit test suite**
+
+Run: `npm run test:run`
+Expected: all pass.
+
+- [ ] **Step 6.4: Final commit (only if any cleanup was needed)**
+
+If steps 6.1–6.3 surfaced no issues, no final commit is needed. If something was tweaked:
+
+```bash
+git add -A
+git commit -m "chore: address lint/build/test fallout from sort toggle"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Hook (Task 1), `showRank` prop (Task 2), `RankedList` toggle + branched render (Task 3), unit tests including the persistence cases the spec called out (Task 4), the e2e happy-path described in the spec (Task 5), and CLAUDE.md's lint/build/manual-mobile requirements (Task 6). All design-doc bullets accounted for.
+- **Type/name consistency:** `SortMode` and `gns:schedule-sort` are defined once in Task 3 and reused in Tasks 4 and 5. `showRank` is added in Task 2 with default `true` and explicitly passed `false` in chronological mode in Task 3.
+- **Edge cases from the design:** Invalid storage value → hook's `isValid` rejects (Task 1, test #3 + Task 3 validator). `localStorage` blocked / SSR → hook swallows and stays on default (Task 1, test #5). Empty suggestions → early return predates the toggle (Task 3 step 3.5; Task 4 test #6). `autoExpandDate` in chronological mode → effect now gated on `sortMode === 'availability'` (Task 3 step 3.3).
+- **Risk from spec:** The "hide vs. placeholder rank slot" question is resolved with grid-template-columns change (Task 2 step 2.2) — content shifts left when rank hidden, no invisible placeholder.

--- a/e2e/tests/scheduling/suggestions-sort-toggle.spec.ts
+++ b/e2e/tests/scheduling/suggestions-sort-toggle.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  setAvailability,
+  getPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Suggested dates sort toggle', () => {
+  test('toggling to Date reorders chronologically and persists across reload', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-sort-toggle-${Date.now()}@e2e.local`,
+      name: 'Sort Toggle GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Sort Toggle Campaign',
+      play_days: [5, 6],
+    });
+
+    // Mark the GM available on a few play dates so we get multiple suggestions.
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(
+      gm.id,
+      game.id,
+      playDates.slice(0, 4).map((date) => ({ date, is_available: true }))
+    );
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /schedule/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /schedule/i }).click();
+
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.locator('[data-testid="ranked-list"]')).toBeVisible();
+
+    // Toggle should be visible and default to availability.
+    const toggle = page.locator('[data-testid="suggestions-sort-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(page.locator('[data-testid="sort-by-availability"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Switch to Date sort.
+    await page.locator('[data-testid="sort-by-date"]').click();
+    await expect(page.locator('[data-testid="sort-by-date"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Rows should be in ascending date order.
+    const dates = await page.locator('[data-testid="ranked-row"]').evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-date'))
+    );
+    const sorted = [...dates].sort();
+    expect(dates).toEqual(sorted);
+
+    // Reload — selection persists.
+    await page.reload();
+    await page.getByRole('button', { name: /schedule/i }).click();
+    await expect(page.locator('[data-testid="ranked-list"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.locator('[data-testid="sort-by-date"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Switching back to Availability works.
+    await page.locator('[data-testid="sort-by-availability"]').click();
+    await expect(page.locator('[data-testid="sort-by-availability"]')).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/e2e/tests/scheduling/suggestions-sort-toggle.spec.ts
+++ b/e2e/tests/scheduling/suggestions-sort-toggle.spec.ts
@@ -4,6 +4,7 @@ import {
   createTestGame,
   setAvailability,
   getPlayDates,
+  addPlayerToGame,
 } from '../../helpers/seed';
 import { TEST_TIMEOUTS } from '../../constants';
 
@@ -15,18 +16,35 @@ test.describe('Suggested dates sort toggle', () => {
       is_gm: true,
     });
 
+    const player = await createTestUser(request, {
+      email: `player-sort-toggle-${Date.now()}@e2e.local`,
+      name: 'Sort Toggle Player',
+      is_gm: false,
+    });
+
     const game = await createTestGame({
       gm_id: gm.id,
       name: 'Sort Toggle Campaign',
       play_days: [5, 6],
     });
 
-    // Mark the GM available on a few play dates so we get multiple suggestions.
+    await addPlayerToGame(game.id, player.id);
+
+    // Mark the GM available on all 4 play dates.
+    // Mark the second player available on only the LATER half.
+    // This makes availability-mode ordering differ from chronological ordering:
+    //   - Availability order: [date2, date3, date0, date1] (2 votes before 1 vote)
+    //   - Chronological order: [date0, date1, date2, date3] (ascending)
     const playDates = getPlayDates([5, 6], 4);
     await setAvailability(
       gm.id,
       game.id,
       playDates.slice(0, 4).map((date) => ({ date, is_available: true }))
+    );
+    await setAvailability(
+      player.id,
+      game.id,
+      playDates.slice(2, 4).map((date) => ({ date, is_available: true }))
     );
 
     await loginTestUser(page, {
@@ -46,6 +64,11 @@ test.describe('Suggested dates sort toggle', () => {
     });
     await expect(page.locator('[data-testid="ranked-list"]')).toBeVisible();
 
+    // Capture availability-mode order before toggling — must differ from chronological.
+    const availabilityOrder = await page.locator('[data-testid="ranked-row"]').evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-date'))
+    );
+
     // Toggle should be visible and default to availability.
     const toggle = page.locator('[data-testid="suggestions-sort-toggle"]');
     await expect(toggle).toBeVisible();
@@ -62,6 +85,10 @@ test.describe('Suggested dates sort toggle', () => {
     const sorted = [...dates].sort();
     expect(dates).toEqual(sorted);
 
+    // Sanity: chronological order differs from availability order. If these
+    // were equal, the toggle could be silently broken and other assertions would still pass.
+    expect(dates).not.toEqual(availabilityOrder);
+
     // Reload — selection persists.
     await page.reload();
     await page.getByRole('button', { name: /schedule/i }).click();
@@ -73,5 +100,11 @@ test.describe('Suggested dates sort toggle', () => {
     // Switching back to Availability works.
     await page.locator('[data-testid="sort-by-availability"]').click();
     await expect(page.locator('[data-testid="sort-by-availability"]')).toHaveAttribute('aria-checked', 'true');
+
+    // Confirm rows reverted to availability ordering.
+    const revertedOrder = await page.locator('[data-testid="ranked-row"]').evaluateAll((nodes) =>
+      nodes.map((n) => n.getAttribute('data-date'))
+    );
+    expect(revertedOrder).toEqual(availabilityOrder);
   });
 });

--- a/e2e/tests/settings/theme.spec.ts
+++ b/e2e/tests/settings/theme.spec.ts
@@ -179,6 +179,37 @@ test.describe('Theme Switching', () => {
     await expect(systemButton).toBeVisible();
   });
 
+  test('hydrates a legacy bare-string color-theme value (retrofit safety)', async ({ page }) => {
+    // Pre-seed localStorage in the pre-retrofit format: a bare string, not
+    // JSON-quoted. This is what the old ThemeContext wrote before the hook
+    // refactor. The new useLocalStoragePref hook must keep working for users
+    // who upgrade the deployed code with this value already in their browser.
+    await page.addInitScript(() => {
+      localStorage.setItem('color-theme', 'forest');
+    });
+
+    await loginTestUser(page, {
+      email: `theme-legacy-${Date.now()}@e2e.local`,
+      name: 'Theme Legacy User',
+      is_gm: false,
+    });
+
+    await page.goto('/settings');
+
+    // The inline FOUC script in app/layout.tsx reads the raw value on first
+    // paint, and the React-side hook hydrates the same value on mount. Both
+    // paths must agree on `data-theme="forest"`.
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'forest');
+
+    // Theme survives a full navigation away and back — the hook re-reads the
+    // (still-bare) value on the next mount.
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: /your games/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'forest');
+  });
+
   test('theme changes apply across pages', async ({ page }) => {
     await loginTestUser(page, {
       email: `theme-cross-${Date.now()}@e2e.local`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3266,6 +3267,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/components/games/schedule/RankedList.test.tsx
+++ b/src/components/games/schedule/RankedList.test.tsx
@@ -119,6 +119,14 @@ describe('RankedList', () => {
     expect(screen.queryByTestId('suggestions-sort-toggle')).not.toBeInTheDocument();
   });
 
+  it('exposes "Sort by" as the radiogroup accessible name', () => {
+    renderList([mk({ date: '2026-05-01' })]);
+    // The visible "Sort by" label is wired to the radiogroup via aria-labelledby,
+    // so Testing Library's accessible-name lookup should find it.
+    expect(screen.getByRole('radiogroup', { name: 'Sort by' })).toBeInTheDocument();
+    expect(screen.getByText('Sort by')).toBeInTheDocument();
+  });
+
   it('keeps the below-threshold section open on initial mount when autoExpandDate matches', () => {
     // Regression: the sort-mode reset effect must skip the initial render. If
     // it doesn't, the auto-expand effect that opens the below-threshold section

--- a/src/components/games/schedule/RankedList.test.tsx
+++ b/src/components/games/schedule/RankedList.test.tsx
@@ -23,7 +23,10 @@ const mk = (overrides: Partial<DateSuggestion>): DateSuggestion => ({
   ...overrides,
 });
 
-const renderList = (suggestions: DateSuggestion[]) =>
+const renderList = (
+  suggestions: DateSuggestion[],
+  opts: { autoExpandDate?: string | null } = {}
+) =>
   render(
     <HoverSyncProvider>
       <RankedList
@@ -34,7 +37,7 @@ const renderList = (suggestions: DateSuggestion[]) =>
         use24h={false}
         minPlayersNeeded={3}
         onLockIn={() => {}}
-        autoExpandDate={null}
+        autoExpandDate={opts.autoExpandDate ?? null}
       />
     </HoverSyncProvider>
   );
@@ -114,5 +117,17 @@ describe('RankedList', () => {
   it('does not render the toggle when there are no suggestions', () => {
     renderList([]);
     expect(screen.queryByTestId('suggestions-sort-toggle')).not.toBeInTheDocument();
+  });
+
+  it('keeps the below-threshold section open on initial mount when autoExpandDate matches', () => {
+    // Regression: the sort-mode reset effect must skip the initial render. If
+    // it doesn't, the auto-expand effect that opens the below-threshold section
+    // for autoExpandDate gets immediately undone in the same commit.
+    const items = [
+      mk({ date: '2026-05-01', meetsThreshold: true }),
+      mk({ date: '2026-05-02', meetsThreshold: false }),
+    ];
+    renderList(items, { autoExpandDate: '2026-05-02' });
+    expect(screen.getByTestId('below-threshold-list')).toBeInTheDocument();
   });
 });

--- a/src/components/games/schedule/RankedList.test.tsx
+++ b/src/components/games/schedule/RankedList.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { RankedList } from './RankedList';
 import { HoverSyncProvider } from './HoverSyncContext';
 import type { DateSuggestion } from '@/types';
@@ -22,31 +23,98 @@ const mk = (overrides: Partial<DateSuggestion>): DateSuggestion => ({
   ...overrides,
 });
 
+const renderList = (suggestions: DateSuggestion[]) =>
+  render(
+    <HoverSyncProvider>
+      <RankedList
+        suggestions={suggestions}
+        isGm={false}
+        gmId="g"
+        coGmIds={new Set()}
+        use24h={false}
+        minPlayersNeeded={3}
+        onLockIn={() => {}}
+        autoExpandDate={null}
+      />
+    </HoverSyncProvider>
+  );
+
 describe('RankedList', () => {
-  it('renders viable rows and hides below-threshold by default', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders viable rows and hides below-threshold by default in availability mode', () => {
     const items = [
       mk({ date: '2026-05-01', meetsThreshold: true }),
       mk({ date: '2026-05-02', meetsThreshold: false }),
     ];
-    render(
-      <HoverSyncProvider>
-        <RankedList
-          suggestions={items}
-          isGm={false}
-          gmId="g"
-          coGmIds={new Set()}
-          use24h={false}
-          minPlayersNeeded={3}
-          onLockIn={() => {}}
-          autoExpandDate={null}
-        />
-      </HoverSyncProvider>
-    );
+    renderList(items);
     expect(screen.getByTestId('ranked-list')).toBeInTheDocument();
     expect(screen.queryByTestId('below-threshold-list')).not.toBeInTheDocument();
-    // Viable row renders with its formatted date
     expect(screen.getByText(/Fri, May 1/)).toBeInTheDocument();
-    // Below-threshold row is not in the DOM (list collapsed)
     expect(screen.queryByText(/Sat, May 2/)).not.toBeInTheDocument();
+  });
+
+  it('switching to chronological mode shows all rows in date order with no below-threshold section', async () => {
+    const user = userEvent.setup();
+    const items = [
+      mk({ date: '2026-05-03', availableCount: 4, meetsThreshold: true }),
+      mk({ date: '2026-05-01', availableCount: 1, meetsThreshold: false }),
+      mk({ date: '2026-05-02', availableCount: 5, meetsThreshold: true }),
+    ];
+    renderList(items);
+    await user.click(screen.getByTestId('sort-by-date'));
+
+    const rows = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row');
+    expect(rows.map((r) => r.getAttribute('data-date'))).toEqual([
+      '2026-05-01',
+      '2026-05-02',
+      '2026-05-03',
+    ]);
+    expect(screen.queryByTestId('below-threshold-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('below-threshold-toggle')).not.toBeInTheDocument();
+  });
+
+  it('chronological mode preserves the below-threshold visual marker in-place', async () => {
+    const user = userEvent.setup();
+    const items = [
+      mk({ date: '2026-05-01', meetsThreshold: false }),
+      mk({ date: '2026-05-02', meetsThreshold: true }),
+    ];
+    renderList(items);
+    await user.click(screen.getByTestId('sort-by-date'));
+
+    const firstRow = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row')[0];
+    expect(firstRow).toHaveAttribute('data-date', '2026-05-01');
+    expect(within(firstRow).getByText(/Below threshold/i)).toBeInTheDocument();
+  });
+
+  it('persists the selected sort mode in localStorage', async () => {
+    const user = userEvent.setup();
+    renderList([mk({ date: '2026-05-01' })]);
+    await user.click(screen.getByTestId('sort-by-date'));
+    expect(window.localStorage.getItem('gns:schedule-sort')).toBe(
+      JSON.stringify('chronological')
+    );
+  });
+
+  it('hydrates from localStorage on mount', () => {
+    window.localStorage.setItem('gns:schedule-sort', JSON.stringify('chronological'));
+    const items = [
+      mk({ date: '2026-05-02', meetsThreshold: true }),
+      mk({ date: '2026-05-01', meetsThreshold: false }),
+    ];
+    renderList(items);
+    const rows = within(screen.getByTestId('ranked-list')).getAllByTestId('ranked-row');
+    expect(rows.map((r) => r.getAttribute('data-date'))).toEqual([
+      '2026-05-01',
+      '2026-05-02',
+    ]);
+  });
+
+  it('does not render the toggle when there are no suggestions', () => {
+    renderList([]);
+    expect(screen.queryByTestId('suggestions-sort-toggle')).not.toBeInTheDocument();
   });
 });

--- a/src/components/games/schedule/RankedList.test.tsx
+++ b/src/components/games/schedule/RankedList.test.tsx
@@ -94,13 +94,11 @@ describe('RankedList', () => {
     const user = userEvent.setup();
     renderList([mk({ date: '2026-05-01' })]);
     await user.click(screen.getByTestId('sort-by-date'));
-    expect(window.localStorage.getItem('gns:schedule-sort')).toBe(
-      JSON.stringify('chronological')
-    );
+    expect(window.localStorage.getItem('gns:schedule-sort')).toBe('chronological');
   });
 
   it('hydrates from localStorage on mount', () => {
-    window.localStorage.setItem('gns:schedule-sort', JSON.stringify('chronological'));
+    window.localStorage.setItem('gns:schedule-sort', 'chronological');
     const items = [
       mk({ date: '2026-05-02', meetsThreshold: true }),
       mk({ date: '2026-05-01', meetsThreshold: false }),

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -55,6 +55,12 @@ export function RankedList({
     return { viable, belowThreshold, chronological: [] as typeof suggestions };
   }, [suggestions, sortMode]);
 
+  // Two intentionally-separate effects on `showBelow`:
+  // (1) auto-expand the below-threshold section when a session was just confirmed
+  //     for a below-threshold date (preserves any prior manual "Show" state).
+  // (2) reset to collapsed whenever the user switches sort modes, so chronological
+  //     mode's lack of partition doesn't leak a stale "expanded" state back into
+  //     availability mode on round-trip.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (
@@ -128,6 +134,8 @@ export function RankedList({
           {chronological.map((s) => (
             <RankedRow
               key={s.date}
+              // Sentinel: showRank={false} below suppresses the rank slot entirely,
+              // so this value is never rendered or used.
               rank={0}
               suggestion={s}
               isGm={isGm}

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { DateSuggestion } from '@/types';
 import { EyebrowLabel, EmptyState } from '@/components/ui';
 import { useLocalStoragePref } from '@/hooks/useLocalStoragePref';
@@ -58,9 +58,11 @@ export function RankedList({
   // Two intentionally-separate effects on `showBelow`:
   // (1) auto-expand the below-threshold section when a session was just confirmed
   //     for a below-threshold date (preserves any prior manual "Show" state).
-  // (2) reset to collapsed whenever the user switches sort modes, so chronological
+  // (2) reset to collapsed on a *subsequent* sort-mode change, so chronological
   //     mode's lack of partition doesn't leak a stale "expanded" state back into
-  //     availability mode on round-trip.
+  //     availability mode on round-trip. Must skip the initial mount: otherwise
+  //     it would immediately undo any auto-expand from effect (1) fired in the
+  //     same commit.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (
@@ -73,8 +75,13 @@ export function RankedList({
   }, [autoExpandDate, belowThreshold, sortMode]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
+  const sortModeMountedRef = useRef(false);
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    if (!sortModeMountedRef.current) {
+      sortModeMountedRef.current = true;
+      return;
+    }
     setShowBelow(false);
   }, [sortMode]);
   /* eslint-enable react-hooks/set-state-in-effect */

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -174,6 +174,7 @@ export function RankedList({
                 onClick={() => setShowBelow((v) => !v)}
                 className="flex w-full items-center justify-between py-2"
                 title={showBelow ? "Hide dates that don't meet the minimum player threshold" : "Show dates that don't meet the minimum player threshold"}
+                data-testid="below-threshold-toggle"
               >
                 <EyebrowLabel variant="muted">Below threshold · {belowThreshold.length}</EyebrowLabel>
                 <span className="font-mono text-[11px] text-muted-foreground">{showBelow ? 'Hide' : 'Show'}</span>

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { DateSuggestion } from '@/types';
 import { EyebrowLabel, EmptyState } from '@/components/ui';
 import { useLocalStoragePref } from '@/hooks/useLocalStoragePref';
@@ -42,6 +42,7 @@ export function RankedList({
     'availability',
     isSortMode
   );
+  const sortLabelId = useId();
 
   const { viable, belowThreshold, chronological } = useMemo(() => {
     if (sortMode === 'chronological') {
@@ -99,12 +100,19 @@ export function RankedList({
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <EyebrowLabel className="block">Suggested dates</EyebrowLabel>
-        <div
-          role="radiogroup"
-          aria-label="Sort suggested dates"
-          className="inline-flex rounded-md border border-border bg-card p-0.5 text-[11px] font-mono"
-          data-testid="suggestions-sort-toggle"
-        >
+        <div className="flex items-center gap-2">
+          <span
+            id={sortLabelId}
+            className="font-mono text-[11px] text-muted-foreground"
+          >
+            Sort by
+          </span>
+          <div
+            role="radiogroup"
+            aria-labelledby={sortLabelId}
+            className="inline-flex rounded-md border border-border bg-card p-0.5 text-[11px] font-mono"
+            data-testid="suggestions-sort-toggle"
+          >
           <button
             type="button"
             role="radio"
@@ -133,6 +141,7 @@ export function RankedList({
           >
             Date
           </button>
+          </div>
         </div>
       </div>
 

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -3,8 +3,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { DateSuggestion } from '@/types';
 import { EyebrowLabel, EmptyState } from '@/components/ui';
+import { useLocalStoragePref } from '@/hooks/useLocalStoragePref';
 import { partitionByThreshold } from '@/lib/scheduleView';
+import { sortSuggestionsChronologically } from '@/lib/suggestions';
 import { RankedRow } from './RankedRow';
+
+type SortMode = 'availability' | 'chronological';
+const SORT_STORAGE_KEY = 'gns:schedule-sort';
+const isSortMode = (v: unknown): v is SortMode =>
+  v === 'availability' || v === 'chronological';
 
 interface RankedListProps {
   suggestions: DateSuggestion[];
@@ -30,17 +37,34 @@ export function RankedList({
   autoExpandDate,
 }: RankedListProps) {
   const [showBelow, setShowBelow] = useState(false);
-  const { viable, belowThreshold } = useMemo(
-    () => partitionByThreshold(suggestions),
-    [suggestions]
+  const [sortMode, setSortMode] = useLocalStoragePref<SortMode>(
+    SORT_STORAGE_KEY,
+    'availability',
+    isSortMode
   );
+
+  const { viable, belowThreshold, chronological } = useMemo(() => {
+    if (sortMode === 'chronological') {
+      return {
+        viable: [] as typeof suggestions,
+        belowThreshold: [] as typeof suggestions,
+        chronological: sortSuggestionsChronologically(suggestions),
+      };
+    }
+    const { viable, belowThreshold } = partitionByThreshold(suggestions);
+    return { viable, belowThreshold, chronological: [] as typeof suggestions };
+  }, [suggestions, sortMode]);
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (autoExpandDate && belowThreshold.some((s) => s.date === autoExpandDate)) {
+    if (
+      sortMode === 'availability' &&
+      autoExpandDate &&
+      belowThreshold.some((s) => s.date === autoExpandDate)
+    ) {
       setShowBelow(true);
     }
-  }, [autoExpandDate, belowThreshold]);
+  }, [autoExpandDate, belowThreshold, sortMode]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   if (suggestions.length === 0) {
@@ -54,61 +78,124 @@ export function RankedList({
 
   return (
     <div className="space-y-3">
-      <EyebrowLabel className="block">Suggested dates</EyebrowLabel>
-      <ul className="space-y-3" data-testid="ranked-list">
-        {viable.map((s, idx) => (
-          <RankedRow
-            key={s.date}
-            rank={idx + 1}
-            suggestion={s}
-            isGm={isGm}
-            gmId={gmId}
-            coGmIds={coGmIds}
-            use24h={use24h}
-            belowThreshold={false}
-            defaultExpanded={idx === 0}
-            minPlayersNeeded={minPlayersNeeded}
-            playDateNote={playDateNotes?.get(s.date) ?? null}
-            onLockIn={onLockIn}
-            autoScrollTrigger={autoExpandDate}
-          />
-        ))}
-      </ul>
-
-      {belowThreshold.length > 0 && (
-        <div className="pt-2">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <EyebrowLabel className="block">Suggested dates</EyebrowLabel>
+        <div
+          role="radiogroup"
+          aria-label="Sort suggested dates"
+          className="inline-flex rounded-md border border-border bg-card p-0.5 text-[11px] font-mono"
+          data-testid="suggestions-sort-toggle"
+        >
           <button
             type="button"
-            aria-expanded={showBelow}
-            onClick={() => setShowBelow((v) => !v)}
-            className="flex w-full items-center justify-between py-2"
-            title={showBelow ? 'Hide dates that don\'t meet the minimum player threshold' : 'Show dates that don\'t meet the minimum player threshold'}
+            role="radio"
+            aria-checked={sortMode === 'availability'}
+            onClick={() => setSortMode('availability')}
+            className={`px-2 py-1 rounded-sm ${
+              sortMode === 'availability'
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            data-testid="sort-by-availability"
           >
-            <EyebrowLabel variant="muted">Below threshold · {belowThreshold.length}</EyebrowLabel>
-            <span className="font-mono text-[11px] text-muted-foreground">{showBelow ? 'Hide' : 'Show'}</span>
+            Availability
           </button>
-          {showBelow && (
-            <ul className="mt-2 space-y-3" data-testid="below-threshold-list">
-              {belowThreshold.map((s, idx) => (
-                <RankedRow
-                  key={s.date}
-                  rank={viable.length + idx + 1}
-                  suggestion={s}
-                  isGm={isGm}
-                  gmId={gmId}
-                  coGmIds={coGmIds}
-                  use24h={use24h}
-                  belowThreshold={true}
-                  defaultExpanded={false}
-                  minPlayersNeeded={minPlayersNeeded}
-                  playDateNote={playDateNotes?.get(s.date) ?? null}
-                  onLockIn={onLockIn}
-                  autoScrollTrigger={autoExpandDate}
-                />
-              ))}
-            </ul>
-          )}
+          <button
+            type="button"
+            role="radio"
+            aria-checked={sortMode === 'chronological'}
+            onClick={() => setSortMode('chronological')}
+            className={`px-2 py-1 rounded-sm ${
+              sortMode === 'chronological'
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            data-testid="sort-by-date"
+          >
+            Date
+          </button>
         </div>
+      </div>
+
+      {sortMode === 'chronological' ? (
+        <ul className="space-y-3" data-testid="ranked-list">
+          {chronological.map((s) => (
+            <RankedRow
+              key={s.date}
+              rank={0}
+              suggestion={s}
+              isGm={isGm}
+              gmId={gmId}
+              coGmIds={coGmIds}
+              use24h={use24h}
+              belowThreshold={!s.meetsThreshold}
+              defaultExpanded={false}
+              minPlayersNeeded={minPlayersNeeded}
+              playDateNote={playDateNotes?.get(s.date) ?? null}
+              onLockIn={onLockIn}
+              autoScrollTrigger={autoExpandDate}
+              showRank={false}
+            />
+          ))}
+        </ul>
+      ) : (
+        <>
+          <ul className="space-y-3" data-testid="ranked-list">
+            {viable.map((s, idx) => (
+              <RankedRow
+                key={s.date}
+                rank={idx + 1}
+                suggestion={s}
+                isGm={isGm}
+                gmId={gmId}
+                coGmIds={coGmIds}
+                use24h={use24h}
+                belowThreshold={false}
+                defaultExpanded={idx === 0}
+                minPlayersNeeded={minPlayersNeeded}
+                playDateNote={playDateNotes?.get(s.date) ?? null}
+                onLockIn={onLockIn}
+                autoScrollTrigger={autoExpandDate}
+              />
+            ))}
+          </ul>
+
+          {belowThreshold.length > 0 && (
+            <div className="pt-2">
+              <button
+                type="button"
+                aria-expanded={showBelow}
+                onClick={() => setShowBelow((v) => !v)}
+                className="flex w-full items-center justify-between py-2"
+                title={showBelow ? "Hide dates that don't meet the minimum player threshold" : "Show dates that don't meet the minimum player threshold"}
+              >
+                <EyebrowLabel variant="muted">Below threshold · {belowThreshold.length}</EyebrowLabel>
+                <span className="font-mono text-[11px] text-muted-foreground">{showBelow ? 'Hide' : 'Show'}</span>
+              </button>
+              {showBelow && (
+                <ul className="mt-2 space-y-3" data-testid="below-threshold-list">
+                  {belowThreshold.map((s, idx) => (
+                    <RankedRow
+                      key={s.date}
+                      rank={viable.length + idx + 1}
+                      suggestion={s}
+                      isGm={isGm}
+                      gmId={gmId}
+                      coGmIds={coGmIds}
+                      use24h={use24h}
+                      belowThreshold={true}
+                      defaultExpanded={false}
+                      minPlayersNeeded={minPlayersNeeded}
+                      playDateNote={playDateNotes?.get(s.date) ?? null}
+                      onLockIn={onLockIn}
+                      autoScrollTrigger={autoExpandDate}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/games/schedule/RankedList.tsx
+++ b/src/components/games/schedule/RankedList.tsx
@@ -67,6 +67,12 @@ export function RankedList({
   }, [autoExpandDate, belowThreshold, sortMode]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    setShowBelow(false);
+  }, [sortMode]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
   if (suggestions.length === 0) {
     return (
       <EmptyState

--- a/src/components/games/schedule/RankedRow.tsx
+++ b/src/components/games/schedule/RankedRow.tsx
@@ -23,6 +23,8 @@ interface RankedRowProps {
   playDateNote?: string | null;
   onLockIn: (date: string) => void;
   autoScrollTrigger?: string | null;
+  /** When false, the rank ordinal slot is hidden and no row is visually highlighted as "rank #1". */
+  showRank?: boolean;
 }
 
 export function RankedRow({
@@ -38,6 +40,7 @@ export function RankedRow({
   playDateNote,
   onLockIn,
   autoScrollTrigger,
+  showRank = true,
 }: RankedRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const rootRef = useRef<HTMLLIElement | null>(null);
@@ -57,7 +60,7 @@ export function RankedRow({
     (suggestion.availableCount / Math.max(1, suggestion.totalPlayers)) * 100
   );
   const windowLabel = formatTimeWindow(suggestion.earliestStartTime, suggestion.latestEndTime, use24h);
-  const highlighted = rank === 1 && !belowThreshold;
+  const highlighted = showRank && rank === 1 && !belowThreshold;
 
   const visibleAvatars: PlayerAvatarItem[] = [
     ...suggestion.availablePlayers.map((p) => ({ state: 'available' as const, user: p.user })),
@@ -83,9 +86,11 @@ export function RankedRow({
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((v) => !v)}
-        className="grid w-full grid-cols-[auto_1fr_auto_auto] items-center gap-3 text-left"
+        className={`grid w-full items-center gap-3 text-left ${
+          showRank ? 'grid-cols-[auto_1fr_auto_auto]' : 'grid-cols-[1fr_auto_auto]'
+        }`}
       >
-        <RankCircle rank={rank} highlighted={highlighted} />
+        {showRank && <RankCircle rank={rank} highlighted={highlighted} />}
         <div className="min-w-0">
           <p className="flex flex-wrap items-center gap-2">
             <span className="text-base font-semibold text-card-foreground">

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState, ReactNode } from 'react';
 import { useTheme as useNextTheme } from 'next-themes';
 import { DEFAULT_THEME_ID, themes, getThemeById, type Theme } from '@/lib/themes';
+import { useLocalStoragePref } from '@/hooks/useLocalStoragePref';
 
 const THEME_STORAGE_KEY = 'color-theme';
+
+const isValidThemeId = (v: unknown): v is string =>
+  typeof v === 'string' && !!getThemeById(v);
 
 interface ThemeContextValue {
   // Light/dark mode from next-themes
@@ -24,29 +28,33 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 export function ThemeContextProvider({ children }: { children: ReactNode }) {
   const { theme: mode, setTheme: setMode, resolvedTheme: resolvedMode } = useNextTheme();
-  const [colorTheme, setColorThemeState] = useState(DEFAULT_THEME_ID);
+  const [colorTheme, setColorThemeRaw] = useLocalStoragePref<string>(
+    THEME_STORAGE_KEY,
+    DEFAULT_THEME_ID,
+    isValidThemeId
+  );
   const [mounted, setMounted] = useState(false);
 
-  // Load saved theme on mount - this is a valid pattern for hydration from localStorage
+  // Mirror the current colorTheme onto the root `data-theme` attribute so CSS
+  // theme variables apply. The inline script in app/layout.tsx handles the
+  // first paint before React mounts; this effect handles every render after.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', colorTheme);
+  }, [colorTheme]);
+
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    const saved = localStorage.getItem(THEME_STORAGE_KEY);
-    if (saved && getThemeById(saved)) {
-      setColorThemeState(saved);
-      document.documentElement.setAttribute('data-theme', saved);
-    } else {
-      document.documentElement.setAttribute('data-theme', DEFAULT_THEME_ID);
-    }
     setMounted(true);
   }, []);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const setColorTheme = (themeId: string) => {
-    if (!getThemeById(themeId)) return;
-    setColorThemeState(themeId);
-    localStorage.setItem(THEME_STORAGE_KEY, themeId);
-    document.documentElement.setAttribute('data-theme', themeId);
-  };
+  const setColorTheme = useCallback(
+    (themeId: string) => {
+      if (!getThemeById(themeId)) return;
+      setColorThemeRaw(themeId);
+    },
+    [setColorThemeRaw]
+  );
 
   return (
     <ThemeContext.Provider

--- a/src/hooks/useLocalStoragePref.test.ts
+++ b/src/hooks/useLocalStoragePref.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useLocalStoragePref } from './useLocalStoragePref';
+
+const isMode = (v: unknown): v is 'a' | 'b' => v === 'a' || v === 'b';
+
+describe('useLocalStoragePref', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns the default value on first render and after hydration when storage is empty', () => {
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+  });
+
+  it('hydrates from localStorage when a valid value is stored', () => {
+    window.localStorage.setItem('k', JSON.stringify('b'));
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('b');
+  });
+
+  it('ignores invalid stored values and uses the default', () => {
+    window.localStorage.setItem('k', JSON.stringify('garbage'));
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+  });
+
+  it('persists through the setter', () => {
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    act(() => {
+      result.current[1]('b');
+    });
+    expect(result.current[0]).toBe('b');
+    expect(window.localStorage.getItem('k')).toBe(JSON.stringify('b'));
+  });
+
+  it('does not throw when localStorage access fails', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('a');
+    spy.mockRestore();
+  });
+});

--- a/src/hooks/useLocalStoragePref.test.ts
+++ b/src/hooks/useLocalStoragePref.test.ts
@@ -3,6 +3,8 @@ import { act, renderHook } from '@testing-library/react';
 import { useLocalStoragePref } from './useLocalStoragePref';
 
 const isMode = (v: unknown): v is 'a' | 'b' => v === 'a' || v === 'b';
+const isPositiveNumber = (v: unknown): v is number =>
+  typeof v === 'number' && v > 0;
 
 describe('useLocalStoragePref', () => {
   beforeEach(() => {
@@ -14,25 +16,44 @@ describe('useLocalStoragePref', () => {
     expect(result.current[0]).toBe('a');
   });
 
-  it('hydrates from localStorage when a valid value is stored', () => {
+  it('hydrates from a bare (legacy) string value', () => {
+    window.localStorage.setItem('k', 'b');
+    const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
+    expect(result.current[0]).toBe('b');
+  });
+
+  it('hydrates from a JSON-quoted string value (forward compatible)', () => {
     window.localStorage.setItem('k', JSON.stringify('b'));
     const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
     expect(result.current[0]).toBe('b');
   });
 
   it('ignores invalid stored values and uses the default', () => {
-    window.localStorage.setItem('k', JSON.stringify('garbage'));
+    window.localStorage.setItem('k', 'garbage');
     const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
     expect(result.current[0]).toBe('a');
   });
 
-  it('persists through the setter', () => {
+  it('persists strings raw (no JSON quoting)', () => {
     const { result } = renderHook(() => useLocalStoragePref('k', 'a', isMode));
     act(() => {
       result.current[1]('b');
     });
     expect(result.current[0]).toBe('b');
-    expect(window.localStorage.getItem('k')).toBe(JSON.stringify('b'));
+    expect(window.localStorage.getItem('k')).toBe('b');
+  });
+
+  it('JSON-encodes non-string values on write and decodes them on read', () => {
+    const { result } = renderHook(() => useLocalStoragePref('n', 1, isPositiveNumber));
+    act(() => {
+      result.current[1](42);
+    });
+    expect(result.current[0]).toBe(42);
+    expect(window.localStorage.getItem('n')).toBe('42');
+
+    // A fresh render reads the JSON-encoded number back.
+    const { result: next } = renderHook(() => useLocalStoragePref('n', 1, isPositiveNumber));
+    expect(next.current[0]).toBe(42);
   });
 
   it('does not throw when localStorage access fails', () => {

--- a/src/hooks/useLocalStoragePref.ts
+++ b/src/hooks/useLocalStoragePref.ts
@@ -8,6 +8,12 @@ import { useCallback, useEffect, useState } from 'react';
  * Returns `defaultValue` on first render so the server and the initial client
  * render match. After mount, hydrates from `localStorage[key]` if the stored
  * value passes `isValid`. The setter updates both state and storage.
+ *
+ * Storage format: strings are stored raw (no JSON quoting); all other values
+ * are JSON-encoded. On read, JSON.parse is attempted first and falls back to
+ * the raw string if parsing fails. This makes the hook safely retrofittable
+ * over legacy localStorage code that stored bare strings, and keeps the
+ * stored format human-readable for the common case.
  */
 export function useLocalStoragePref<T>(
   key: string,
@@ -20,12 +26,18 @@ export function useLocalStoragePref<T>(
     try {
       const raw = window.localStorage.getItem(key);
       if (raw === null) return;
-      const parsed: unknown = JSON.parse(raw);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        // Not JSON — treat as a bare string value (legacy or hook-written string).
+        parsed = raw;
+      }
       if (isValid(parsed)) {
         setValue(parsed);
       }
     } catch {
-      // Ignore: localStorage may be unavailable or contain invalid JSON.
+      // Ignore: localStorage may be unavailable.
     }
     // We intentionally read storage once on mount and don't track key changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -35,7 +47,8 @@ export function useLocalStoragePref<T>(
     (next: T) => {
       setValue(next);
       try {
-        window.localStorage.setItem(key, JSON.stringify(next));
+        const encoded = typeof next === 'string' ? next : JSON.stringify(next);
+        window.localStorage.setItem(key, encoded);
       } catch {
         // Ignore write failures (private browsing, quota, etc.).
       }

--- a/src/hooks/useLocalStoragePref.ts
+++ b/src/hooks/useLocalStoragePref.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * SSR-safe localStorage-backed React state.
+ *
+ * Returns `defaultValue` on first render so the server and the initial client
+ * render match. After mount, hydrates from `localStorage[key]` if the stored
+ * value passes `isValid`. The setter updates both state and storage.
+ */
+export function useLocalStoragePref<T>(
+  key: string,
+  defaultValue: T,
+  isValid: (v: unknown) => v is T
+): [T, (next: T) => void] {
+  const [value, setValue] = useState<T>(defaultValue);
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw === null) return;
+      const parsed: unknown = JSON.parse(raw);
+      if (isValid(parsed)) {
+        setValue(parsed);
+      }
+    } catch {
+      // Ignore: localStorage may be unavailable or contain invalid JSON.
+    }
+    // We intentionally read storage once on mount and don't track key changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const setPersisted = useCallback(
+    (next: T) => {
+      setValue(next);
+      try {
+        window.localStorage.setItem(key, JSON.stringify(next));
+      } catch {
+        // Ignore write failures (private browsing, quota, etc.).
+      }
+    },
+    [key]
+  );
+
+  return [value, setPersisted];
+}

--- a/src/hooks/useLocalStoragePref.ts
+++ b/src/hooks/useLocalStoragePref.ts
@@ -16,7 +16,6 @@ export function useLocalStoragePref<T>(
 ): [T, (next: T) => void] {
   const [value, setValue] = useState<T>(defaultValue);
 
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     try {
       const raw = window.localStorage.getItem(key);
@@ -31,7 +30,6 @@ export function useLocalStoragePref<T>(
     // We intentionally read storage once on mount and don't track key changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const setPersisted = useCallback(
     (next: T) => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// jsdom does not implement Element.prototype.scrollIntoView. Components that
+// call it (e.g., RankedRow's auto-scroll-to-expanded effect) would throw in
+// tests. Stub it as a no-op for the entire test suite.
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
 
 // Node.js 26 exposes a built-in `localStorage` that is `undefined` without
 // the --localstorage-file flag, which prevents vitest/jsdom from overriding it.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,17 @@
 import "@testing-library/jest-dom/vitest";
+
+// Node.js 26 exposes a built-in `localStorage` that is `undefined` without
+// the --localstorage-file flag, which prevents vitest/jsdom from overriding it.
+// Explicitly restore the jsdom-backed Storage objects on globalThis so tests
+// that touch window.localStorage / window.sessionStorage work correctly.
+if (typeof globalThis.jsdom !== "undefined") {
+  const win = (globalThis.jsdom as { window: Window }).window;
+  Object.defineProperty(globalThis, "localStorage", {
+    get: () => win.localStorage,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "sessionStorage", {
+    get: () => win.sessionStorage,
+    configurable: true,
+  });
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,8 +4,9 @@ import "@testing-library/jest-dom/vitest";
 // the --localstorage-file flag, which prevents vitest/jsdom from overriding it.
 // Explicitly restore the jsdom-backed Storage objects on globalThis so tests
 // that touch window.localStorage / window.sessionStorage work correctly.
-if (typeof globalThis.jsdom !== "undefined") {
-  const win = (globalThis.jsdom as { window: Window }).window;
+const maybeJsdom = (globalThis as unknown as { jsdom?: { window: Window } }).jsdom;
+if (maybeJsdom) {
+  const win = maybeJsdom.window;
   Object.defineProperty(globalThis, "localStorage", {
     get: () => win.localStorage,
     configurable: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost",
+      },
+    },
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {


### PR DESCRIPTION
## Summary

- Adds a **Sort by** toggle on the Schedule tab's Suggested dates section. Users can switch between **Availability** (the existing ranked-by-score view, still the default) and **Date** (chronological).
- Selection persists per-user via `localStorage` under key `gns:schedule-sort`.
- Introduces a reusable `useLocalStoragePref<T>` hook and uses the opportunity to retrofit `ThemeContext` onto it.

## Implementation notes

- **New hook** (`src/hooks/useLocalStoragePref.ts`): SSR-safe React state backed by `localStorage`. Returns `defaultValue` on first render, hydrates from storage in a mount effect, and persists through the setter. Stores strings raw and JSON-encodes other types; reads tolerate either format. This keeps the hook safely retrofittable over legacy localStorage code (e.g., the existing FOUC script for theme).
- **`RankedList` branching**: a single `useMemo` returns either the partitioned (viable / below-threshold) shape or a flat chronological list, based on `sortMode`. In chronological mode `RankedRow` receives `showRank={false}`, which suppresses the rank ordinal and shifts the grid from 4 columns to 3. Below-threshold rows keep their warning eyebrow in-place rather than being collapsed into a separate section.
- **`ThemeContext` retrofit**: replaces hand-rolled `useState` + read-on-mount `useEffect` + manual `setItem` with one `useLocalStoragePref<string>` call. DOM `data-theme` side-effect lives in its own focused effect. The inline FOUC script in `app/layout.tsx` is unchanged — strings stay raw in storage.
- **A11y**: the segmented control uses `role="radiogroup"` + two `role="radio"` buttons with `aria-checked`. The visible "Sort by" label is linked to the radiogroup via `aria-labelledby` (using `useId()` for collision-free IDs), so sighted and screen-reader users get the same name.
- **Test environment fixes** (Node 26 / jsdom): added a small polyfill in `src/test/setup.ts` to restore jsdom's `localStorage` on Node 26, plus a `scrollIntoView` stub so components with auto-scroll effects don't blow up in tests.

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npm run test:run` — 421/421 unit tests pass
- [ ] `npm run build` — production build succeeds
- [ ] `npx playwright test e2e/tests/scheduling/suggestions-sort-toggle.spec.ts --project=chromium` — passes
- [ ] `npx playwright test e2e/tests/settings/theme.spec.ts --project=chromium` — passes (incl. new legacy-hydration test)
- [ ] **Manual (desktop)**: `npm run dev:local`, log in via `/dev-login` as "Dev GM", open a game with a few play days and some availability marked. Schedule tab should show the toggle inline with "SUGGESTED DATES". Click **Date** → rows reorder chronologically, rank circles disappear, below-threshold rows stay in place with the warning eyebrow. Reload — selection persists.
- [ ] **Manual (mobile viewport)**: same flow at iPhone-12 width. The header should wrap to two rows on narrow screens (section eyebrow on top, "Sort by" + toggle below).
- [ ] **Manual (theme picker)**: visit `/settings`, switch color themes — verify the theme still applies and persists. (Tests the ThemeContext retrofit.)