### PR TITLE
Cross-game upcoming sessions panel on the dashboard

### DIFF
--- a/e2e/tests/dashboard/upcoming-sessions.spec.ts
+++ b/e2e/tests/dashboard/upcoming-sessions.spec.ts
@@ -5,7 +5,6 @@ import {
   addPlayerToGame,
   createTestSession,
   getPlayDates,
-  getPastPlayDates,
 } from '../../helpers/seed';
 import { TEST_TIMEOUTS } from '../../constants';
 
@@ -55,9 +54,9 @@ test.describe('Dashboard upcoming sessions', () => {
         confirmed_by: user.id,
       });
     }
-    // One past session in game A — must NOT appear.
-    const past = getPastPlayDates([0, 1, 2, 3, 4, 5, 6], 1)[0];
-    await createTestSession({ game_id: gameA.id, date: past, confirmed_by: user.id });
+    // One clearly-past session in game A — must NOT appear. Use 5 days ago so it
+    // stays below the one-day fetch buffer regardless of the runner's timezone.
+    await createTestSession({ game_id: gameA.id, date: localDateString(-5), confirmed_by: user.id });
 
     await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
     await page.goto('/dashboard');
@@ -116,14 +115,13 @@ test.describe('Dashboard upcoming sessions', () => {
       name: 'No Upcoming User',
       is_gm: true,
     });
-    // A game with only a past session.
+    // A game with only a clearly-past session (5 days ago).
     const game = await createTestGame({
       gm_id: user.id,
       name: 'Quiet Campaign',
       play_days: [0, 1, 2, 3, 4, 5, 6],
     });
-    const past = getPastPlayDates([0, 1, 2, 3, 4, 5, 6], 1)[0];
-    await createTestSession({ game_id: game.id, date: past, confirmed_by: user.id });
+    await createTestSession({ game_id: game.id, date: localDateString(-5), confirmed_by: user.id });
 
     await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
     await page.goto('/dashboard');

--- a/e2e/tests/dashboard/upcoming-sessions.spec.ts
+++ b/e2e/tests/dashboard/upcoming-sessions.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  addPlayerToGame,
+  createTestSession,
+  getPlayDates,
+  getPastPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+function localDateString(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+test.describe('Dashboard upcoming sessions', () => {
+  test('lists future sessions across games, capped with show more, excluding past', async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request, {
+      email: `upcoming-${Date.now()}@e2e.local`,
+      name: 'Upcoming User',
+      is_gm: true,
+    });
+
+    const gameA = await createTestGame({
+      gm_id: user.id,
+      name: 'Alpha Quest',
+      play_days: [0, 1, 2, 3, 4, 5, 6],
+    });
+    const otherGm = await createTestUser(request, {
+      email: `gmB-${Date.now()}@e2e.local`,
+      name: 'GM B',
+      is_gm: true,
+    });
+    const gameB = await createTestGame({
+      gm_id: otherGm.id,
+      name: 'Beta Saga',
+      play_days: [0, 1, 2, 3, 4, 5, 6],
+    });
+    await addPlayerToGame(gameB.id, user.id);
+
+    // 7 future sessions split across the two games (every day for the next week).
+    const future = getPlayDates([0, 1, 2, 3, 4, 5, 6], 2).slice(0, 7);
+    for (let i = 0; i < future.length; i++) {
+      await createTestSession({
+        game_id: i % 2 === 0 ? gameA.id : gameB.id,
+        date: future[i],
+        confirmed_by: user.id,
+      });
+    }
+    // One past session in game A — must NOT appear.
+    const past = getPastPlayDates([0, 1, 2, 3, 4, 5, 6], 1)[0];
+    await createTestSession({ game_id: gameA.id, date: past, confirmed_by: user.id });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('heading', { name: /your games/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    const panel = page.getByTestId('upcoming-sessions-panel');
+    await expect(panel.getByRole('heading', { name: /upcoming sessions/i })).toBeVisible();
+
+    // Soft cap: 5 visible initially, 7 after Show more.
+    await expect(panel.getByTestId('upcoming-session')).toHaveCount(5);
+    await panel.getByRole('button', { name: /show more/i }).click();
+    await expect(panel.getByTestId('upcoming-session')).toHaveCount(7);
+
+    // Show less collapses back to 5.
+    await panel.getByRole('button', { name: /show less/i }).click();
+    await expect(panel.getByTestId('upcoming-session')).toHaveCount(5);
+  });
+
+  test("highlights today's session and navigates to the game on click", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request, {
+      email: `today-${Date.now()}@e2e.local`,
+      name: 'Today User',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: user.id,
+      name: 'Today Campaign',
+      play_days: [0, 1, 2, 3, 4, 5, 6],
+    });
+    await createTestSession({ game_id: game.id, date: localDateString(0), confirmed_by: user.id });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto('/dashboard');
+
+    const panel = page.getByTestId('upcoming-sessions-panel');
+    await expect(panel.getByText('Today', { exact: true })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    await panel.getByTestId('upcoming-session').first().click();
+    await expect(page).toHaveURL(`/games/${game.id}`);
+  });
+
+  test('shows the empty message when there are no upcoming sessions', async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request, {
+      email: `noupcoming-${Date.now()}@e2e.local`,
+      name: 'No Upcoming User',
+      is_gm: true,
+    });
+    // A game with only a past session.
+    const game = await createTestGame({
+      gm_id: user.id,
+      name: 'Quiet Campaign',
+      play_days: [0, 1, 2, 3, 4, 5, 6],
+    });
+    const past = getPastPlayDates([0, 1, 2, 3, 4, 5, 6], 1)[0];
+    await createTestSession({ game_id: game.id, date: past, confirmed_by: user.id });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto('/dashboard');
+
+    const panel = page.getByTestId('upcoming-sessions-panel');
+    await expect(panel.getByText(/no upcoming sessions/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Test coverage output:
     "coverage/**",
+    // Nested git worktrees (e.g. Conductor workspaces) are ephemeral copies of
+    // the repo; linting them re-lints the whole project and floods output.
+    ".claude/**",
   ]),
   // Tailwind CSS linting (canonical classes, shorthands, duplicates, etc.)
   {

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -30,7 +30,7 @@ interface GameWithGMAndCount extends GameWithGM {
 
 export function DashboardContent() {
   const { profile, authStatus } = useAuth();
-  const { use24h } = useUserPreferences();
+  const { use24h, timezone: userTimezone } = useUserPreferences();
   const [games, setGames] = useState<GameWithGMAndCount[]>([]);
   const [sessionRows, setSessionRows] = useState<UpcomingSessionRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -88,8 +88,8 @@ export function DashboardContent() {
 
       const today = getTodayLocalDate();
       const gameIds = uniqueGames.map((g) => g.id);
-      const gameNames = new Map<string, string>(
-        uniqueGames.map((g) => [g.id, g.name])
+      const gameInfo = new Map<string, { name: string; timezone: string | null }>(
+        uniqueGames.map((g) => [g.id, { name: g.name, timezone: g.timezone }])
       );
       const { data: upcoming } = await fetchUpcomingSessionsForGames(
         supabase,
@@ -99,7 +99,7 @@ export function DashboardContent() {
       setSessionRows(
         buildUpcomingSessionRows(
           (upcoming ?? []) as GameSession[],
-          gameNames,
+          gameInfo,
           today
         )
       );
@@ -207,7 +207,11 @@ export function DashboardContent() {
           </div>
 
           <div className="order-first lg:order-last lg:w-80 lg:shrink-0">
-            <UpcomingSessionsPanel rows={sessionRows} use24h={use24h} />
+            <UpcomingSessionsPanel
+              rows={sessionRows}
+              use24h={use24h}
+              userTimezone={userTimezone}
+            />
           </div>
         </div>
       )}

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -18,7 +18,7 @@ import { useUserPreferences } from "@/hooks/useUserPreferences";
 import {
   buildUpcomingSessionRows,
   getTodayLocalDate,
-  toLocalDateString,
+  getUpcomingQueryFloor,
   type UpcomingSessionRow,
 } from "@/lib/upcomingSessions";
 import { WelcomeEmptyState } from "./WelcomeEmptyState";
@@ -89,11 +89,9 @@ export function DashboardContent() {
 
       const nowMs = Date.now();
       const today = getTodayLocalDate();
-      // Fetch from one day before the viewer's "today": a game in a far-eastern
-      // timezone may already be on the next date, and the timezone gap between
-      // any two zones is under 26h, so a one-day buffer can't miss an upcoming
-      // session. buildUpcomingSessionRows then filters by each game's own date.
-      const queryFloor = toLocalDateString(new Date(nowMs - 24 * 60 * 60 * 1000));
+      // Two-day buffer covers the full UTC-12..UTC+14 span; the per-game-timezone
+      // filter in buildUpcomingSessionRows then trims it precisely.
+      const queryFloor = getUpcomingQueryFloor(nowMs);
       const gameIds = uniqueGames.map((g) => g.id);
       const gameInfo = new Map<string, { name: string; timezone: string | null }>(
         uniqueGames.map((g) => [g.id, { name: g.name, timezone: g.timezone }])

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -18,6 +18,7 @@ import { useUserPreferences } from "@/hooks/useUserPreferences";
 import {
   buildUpcomingSessionRows,
   getTodayLocalDate,
+  toLocalDateString,
   type UpcomingSessionRow,
 } from "@/lib/upcomingSessions";
 import { WelcomeEmptyState } from "./WelcomeEmptyState";
@@ -86,7 +87,13 @@ export function DashboardContent() {
 
       setGames(gamesWithCounts as GameWithGMAndCount[]);
 
+      const nowMs = Date.now();
       const today = getTodayLocalDate();
+      // Fetch from one day before the viewer's "today": a game in a far-eastern
+      // timezone may already be on the next date, and the timezone gap between
+      // any two zones is under 26h, so a one-day buffer can't miss an upcoming
+      // session. buildUpcomingSessionRows then filters by each game's own date.
+      const queryFloor = toLocalDateString(new Date(nowMs - 24 * 60 * 60 * 1000));
       const gameIds = uniqueGames.map((g) => g.id);
       const gameInfo = new Map<string, { name: string; timezone: string | null }>(
         uniqueGames.map((g) => [g.id, { name: g.name, timezone: g.timezone }])
@@ -94,7 +101,7 @@ export function DashboardContent() {
       const { data: upcoming, error: sessionsError } = await fetchUpcomingSessionsForGames(
         supabase,
         gameIds,
-        today
+        queryFloor
       );
       if (sessionsError) {
         // Games already rendered above; surface the failure rather than showing
@@ -105,7 +112,8 @@ export function DashboardContent() {
         buildUpcomingSessionRows(
           (upcoming ?? []) as GameSession[],
           gameInfo,
-          today
+          today,
+          nowMs
         )
       );
 

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -91,11 +91,16 @@ export function DashboardContent() {
       const gameInfo = new Map<string, { name: string; timezone: string | null }>(
         uniqueGames.map((g) => [g.id, { name: g.name, timezone: g.timezone }])
       );
-      const { data: upcoming } = await fetchUpcomingSessionsForGames(
+      const { data: upcoming, error: sessionsError } = await fetchUpcomingSessionsForGames(
         supabase,
         gameIds,
         today
       );
+      if (sessionsError) {
+        // Games already rendered above; surface the failure rather than showing
+        // a silently-empty panel that looks like "no upcoming sessions".
+        console.error('[UpcomingSessions] failed to fetch upcoming sessions:', sessionsError);
+      }
       setSessionRows(
         buildUpcomingSessionRows(
           (upcoming ?? []) as GameSession[],

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -6,10 +6,22 @@ import Link from "next/link";
 import { Users, Calendar } from "lucide-react";
 import { Button, LoadingSpinner } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
-import { GameWithGM } from "@/types";
+import { GameWithGM, GameSession } from "@/types";
 import { DAY_LABELS } from "@/lib/constants";
-import { fetchUserMemberships, fetchUserGmGames, fetchMembershipCount } from "@/lib/data";
+import {
+  fetchUserMemberships,
+  fetchUserGmGames,
+  fetchMembershipCount,
+  fetchUpcomingSessionsForGames,
+} from "@/lib/data";
+import { useUserPreferences } from "@/hooks/useUserPreferences";
+import {
+  buildUpcomingSessionRows,
+  getTodayLocalDate,
+  type UpcomingSessionRow,
+} from "@/lib/upcomingSessions";
 import { WelcomeEmptyState } from "./WelcomeEmptyState";
+import { UpcomingSessionsPanel } from "./UpcomingSessionsPanel";
 
 interface GameWithGMAndCount extends GameWithGM {
   member_count: number;
@@ -18,7 +30,9 @@ interface GameWithGMAndCount extends GameWithGM {
 
 export function DashboardContent() {
   const { profile, authStatus } = useAuth();
+  const { use24h } = useUserPreferences();
   const [games, setGames] = useState<GameWithGMAndCount[]>([]);
+  const [sessionRows, setSessionRows] = useState<UpcomingSessionRow[]>([]);
   const [loading, setLoading] = useState(true);
   const supabase = createClient();
 
@@ -71,6 +85,25 @@ export function DashboardContent() {
       );
 
       setGames(gamesWithCounts as GameWithGMAndCount[]);
+
+      const today = getTodayLocalDate();
+      const gameIds = uniqueGames.map((g) => g.id);
+      const gameNames = new Map<string, string>(
+        uniqueGames.map((g) => [g.id, g.name])
+      );
+      const { data: upcoming } = await fetchUpcomingSessionsForGames(
+        supabase,
+        gameIds,
+        today
+      );
+      setSessionRows(
+        buildUpcomingSessionRows(
+          (upcoming ?? []) as GameSession[],
+          gameNames,
+          today
+        )
+      );
+
       setLoading(false);
     }
 
@@ -113,8 +146,10 @@ export function DashboardContent() {
       {games.length === 0 ? (
         <WelcomeEmptyState />
       ) : (
-        <ul className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-          {games.map((game) => {
+        <div className="flex flex-col gap-8 lg:flex-row">
+          <div className="order-last lg:order-first lg:flex-1">
+            <ul className="grid gap-5 md:grid-cols-2">
+              {games.map((game) => {
             const isOwner = game.gm_id === profile?.id;
             const cadence = game.ad_hoc_only
               ? 'Ad-hoc'
@@ -166,9 +201,15 @@ export function DashboardContent() {
                   </div>
                 </Link>
               </li>
-            );
-          })}
-        </ul>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div className="order-first lg:order-last lg:w-80 lg:shrink-0">
+            <UpcomingSessionsPanel rows={sessionRows} use24h={use24h} />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/dashboard/UpcomingSessionsPanel.test.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UpcomingSessionsPanel } from './UpcomingSessionsPanel';
+import type { UpcomingSessionRow } from '@/lib/upcomingSessions';
+import type { GameSession } from '@/types';
+
+const mkRow = (overrides: Partial<UpcomingSessionRow> & { id: string }): UpcomingSessionRow => {
+  const session: GameSession = {
+    id: overrides.id,
+    game_id: overrides.gameId ?? 'g1',
+    date: '2026-06-10',
+    start_time: '19:00:00',
+    end_time: '22:00:00',
+    status: 'confirmed',
+    confirmed_by: 'u1',
+    location: null,
+    notes: null,
+    created_at: '2026-01-01T00:00:00Z',
+    // Spread last so explicitly-provided values (including null) win over defaults.
+    ...overrides.session,
+  };
+  return {
+    session,
+    gameId: overrides.gameId ?? 'g1',
+    gameName: overrides.gameName ?? 'Curse of Strahd',
+    dayHighlight: overrides.dayHighlight ?? null,
+  };
+};
+
+describe('UpcomingSessionsPanel', () => {
+  it('renders the empty message when there are no rows', () => {
+    render(<UpcomingSessionsPanel rows={[]} use24h={false} />);
+    expect(screen.getByText(/no upcoming sessions/i)).toBeInTheDocument();
+  });
+
+  it('renders game name, date/time, and a link to the game', () => {
+    render(
+      <UpcomingSessionsPanel
+        rows={[mkRow({ id: 's1', gameId: 'g42', gameName: 'Heist Crew' })]}
+        use24h={false}
+      />
+    );
+    expect(screen.getByText('Heist Crew')).toBeInTheDocument();
+    const link = screen.getByTestId('upcoming-session');
+    expect(link).toHaveAttribute('href', '/games/g42');
+    expect(within(link).getByText(/7pm/i)).toBeInTheDocument();
+  });
+
+  it('shows "time TBD" when there is no start time', () => {
+    render(
+      <UpcomingSessionsPanel
+        rows={[mkRow({ id: 's1', session: { start_time: null } as GameSession })]}
+        use24h={false}
+      />
+    );
+    expect(screen.getByText(/time TBD/i)).toBeInTheDocument();
+  });
+
+  it('only renders location and notes when present', () => {
+    const { rerender } = render(
+      <UpcomingSessionsPanel rows={[mkRow({ id: 's1' })]} use24h={false} />
+    );
+    expect(screen.queryByText(/bring dice/i)).not.toBeInTheDocument();
+    rerender(
+      <UpcomingSessionsPanel
+        rows={[mkRow({ id: 's1', session: { location: "Tom's", notes: 'bring dice' } as GameSession })]}
+        use24h={false}
+      />
+    );
+    expect(screen.getByText("Tom's")).toBeInTheDocument();
+    expect(screen.getByText('bring dice')).toBeInTheDocument();
+  });
+
+  it('renders a Today badge for today-highlighted rows', () => {
+    render(
+      <UpcomingSessionsPanel rows={[mkRow({ id: 's1', dayHighlight: 'today' })]} use24h={false} />
+    );
+    expect(screen.getByText('Today')).toBeInTheDocument();
+  });
+
+  it('soft-caps at 5 rows with a working show more / show less toggle', async () => {
+    const rows = Array.from({ length: 7 }, (_, i) =>
+      mkRow({ id: `s${i}`, session: { date: `2026-06-1${i}` } as GameSession })
+    );
+    render(<UpcomingSessionsPanel rows={rows} use24h={false} />);
+    expect(screen.getAllByTestId('upcoming-session')).toHaveLength(5);
+    await userEvent.click(screen.getByRole('button', { name: /show more/i }));
+    expect(screen.getAllByTestId('upcoming-session')).toHaveLength(7);
+    await userEvent.click(screen.getByRole('button', { name: /show less/i }));
+    expect(screen.getAllByTestId('upcoming-session')).toHaveLength(5);
+  });
+
+  it('does not render the toggle when there are 5 or fewer rows', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => mkRow({ id: `s${i}` }));
+    render(<UpcomingSessionsPanel rows={rows} use24h={false} />);
+    expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/UpcomingSessionsPanel.test.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.test.tsx
@@ -24,6 +24,7 @@ const mkRow = (overrides: Partial<UpcomingSessionRow> & { id: string }): Upcomin
     session,
     gameId: overrides.gameId ?? 'g1',
     gameName: overrides.gameName ?? 'Curse of Strahd',
+    gameTimezone: overrides.gameTimezone ?? null,
     dayHighlight: overrides.dayHighlight ?? null,
   };
 };
@@ -70,6 +71,41 @@ describe('UpcomingSessionsPanel', () => {
     );
     expect(screen.getByText("Tom's")).toBeInTheDocument();
     expect(screen.getByText('bring dice')).toBeInTheDocument();
+  });
+
+  it('shows the game timezone and a "for you" conversion when the user is in a different timezone', () => {
+    render(
+      <UpcomingSessionsPanel
+        rows={[
+          mkRow({
+            id: 's1',
+            gameTimezone: 'America/Los_Angeles',
+            session: { date: '2026-06-10', start_time: '19:00:00', end_time: '22:00:00' } as GameSession,
+          }),
+        ]}
+        use24h={false}
+        userTimezone="America/New_York"
+      />
+    );
+    const link = screen.getByTestId('upcoming-session');
+    // Game-local time labelled with the game's tz abbreviation...
+    expect(within(link).getByText(/PDT/)).toBeInTheDocument();
+    // ...plus the viewer's own time.
+    expect(within(link).getByText(/for you/i)).toBeInTheDocument();
+    expect(within(link).getByText(/EDT/)).toBeInTheDocument();
+  });
+
+  it('stays compact (no tz abbreviation) when the user shares the game timezone', () => {
+    render(
+      <UpcomingSessionsPanel
+        rows={[mkRow({ id: 's1', gameTimezone: 'America/Los_Angeles' })]}
+        use24h={false}
+        userTimezone="America/Los_Angeles"
+      />
+    );
+    const link = screen.getByTestId('upcoming-session');
+    expect(within(link).getByText(/7pm/i)).toBeInTheDocument();
+    expect(within(link).queryByText(/for you/i)).not.toBeInTheDocument();
   });
 
   it('renders a Today badge for today-highlighted rows', () => {

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -77,7 +77,7 @@ export function UpcomingSessionsPanel({
           <p className="text-sm text-muted-foreground">No upcoming sessions.</p>
         ) : (
           <>
-            <ul className="divide-y divide-border">
+            <ul className="divide-y divide-muted-foreground/20">
               {visible.map((row) => {
                 const highlighted = row.dayHighlight !== null;
                 return (

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { parseISO } from 'date-fns';
 import { CalendarClock, MapPin, StickyNote } from 'lucide-react';
 import { formatTimeShort } from '@/lib/formatting';
+import { convertTimeForDisplay } from '@/lib/timezone';
 import type { UpcomingSessionRow } from '@/lib/upcomingSessions';
 
 const SOFT_CAP = 5;
@@ -17,22 +18,53 @@ function formatSessionDate(dateStr: string): string {
   });
 }
 
+/**
+ * Build the time label for a session row, mirroring the game schedule view:
+ * a compact game-local time, labelled with the game's timezone abbreviation
+ * and a "(… for you)" conversion when the viewer is in a different timezone.
+ */
 function formatTimeRange(
+  date: string,
   start: string | null,
   end: string | null,
+  gameTimezone: string | null,
+  userTimezone: string | null,
   use24h: boolean
 ): string {
   if (!start) return 'time TBD';
-  const startLabel = formatTimeShort(start, use24h);
-  return end ? `${startLabel}–${formatTimeShort(end, use24h)}` : startLabel;
+  const base = end
+    ? `${formatTimeShort(start, use24h)}–${formatTimeShort(end, use24h)}`
+    : formatTimeShort(start, use24h);
+
+  // No game timezone recorded: nothing to convert against.
+  if (!gameTimezone) return base;
+
+  const startConv = convertTimeForDisplay(date, start, gameTimezone, userTimezone, use24h);
+  // Same (or equivalent) timezone: the compact local time is already "for you".
+  if (!startConv.isDifferentTz) return base;
+
+  const gameLabel = `${base} ${startConv.gameTzAbbrev}`;
+  const endConv = end
+    ? convertTimeForDisplay(date, end, gameTimezone, userTimezone, use24h)
+    : null;
+  const forYou =
+    endConv?.userTime != null
+      ? `${startConv.userTime} – ${endConv.userTime} ${startConv.userTzAbbrev}`
+      : `${startConv.userTime} ${startConv.userTzAbbrev}`;
+  return `${gameLabel} (${forYou} for you)`;
 }
 
 interface UpcomingSessionsPanelProps {
   rows: UpcomingSessionRow[];
   use24h: boolean;
+  userTimezone?: string | null;
 }
 
-export function UpcomingSessionsPanel({ rows, use24h }: UpcomingSessionsPanelProps) {
+export function UpcomingSessionsPanel({
+  rows,
+  use24h,
+  userTimezone = null,
+}: UpcomingSessionsPanelProps) {
   const [showAll, setShowAll] = useState(false);
   const visible = showAll ? rows : rows.slice(0, SOFT_CAP);
 
@@ -71,7 +103,14 @@ export function UpcomingSessionsPanel({ rows, use24h }: UpcomingSessionsPanelPro
                       <CalendarClock className="size-3 shrink-0" />
                       <span>
                         {formatSessionDate(row.session.date)} ·{' '}
-                        {formatTimeRange(row.session.start_time, row.session.end_time, use24h)}
+                        {formatTimeRange(
+                          row.session.date,
+                          row.session.start_time,
+                          row.session.end_time,
+                          row.gameTimezone,
+                          userTimezone,
+                          use24h
+                        )}
                       </span>
                     </div>
 

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -47,6 +47,10 @@ function formatTimeRange(
   const endConv = end
     ? convertTimeForDisplay(date, end, gameTimezone, userTimezone, use24h)
     : null;
+  // Intentional divergence from ScheduledRow (the game-page view), which only shows the
+  // "for you" conversion when both start and end times exist. Here we also show it for a
+  // start-only session, since this aggregate view is the one place a player sees the start
+  // time in their own zone. startConv.userTime is non-null whenever isDifferentTz is true.
   const forYou =
     endConv?.userTime != null
       ? `${startConv.userTime} – ${endConv.userTime} ${startConv.userTzAbbrev}`

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -85,7 +85,7 @@ export function UpcomingSessionsPanel({
                     <Link
                       href={`/games/${row.gameId}`}
                       data-testid="upcoming-session"
-                      className={`group block py-3 transition-colors first:pt-2 last:pb-0 ${
+                      className={`group block py-3.5 transition-colors ${
                         highlighted ? 'border-l-2 border-primary pl-3' : ''
                       }`}
                     >

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -70,80 +70,82 @@ export function UpcomingSessionsPanel({
 
   return (
     <aside data-testid="upcoming-sessions-panel" className="lg:sticky lg:top-20">
-      <h2 className="mb-3 text-sm font-semibold text-foreground">Upcoming Sessions</h2>
+      <div className="rounded-xl bg-muted p-4">
+        <h2 className="mb-2 text-sm font-semibold text-foreground">Upcoming Sessions</h2>
 
-      {rows.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No upcoming sessions.</p>
-      ) : (
-        <>
-          <ul className="space-y-2">
-            {visible.map((row) => {
-              const highlighted = row.dayHighlight !== null;
-              return (
-                <li key={row.session.id}>
-                  <Link
-                    href={`/games/${row.gameId}`}
-                    data-testid="upcoming-session"
-                    className={`block rounded-lg border p-3 transition-colors hover:ring-2 hover:ring-primary/30 ${
-                      highlighted ? 'border-primary/30 bg-primary/10' : 'border-border bg-card'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <span className="truncate text-sm font-medium text-card-foreground">
-                        {row.gameName}
-                      </span>
-                      {row.dayHighlight && (
-                        <span className="shrink-0 rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary">
-                          {row.dayHighlight === 'today' ? 'Today' : 'Tomorrow'}
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No upcoming sessions.</p>
+        ) : (
+          <>
+            <ul className="divide-y divide-border">
+              {visible.map((row) => {
+                const highlighted = row.dayHighlight !== null;
+                return (
+                  <li key={row.session.id}>
+                    <Link
+                      href={`/games/${row.gameId}`}
+                      data-testid="upcoming-session"
+                      className={`group block py-3 transition-colors first:pt-2 last:pb-0 ${
+                        highlighted ? 'border-l-2 border-primary pl-3' : ''
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="truncate text-sm font-medium text-foreground transition-colors group-hover:text-primary">
+                          {row.gameName}
                         </span>
-                      )}
-                    </div>
-
-                    <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <CalendarClock className="size-3 shrink-0" />
-                      <span>
-                        {formatSessionDate(row.session.date)} ·{' '}
-                        {formatTimeRange(
-                          row.session.date,
-                          row.session.start_time,
-                          row.session.end_time,
-                          row.gameTimezone,
-                          userTimezone,
-                          use24h
+                        {row.dayHighlight && (
+                          <span className="shrink-0 rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary">
+                            {row.dayHighlight === 'today' ? 'Today' : 'Tomorrow'}
+                          </span>
                         )}
-                      </span>
-                    </div>
+                      </div>
 
-                    {row.session.location && (
                       <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <MapPin className="size-3 shrink-0" />
-                        <span className="truncate">{row.session.location}</span>
+                        <CalendarClock className="size-3 shrink-0" />
+                        <span>
+                          {formatSessionDate(row.session.date)} ·{' '}
+                          {formatTimeRange(
+                            row.session.date,
+                            row.session.start_time,
+                            row.session.end_time,
+                            row.gameTimezone,
+                            userTimezone,
+                            use24h
+                          )}
+                        </span>
                       </div>
-                    )}
 
-                    {row.session.notes && (
-                      <div className="mt-1 flex items-start gap-1.5 text-xs text-muted-foreground">
-                        <StickyNote className="mt-0.5 size-3 shrink-0" />
-                        <span className="line-clamp-2">{row.session.notes}</span>
-                      </div>
-                    )}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+                      {row.session.location && (
+                        <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <MapPin className="size-3 shrink-0" />
+                          <span className="truncate">{row.session.location}</span>
+                        </div>
+                      )}
 
-          {rows.length > SOFT_CAP && (
-            <button
-              type="button"
-              onClick={() => setShowAll((v) => !v)}
-              className="mt-3 text-xs font-medium text-primary hover:underline"
-            >
-              {showAll ? 'Show less' : `Show more (${rows.length - SOFT_CAP})`}
-            </button>
-          )}
-        </>
-      )}
+                      {row.session.notes && (
+                        <div className="mt-1 flex items-start gap-1.5 text-xs text-muted-foreground">
+                          <StickyNote className="mt-0.5 size-3 shrink-0" />
+                          <span className="line-clamp-2">{row.session.notes}</span>
+                        </div>
+                      )}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {rows.length > SOFT_CAP && (
+              <button
+                type="button"
+                onClick={() => setShowAll((v) => !v)}
+                className="mt-3 text-xs font-medium text-primary hover:underline"
+              >
+                {showAll ? 'Show less' : `Show more (${rows.length - SOFT_CAP})`}
+              </button>
+            )}
+          </>
+        )}
+      </div>
     </aside>
   );
 }

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { parseISO } from 'date-fns';
+import { CalendarClock, MapPin, StickyNote } from 'lucide-react';
+import { formatTimeShort } from '@/lib/formatting';
+import type { UpcomingSessionRow } from '@/lib/upcomingSessions';
+
+const SOFT_CAP = 5;
+
+function formatSessionDate(dateStr: string): string {
+  return parseISO(dateStr).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTimeRange(
+  start: string | null,
+  end: string | null,
+  use24h: boolean
+): string {
+  if (!start) return 'time TBD';
+  const startLabel = formatTimeShort(start, use24h);
+  return end ? `${startLabel}–${formatTimeShort(end, use24h)}` : startLabel;
+}
+
+interface UpcomingSessionsPanelProps {
+  rows: UpcomingSessionRow[];
+  use24h: boolean;
+}
+
+export function UpcomingSessionsPanel({ rows, use24h }: UpcomingSessionsPanelProps) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? rows : rows.slice(0, SOFT_CAP);
+
+  return (
+    <aside data-testid="upcoming-sessions-panel" className="lg:sticky lg:top-20">
+      <h2 className="mb-3 text-sm font-semibold text-foreground">Upcoming Sessions</h2>
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No upcoming sessions.</p>
+      ) : (
+        <>
+          <ul className="space-y-2">
+            {visible.map((row) => {
+              const highlighted = row.dayHighlight !== null;
+              return (
+                <li key={row.session.id}>
+                  <Link
+                    href={`/games/${row.gameId}`}
+                    data-testid="upcoming-session"
+                    className={`block rounded-lg border p-3 transition-colors hover:ring-2 hover:ring-primary/30 ${
+                      highlighted ? 'border-primary/30 bg-primary/10' : 'border-border bg-card'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="truncate text-sm font-medium text-card-foreground">
+                        {row.gameName}
+                      </span>
+                      {row.dayHighlight && (
+                        <span className="shrink-0 rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary">
+                          {row.dayHighlight === 'today' ? 'Today' : 'Tomorrow'}
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <CalendarClock className="size-3 shrink-0" />
+                      <span>
+                        {formatSessionDate(row.session.date)} ·{' '}
+                        {formatTimeRange(row.session.start_time, row.session.end_time, use24h)}
+                      </span>
+                    </div>
+
+                    {row.session.location && (
+                      <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <MapPin className="size-3 shrink-0" />
+                        <span className="truncate">{row.session.location}</span>
+                      </div>
+                    )}
+
+                    {row.session.notes && (
+                      <div className="mt-1 flex items-start gap-1.5 text-xs text-muted-foreground">
+                        <StickyNote className="mt-0.5 size-3 shrink-0" />
+                        <span className="line-clamp-2">{row.session.notes}</span>
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+
+          {rows.length > SOFT_CAP && (
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              className="mt-3 text-xs font-medium text-primary hover:underline"
+            >
+              {showAll ? 'Show less' : `Show more (${rows.length - SOFT_CAP})`}
+            </button>
+          )}
+        </>
+      )}
+    </aside>
+  );
+}

--- a/src/lib/data/sessions.test.ts
+++ b/src/lib/data/sessions.test.ts
@@ -105,3 +105,35 @@ describe("updateSession", () => {
     expect(mock.update).toHaveBeenCalledWith({ notes: "new" });
   });
 });
+
+describe("fetchUpcomingSessionsForGames", () => {
+  function makeSelectMock() {
+    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const gte = vi.fn().mockReturnValue({ order });
+    const inFn = vi.fn().mockReturnValue({ gte });
+    const select = vi.fn().mockReturnValue({ in: inFn });
+    const from = vi.fn().mockReturnValue({ select });
+    return { from, select, inFn, gte, order };
+  }
+
+  it("queries sessions for the given game IDs from the given date, ordered by date asc", async () => {
+    const { fetchUpcomingSessionsForGames } = await import("./sessions");
+    const mock = makeSelectMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fetchUpcomingSessionsForGames(mock as any, ["g1", "g2"], "2026-06-01");
+    expect(mock.from).toHaveBeenCalledWith("sessions");
+    expect(mock.select).toHaveBeenCalledWith("*");
+    expect(mock.inFn).toHaveBeenCalledWith("game_id", ["g1", "g2"]);
+    expect(mock.gte).toHaveBeenCalledWith("date", "2026-06-01");
+    expect(mock.order).toHaveBeenCalledWith("date", { ascending: true });
+  });
+
+  it("returns an empty result without querying when there are no game IDs", async () => {
+    const { fetchUpcomingSessionsForGames } = await import("./sessions");
+    const mock = makeSelectMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await fetchUpcomingSessionsForGames(mock as any, [], "2026-06-01");
+    expect(mock.from).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [], error: null });
+  });
+});

--- a/src/lib/data/sessions.ts
+++ b/src/lib/data/sessions.ts
@@ -51,6 +51,22 @@ export async function fetchFutureSessions(
     .gte('date', fromDate);
 }
 
+export async function fetchUpcomingSessionsForGames(
+  supabase: SupabaseClient,
+  gameIds: string[],
+  fromDate: string
+) {
+  if (gameIds.length === 0) {
+    return { data: [] as GameSession[], error: null };
+  }
+  return supabase
+    .from('sessions')
+    .select('*')
+    .in('game_id', gameIds)
+    .gte('date', fromDate)
+    .order('date', { ascending: true });
+}
+
 export async function updateSession(
   supabase: SupabaseClient,
   sessionId: string,

--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -4,6 +4,8 @@ import {
   formatTimezoneDisplay,
   getTimezoneAbbreviation,
   convertTimeForDisplay,
+  getSessionInstantMs,
+  getDateInTimezone,
 } from "./timezone";
 
 describe("isValidTimezone", () => {
@@ -221,5 +223,41 @@ describe("convertTimeForDisplay", () => {
     expect(result.gameTime).toBe("10:00 AM");
     expect(result.gameTzAbbrev).toBe("UTC");
     expect(result.userTime).toBe("3:30 PM");
+  });
+});
+
+describe("getSessionInstantMs", () => {
+  it("resolves a Los Angeles evening to the correct UTC instant (PDT = UTC-7)", () => {
+    // 2026-06-01 19:00 PDT == 2026-06-02 02:00 UTC
+    const ms = getSessionInstantMs("2026-06-01", "19:00", "America/Los_Angeles");
+    expect(new Date(ms).toISOString()).toBe("2026-06-02T02:00:00.000Z");
+  });
+
+  it("orders cross-timezone sessions by true instant, not by local clock time", () => {
+    // New York 20:00 EDT (00:00 UTC) is earlier than LA 19:00 PDT (02:00 UTC),
+    // even though 19:00 < 20:00 as raw strings.
+    const ny = getSessionInstantMs("2026-06-01", "20:00", "America/New_York");
+    const la = getSessionInstantMs("2026-06-01", "19:00", "America/Los_Angeles");
+    expect(ny).toBeLessThan(la);
+  });
+
+  it("defaults a missing time to start-of-day", () => {
+    const ms = getSessionInstantMs("2026-06-01", null, "America/Los_Angeles");
+    // 2026-06-01 00:00 PDT == 2026-06-01 07:00 UTC
+    expect(new Date(ms).toISOString()).toBe("2026-06-01T07:00:00.000Z");
+  });
+
+  it("treats the local time as UTC when no timezone is given", () => {
+    const ms = getSessionInstantMs("2026-06-01", "12:00", null);
+    expect(new Date(ms).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+  });
+});
+
+describe("getDateInTimezone", () => {
+  it("returns the previous calendar date in a western timezone before its midnight", () => {
+    // 2026-06-02 03:00 UTC is still 2026-06-01 20:00 in Los Angeles
+    const ms = Date.UTC(2026, 5, 2, 3, 0, 0);
+    expect(getDateInTimezone(ms, "America/Los_Angeles")).toBe("2026-06-01");
+    expect(getDateInTimezone(ms, "Asia/Tokyo")).toBe("2026-06-02");
   });
 });

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -155,6 +155,54 @@ export function convertTimeForDisplay(
 }
 
 /**
+ * Resolve the absolute UTC instant (epoch ms) of a session given its local
+ * date/time in a game's timezone. Used to order sessions chronologically across
+ * games in different timezones, where raw HH:MM comparison would be wrong.
+ *
+ * @param dateStr  Session date in YYYY-MM-DD (interpreted in `timezone`)
+ * @param timeStr  Time in HH:MM[:SS] (interpreted in `timezone`); null → 00:00
+ * @param timezone IANA timezone, or null to interpret the local time as UTC
+ * @returns UTC epoch milliseconds
+ */
+export function getSessionInstantMs(
+  dateStr: string,
+  timeStr: string | null,
+  timezone: string | null
+): number {
+  const [y, mo, d] = dateStr.split('-').map(Number);
+  const [h, m] = (timeStr ?? '00:00').split(':').map(Number);
+  const probeUtc = new Date(Date.UTC(y, mo - 1, d, h, m || 0, 0));
+  if (!timezone) return probeUtc.getTime();
+  const offset = getTimezoneOffsetMinutes(probeUtc, timezone);
+  return probeUtc.getTime() - offset * 60000;
+}
+
+/**
+ * Get the calendar date (YYYY-MM-DD) at a given instant, as observed in a
+ * specific timezone. Used to decide whether a session is still "upcoming" in
+ * its own game's timezone rather than the viewer's.
+ *
+ * @param ms       UTC epoch milliseconds
+ * @param timezone IANA timezone, or null to use the runtime's local date
+ */
+export function getDateInTimezone(ms: number, timezone: string | null): string {
+  const date = new Date(ms);
+  if (!timezone) {
+    const y = date.getFullYear();
+    const mo = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${mo}-${d}`;
+  }
+  // en-CA formats as YYYY-MM-DD, which sorts lexicographically.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+/**
  * Get the UTC offset in minutes for a timezone at a given moment.
  * Positive = ahead of UTC, negative = behind.
  */

--- a/src/lib/upcomingSessions.test.ts
+++ b/src/lib/upcomingSessions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildUpcomingSessionRows,
   toLocalDateString,
+  getUpcomingQueryFloor,
 } from './upcomingSessions';
 import type { GameSession } from '@/types';
 
@@ -33,6 +34,19 @@ describe('toLocalDateString', () => {
   it('formats a Date as YYYY-MM-DD in local time', () => {
     // Month is 0-indexed: 5 => June
     expect(toLocalDateString(new Date(2026, 5, 3))).toBe('2026-06-03');
+  });
+});
+
+describe('getUpcomingQueryFloor', () => {
+  it('returns a date two calendar days before the viewer-local date', () => {
+    // Two days covers the widest timezone span (UTC-12..UTC+14 = 26h), which can
+    // put a game's local date up to two calendar days behind the viewer's.
+    const now = Date.UTC(2026, 5, 3, 12, 0, 0);
+    const today = toLocalDateString(new Date(now));
+    const floor = getUpcomingQueryFloor(now);
+    // Parsed as UTC midnight on both sides, so the diff is exact and tz-independent.
+    const diffDays = (Date.parse(today) - Date.parse(floor)) / 86_400_000;
+    expect(diffDays).toBe(2);
   });
 });
 

--- a/src/lib/upcomingSessions.test.ts
+++ b/src/lib/upcomingSessions.test.ts
@@ -19,9 +19,9 @@ const mkSession = (overrides: Partial<GameSession>): GameSession => ({
   ...overrides,
 });
 
-const names = new Map<string, string>([
-  ['g1', 'Curse of Strahd'],
-  ['g2', 'Heist Crew'],
+const names = new Map<string, { name: string; timezone: string | null }>([
+  ['g1', { name: 'Curse of Strahd', timezone: 'America/Los_Angeles' }],
+  ['g2', { name: 'Heist Crew', timezone: 'America/New_York' }],
 ]);
 
 describe('toLocalDateString', () => {
@@ -46,13 +46,27 @@ describe('buildUpcomingSessionRows', () => {
     expect(rows[1].gameName).toBe('Heist Crew');
   });
 
-  it('falls back to "Unknown game" when a name is missing', () => {
+  it('falls back to "Unknown game" with null timezone when the game is missing', () => {
     const rows = buildUpcomingSessionRows(
       [mkSession({ game_id: 'gX', date: '2026-06-10' })],
       names,
       '2026-06-01'
     );
     expect(rows[0].gameName).toBe('Unknown game');
+    expect(rows[0].gameTimezone).toBeNull();
+  });
+
+  it('carries the game timezone onto each row', () => {
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'a', game_id: 'g1', date: '2026-06-10' }),
+        mkSession({ id: 'b', game_id: 'g2', date: '2026-06-11' }),
+      ],
+      names,
+      '2026-06-01'
+    );
+    expect(rows[0].gameTimezone).toBe('America/Los_Angeles');
+    expect(rows[1].gameTimezone).toBe('America/New_York');
   });
 
   it('tags today and tomorrow, leaving other dates null', () => {

--- a/src/lib/upcomingSessions.test.ts
+++ b/src/lib/upcomingSessions.test.ts
@@ -22,7 +22,12 @@ const mkSession = (overrides: Partial<GameSession>): GameSession => ({
 const names = new Map<string, { name: string; timezone: string | null }>([
   ['g1', { name: 'Curse of Strahd', timezone: 'America/Los_Angeles' }],
   ['g2', { name: 'Heist Crew', timezone: 'America/New_York' }],
+  ['g3', { name: 'Avalon', timezone: 'America/Los_Angeles' }],
 ]);
+
+// A "now" of noon UTC on the given date keeps US-timezone "today" equal to that
+// date, so the upcoming-cutoff filter doesn't drop the test's sessions.
+const noonUtc = (dateStr: string): number => Date.parse(`${dateStr}T12:00:00Z`);
 
 describe('toLocalDateString', () => {
   it('formats a Date as YYYY-MM-DD in local time', () => {
@@ -39,7 +44,8 @@ describe('buildUpcomingSessionRows', () => {
         mkSession({ id: 'b', game_id: 'g1', date: '2026-06-10' }),
       ],
       names,
-      '2026-06-01'
+      '2026-06-01',
+      noonUtc('2026-06-01')
     );
     expect(rows.map((r) => r.session.id)).toEqual(['b', 'a']);
     expect(rows[0].gameName).toBe('Curse of Strahd');
@@ -50,7 +56,8 @@ describe('buildUpcomingSessionRows', () => {
     const rows = buildUpcomingSessionRows(
       [mkSession({ game_id: 'gX', date: '2026-06-10' })],
       names,
-      '2026-06-01'
+      '2026-06-01',
+      noonUtc('2026-06-01')
     );
     expect(rows[0].gameName).toBe('Unknown game');
     expect(rows[0].gameTimezone).toBeNull();
@@ -63,7 +70,8 @@ describe('buildUpcomingSessionRows', () => {
         mkSession({ id: 'b', game_id: 'g2', date: '2026-06-11' }),
       ],
       names,
-      '2026-06-01'
+      '2026-06-01',
+      noonUtc('2026-06-01')
     );
     expect(rows[0].gameTimezone).toBe('America/Los_Angeles');
     expect(rows[1].gameTimezone).toBe('America/New_York');
@@ -77,7 +85,8 @@ describe('buildUpcomingSessionRows', () => {
         mkSession({ id: 'later', date: '2026-06-12' }),
       ],
       names,
-      '2026-06-10'
+      '2026-06-10',
+      noonUtc('2026-06-10')
     );
     const byId = Object.fromEntries(rows.map((r) => [r.session.id, r.dayHighlight]));
     expect(byId.today).toBe('today');
@@ -89,21 +98,75 @@ describe('buildUpcomingSessionRows', () => {
     const rows = buildUpcomingSessionRows(
       [mkSession({ id: 'ny', date: '2027-01-01' })],
       names,
-      '2026-12-31'
+      '2026-12-31',
+      noonUtc('2026-12-31')
     );
     expect(rows[0].dayHighlight).toBe('tomorrow');
   });
 
-  it('breaks date ties by start_time (nulls last) then game name', () => {
+  it('orders sessions by their true instant across timezones, not raw local time', () => {
+    // Same calendar date. NY 20:00 EDT (00:00 UTC) precedes LA 19:00 PDT (02:00 UTC),
+    // even though "19:00" < "20:00" as strings.
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'la', game_id: 'g1', date: '2026-06-10', start_time: '19:00:00' }),
+        mkSession({ id: 'ny', game_id: 'g2', date: '2026-06-10', start_time: '20:00:00' }),
+      ],
+      names,
+      '2026-06-01',
+      noonUtc('2026-06-01')
+    );
+    expect(rows.map((r) => r.session.id)).toEqual(['ny', 'la']);
+  });
+
+  it('places start-less sessions after timed ones on the same date', () => {
     const rows = buildUpcomingSessionRows(
       [
         mkSession({ id: 'noTime', game_id: 'g1', date: '2026-06-10', start_time: null }),
-        mkSession({ id: 'late', game_id: 'g2', date: '2026-06-10', start_time: '20:00:00' }),
-        mkSession({ id: 'early', game_id: 'g1', date: '2026-06-10', start_time: '18:00:00' }),
+        mkSession({ id: 'timed', game_id: 'g1', date: '2026-06-10', start_time: '18:00:00' }),
       ],
       names,
-      '2026-06-01'
+      '2026-06-01',
+      noonUtc('2026-06-01')
     );
-    expect(rows.map((r) => r.session.id)).toEqual(['early', 'late', 'noTime']);
+    expect(rows.map((r) => r.session.id)).toEqual(['timed', 'noTime']);
+  });
+
+  it('breaks exact-instant ties by game name', () => {
+    // Same timezone, date, and start time → identical instant → name decides.
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'curse', game_id: 'g1', date: '2026-06-10', start_time: '19:00:00' }),
+        mkSession({ id: 'avalon', game_id: 'g3', date: '2026-06-10', start_time: '19:00:00' }),
+      ],
+      names,
+      '2026-06-01',
+      noonUtc('2026-06-01')
+    );
+    expect(rows.map((r) => r.session.id)).toEqual(['avalon', 'curse']);
+  });
+
+  it("keeps a session still upcoming in the game's timezone after the viewer's date rolls over", () => {
+    // Viewer is on 2026-06-02, but in Los Angeles it is still 2026-06-01 20:00.
+    // An LA session dated 2026-06-01 is still upcoming and must not be dropped.
+    const nowMs = Date.UTC(2026, 5, 2, 3, 0, 0);
+    const rows = buildUpcomingSessionRows(
+      [mkSession({ id: 'laEvening', game_id: 'g1', date: '2026-06-01' })],
+      names,
+      '2026-06-02',
+      nowMs
+    );
+    expect(rows.map((r) => r.session.id)).toEqual(['laEvening']);
+  });
+
+  it("drops sessions already past in the game's own timezone", () => {
+    const nowMs = Date.UTC(2026, 5, 2, 3, 0, 0); // LA: 2026-06-01 20:00
+    const rows = buildUpcomingSessionRows(
+      [mkSession({ id: 'old', game_id: 'g1', date: '2026-05-31' })],
+      names,
+      '2026-06-02',
+      nowMs
+    );
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/lib/upcomingSessions.test.ts
+++ b/src/lib/upcomingSessions.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildUpcomingSessionRows,
+  toLocalDateString,
+} from './upcomingSessions';
+import type { GameSession } from '@/types';
+
+const mkSession = (overrides: Partial<GameSession>): GameSession => ({
+  id: `s-${overrides.date}-${overrides.game_id ?? 'g'}`,
+  game_id: 'g1',
+  date: '2026-06-10',
+  start_time: '19:00:00',
+  end_time: '22:00:00',
+  status: 'confirmed',
+  confirmed_by: 'u1',
+  location: null,
+  notes: null,
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const names = new Map<string, string>([
+  ['g1', 'Curse of Strahd'],
+  ['g2', 'Heist Crew'],
+]);
+
+describe('toLocalDateString', () => {
+  it('formats a Date as YYYY-MM-DD in local time', () => {
+    // Month is 0-indexed: 5 => June
+    expect(toLocalDateString(new Date(2026, 5, 3))).toBe('2026-06-03');
+  });
+});
+
+describe('buildUpcomingSessionRows', () => {
+  it('joins game names and sorts by date ascending', () => {
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'a', game_id: 'g2', date: '2026-06-12' }),
+        mkSession({ id: 'b', game_id: 'g1', date: '2026-06-10' }),
+      ],
+      names,
+      '2026-06-01'
+    );
+    expect(rows.map((r) => r.session.id)).toEqual(['b', 'a']);
+    expect(rows[0].gameName).toBe('Curse of Strahd');
+    expect(rows[1].gameName).toBe('Heist Crew');
+  });
+
+  it('falls back to "Unknown game" when a name is missing', () => {
+    const rows = buildUpcomingSessionRows(
+      [mkSession({ game_id: 'gX', date: '2026-06-10' })],
+      names,
+      '2026-06-01'
+    );
+    expect(rows[0].gameName).toBe('Unknown game');
+  });
+
+  it('tags today and tomorrow, leaving other dates null', () => {
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'today', date: '2026-06-10' }),
+        mkSession({ id: 'tom', date: '2026-06-11' }),
+        mkSession({ id: 'later', date: '2026-06-12' }),
+      ],
+      names,
+      '2026-06-10'
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.session.id, r.dayHighlight]));
+    expect(byId.today).toBe('today');
+    expect(byId.tom).toBe('tomorrow');
+    expect(byId.later).toBeNull();
+  });
+
+  it('computes tomorrow across a month/year boundary', () => {
+    const rows = buildUpcomingSessionRows(
+      [mkSession({ id: 'ny', date: '2027-01-01' })],
+      names,
+      '2026-12-31'
+    );
+    expect(rows[0].dayHighlight).toBe('tomorrow');
+  });
+
+  it('breaks date ties by start_time (nulls last) then game name', () => {
+    const rows = buildUpcomingSessionRows(
+      [
+        mkSession({ id: 'noTime', game_id: 'g1', date: '2026-06-10', start_time: null }),
+        mkSession({ id: 'late', game_id: 'g2', date: '2026-06-10', start_time: '20:00:00' }),
+        mkSession({ id: 'early', game_id: 'g1', date: '2026-06-10', start_time: '18:00:00' }),
+      ],
+      names,
+      '2026-06-01'
+    );
+    expect(rows.map((r) => r.session.id)).toEqual(['early', 'late', 'noTime']);
+  });
+});

--- a/src/lib/upcomingSessions.ts
+++ b/src/lib/upcomingSessions.ts
@@ -29,6 +29,24 @@ export function getTodayLocalDate(): string {
   return toLocalDateString(new Date());
 }
 
+/**
+ * DB fetch floor for upcoming sessions: two calendar days before the viewer's
+ * local date.
+ *
+ * The widest IANA timezone span is UTC-12..UTC+14 (26 hours), so a game's local
+ * date can trail the viewer's by up to two calendar days (26h < 48h can never
+ * cross three midnights). A two-day buffer therefore guarantees we fetch every
+ * still-upcoming session regardless of the viewer's timezone;
+ * buildUpcomingSessionRows then filters precisely against each game's own date.
+ *
+ * @param nowMs Current instant (epoch ms).
+ */
+export function getUpcomingQueryFloor(nowMs: number): string {
+  const d = new Date(nowMs);
+  d.setDate(d.getDate() - 2);
+  return toLocalDateString(d);
+}
+
 /** Add one calendar day to a YYYY-MM-DD string, handling month/year rollover. */
 function addOneDay(dateStr: string): string {
   const [y, m, d] = dateStr.split('-').map(Number);

--- a/src/lib/upcomingSessions.ts
+++ b/src/lib/upcomingSessions.ts
@@ -1,0 +1,63 @@
+import type { GameSession } from '@/types';
+
+export type DayHighlight = 'today' | 'tomorrow' | null;
+
+export interface UpcomingSessionRow {
+  session: GameSession;
+  gameId: string;
+  gameName: string;
+  dayHighlight: DayHighlight;
+}
+
+/** Format a Date as YYYY-MM-DD in local time (matches how session dates are stored). */
+export function toLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Today's date as YYYY-MM-DD in the user's local timezone. */
+export function getTodayLocalDate(): string {
+  return toLocalDateString(new Date());
+}
+
+/** Add one calendar day to a YYYY-MM-DD string, handling month/year rollover. */
+function addOneDay(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  date.setDate(date.getDate() + 1);
+  return toLocalDateString(date);
+}
+
+/**
+ * Build sorted, game-named rows from raw sessions.
+ *
+ * @param sessions  Raw session rows (assumed already filtered to date >= today).
+ * @param gameNames Map of game_id -> game name.
+ * @param today     YYYY-MM-DD reference for "today" (local). Drives the today/tomorrow highlight.
+ */
+export function buildUpcomingSessionRows(
+  sessions: GameSession[],
+  gameNames: Map<string, string>,
+  today: string
+): UpcomingSessionRow[] {
+  const tomorrow = addOneDay(today);
+
+  return [...sessions]
+    .sort((a, b) => {
+      if (a.date !== b.date) return a.date.localeCompare(b.date);
+      // Same date: order by start_time, nulls last, then game name.
+      const at = a.start_time ?? '99:99';
+      const bt = b.start_time ?? '99:99';
+      if (at !== bt) return at.localeCompare(bt);
+      return (gameNames.get(a.game_id) ?? '').localeCompare(gameNames.get(b.game_id) ?? '');
+    })
+    .map((session) => ({
+      session,
+      gameId: session.game_id,
+      gameName: gameNames.get(session.game_id) ?? 'Unknown game',
+      dayHighlight:
+        session.date === today ? 'today' : session.date === tomorrow ? 'tomorrow' : null,
+    }));
+}

--- a/src/lib/upcomingSessions.ts
+++ b/src/lib/upcomingSessions.ts
@@ -2,10 +2,16 @@ import type { GameSession } from '@/types';
 
 export type DayHighlight = 'today' | 'tomorrow' | null;
 
+export interface GameDisplayInfo {
+  name: string;
+  timezone: string | null;
+}
+
 export interface UpcomingSessionRow {
   session: GameSession;
   gameId: string;
   gameName: string;
+  gameTimezone: string | null;
   dayHighlight: DayHighlight;
 }
 
@@ -33,13 +39,13 @@ function addOneDay(dateStr: string): string {
 /**
  * Build sorted, game-named rows from raw sessions.
  *
- * @param sessions  Raw session rows (assumed already filtered to date >= today).
- * @param gameNames Map of game_id -> game name.
- * @param today     YYYY-MM-DD reference for "today" (local). Drives the today/tomorrow highlight.
+ * @param sessions Raw session rows (assumed already filtered to date >= today).
+ * @param games    Map of game_id -> { name, timezone }.
+ * @param today    YYYY-MM-DD reference for "today" (local). Drives the today/tomorrow highlight.
  */
 export function buildUpcomingSessionRows(
   sessions: GameSession[],
-  gameNames: Map<string, string>,
+  games: Map<string, GameDisplayInfo>,
   today: string
 ): UpcomingSessionRow[] {
   const tomorrow = addOneDay(today);
@@ -51,12 +57,13 @@ export function buildUpcomingSessionRows(
       const at = a.start_time ?? '99:99';
       const bt = b.start_time ?? '99:99';
       if (at !== bt) return at.localeCompare(bt);
-      return (gameNames.get(a.game_id) ?? '').localeCompare(gameNames.get(b.game_id) ?? '');
+      return (games.get(a.game_id)?.name ?? '').localeCompare(games.get(b.game_id)?.name ?? '');
     })
     .map((session) => ({
       session,
       gameId: session.game_id,
-      gameName: gameNames.get(session.game_id) ?? 'Unknown game',
+      gameName: games.get(session.game_id)?.name ?? 'Unknown game',
+      gameTimezone: games.get(session.game_id)?.timezone ?? null,
       dayHighlight:
         session.date === today ? 'today' : session.date === tomorrow ? 'tomorrow' : null,
     }));

--- a/src/lib/upcomingSessions.ts
+++ b/src/lib/upcomingSessions.ts
@@ -1,4 +1,5 @@
 import type { GameSession } from '@/types';
+import { getSessionInstantMs, getDateInTimezone } from './timezone';
 
 export type DayHighlight = 'today' | 'tomorrow' | null;
 
@@ -39,24 +40,41 @@ function addOneDay(dateStr: string): string {
 /**
  * Build sorted, game-named rows from raw sessions.
  *
- * @param sessions Raw session rows (assumed already filtered to date >= today).
+ * Sessions are filtered to those still upcoming **in each game's own timezone**
+ * (so a westward game's evening session isn't dropped once the viewer's local
+ * date rolls over) and sorted by their true UTC instant (so cross-timezone
+ * sessions read in real chronological order rather than by raw clock time).
+ *
+ * @param sessions Raw session rows (fetched with a one-day buffer below `today`).
  * @param games    Map of game_id -> { name, timezone }.
- * @param today    YYYY-MM-DD reference for "today" (local). Drives the today/tomorrow highlight.
+ * @param today    YYYY-MM-DD viewer-local date. Drives the today/tomorrow highlight.
+ * @param nowMs    Current instant (epoch ms). Used to compute each game's local
+ *                 "today" for the upcoming cutoff.
  */
 export function buildUpcomingSessionRows(
   sessions: GameSession[],
   games: Map<string, GameDisplayInfo>,
-  today: string
+  today: string,
+  nowMs: number
 ): UpcomingSessionRow[] {
   const tomorrow = addOneDay(today);
+  // Start-less sessions sort after timed ones on the same date.
+  const instantOf = (s: GameSession, tz: string | null) =>
+    getSessionInstantMs(s.date, s.start_time ?? '23:59:59', tz);
 
   return [...sessions]
+    .filter((session) => {
+      const tz = games.get(session.game_id)?.timezone ?? null;
+      // A session is upcoming if its date is today-or-later in the game's tz.
+      const gameToday = tz ? getDateInTimezone(nowMs, tz) : today;
+      return session.date >= gameToday;
+    })
     .sort((a, b) => {
-      if (a.date !== b.date) return a.date.localeCompare(b.date);
-      // Same date: order by start_time, nulls last, then game name.
-      const at = a.start_time ?? '99:99';
-      const bt = b.start_time ?? '99:99';
-      if (at !== bt) return at.localeCompare(bt);
+      const tzA = games.get(a.game_id)?.timezone ?? null;
+      const tzB = games.get(b.game_id)?.timezone ?? null;
+      const ia = instantOf(a, tzA);
+      const ib = instantOf(b, tzB);
+      if (ia !== ib) return ia - ib;
       return (games.get(a.game_id)?.name ?? '').localeCompare(games.get(b.game_id)?.name ?? '');
     })
     .map((session) => ({


### PR DESCRIPTION
## Summary

Adds an **Upcoming Sessions** panel to the dashboard ("Your Games") so players/GMs in multiple games can see every confirmed future session in one place instead of clicking into each game.

- **Layout:** right sidebar on desktop (sticky), stacked above the games grid on mobile.
- **Rows (compact):** game name, date + time, optional location, optional note. Today/tomorrow get a left accent bar + badge.
- **Soft cap** of 5 with a Show more / Show less toggle; empty state when there are none.
- **Visual separation:** the rail sits on a `bg-muted` panel with flat divided rows, so sessions don't read like the bordered game cards.
- Rows link to their game's page.

## Timezone correctness

Session times and the upcoming cutoff are timezone-aware, consistent with the game schedule view:

- Times render as game-local time + tz abbreviation, with a "(… for you)" conversion when the viewer's timezone differs (`convertTimeForDisplay`).
- Rows are sorted by their **true UTC instant**, not raw local clock time, so cross-timezone sessions read in real chronological order.
- "Upcoming" is judged against each **game's own timezone date**, and the DB fetch floor is widened by two days (covers the full UTC-12..UTC+14 span), so a westward game's still-future session isn't dropped once the viewer's local date rolls over.

## Architecture

- `src/lib/upcomingSessions.ts` — pure helper: builds sorted, game-named, timezone-tagged rows; owns the today/tomorrow logic and the fetch-floor calc.
- `src/lib/timezone.ts` — adds `getSessionInstantMs` / `getDateInTimezone`.
- `src/lib/data/sessions.ts` — `fetchUpcomingSessionsForGames` (single `.in(...).gte(...)` query, empty-list short-circuit).
- `src/components/dashboard/UpcomingSessionsPanel.tsx` — presentational panel; owns show-more state.
- `src/components/dashboard/DashboardContent.tsx` — reuses the already-fetched game set (no extra queries) and renders the two-column layout.

Also: excludes nested `.claude/` worktrees from ESLint (they were flooding `npm run lint` with ~17k phantom problems from a duplicate checkout).

## Test plan

- [x] Unit (453 passing): row build/sort, today/tomorrow tagging incl. month/year boundary, cross-timezone instant ordering, per-game-timezone upcoming cutoff, fetch-floor width, timezone utils, data-helper query shape.
- [x] E2E (3 passing): future-only listing with soft cap + show more/less, today highlight + navigation, empty state.
- [x] `npm run lint` clean (exit 0), `npm run build` succeeds.
- [ ] Manual: verify desktop sidebar + mobile stacking, today/tomorrow highlight, and cross-timezone "for you" labels with a multi-game user.