### PR TITLE
Add Vercel Web Analytics and Speed Insights

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,22 @@
 import type { NextConfig } from "next";
 
+// In production, Vercel Analytics & Speed Insights serve their scripts same-origin
+// (/_vercel/*), so 'self' already covers them. In development the packages load a
+// debug script from va.vercel-scripts.com and beacon to Vercel's collection endpoints,
+// so widen the CSP for dev only — keeping the production policy as tight as possible.
+const isDev = process.env.NODE_ENV !== 'production';
+const vercelAnalyticsScriptSrc = isDev ? ['https://va.vercel-scripts.com'] : [];
+const vercelAnalyticsConnectSrc = isDev
+  ? ['https://va.vercel-scripts.com', 'https://vitals.vercel-analytics.com']
+  : [];
+
+const scriptSrc = [
+  "'self'",
+  "'unsafe-inline'",
+  "'unsafe-eval'",
+  ...vercelAnalyticsScriptSrc,
+].join(' ');
+
 // Build connect-src dynamically so the CSP allows the configured Supabase URL
 // (cloud in production, localhost in local development)
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
@@ -8,6 +25,7 @@ const connectSrc = [
   'https://*.supabase.co',
   // Include the exact Supabase URL for local development (http://localhost:54321)
   ...(supabaseUrl && !supabaseUrl.includes('.supabase.co') ? [supabaseUrl] : []),
+  ...vercelAnalyticsConnectSrc,
 ].join(' ');
 
 const nextConfig: NextConfig = {
@@ -32,7 +50,7 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              `script-src ${scriptSrc}`,
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' https://lh3.googleusercontent.com https://cdn.discordapp.com https://avatars.githubusercontent.com data:",
               "font-src 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.90.1",
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.563.0",
         "nanoid": "^5.1.6",
@@ -4044,6 +4046,48 @@
         "valibot": "^1.2.0"
       }
     },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vercel/backends": {
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.0.23.tgz",
@@ -5608,6 +5652,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/static-build": {
       "version": "2.8.28",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.90.1",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.563.0",
     "nanoid": "^5.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { Providers, Navbar, StatusBanner } from '@/components/layout';
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import './globals.css';
 
 const geistSans = Geist({
@@ -71,6 +73,8 @@ export default function RootLayout({
           <StatusBanner />
           <main>{children}</main>
         </Providers>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-foreground">Privacy Policy</h1>
         <p className="mt-2 text-muted-foreground">
-          Effective February 2026
+          Effective June 2026
         </p>
       </div>
 
@@ -56,6 +56,21 @@ export default function PrivacyPage() {
           </p>
         </Section>
 
+        <Section title="Analytics & Performance">
+          <p>
+            We use Vercel&apos;s privacy-friendly Web Analytics and{' '}
+            Speed Insights to understand how the app is
+            used and to monitor performance. These collect aggregated, anonymous information &mdash;
+            such as page views, the site that referred you, and general device, browser, and country
+            data &mdash; along with page load and responsiveness metrics measured during your visit.
+          </p>
+          <p>
+            This collection is cookieless. It is not
+            linked to your account, is not used to track you across other websites, and is never used
+            to build an advertising profile.
+          </p>
+        </Section>
+
         <Section title="Third-Party Services">
           <p>
             Can We Play? relies on the following third-party services:
@@ -84,7 +99,8 @@ export default function PrivacyPage() {
               </a>.
             </li>
             <li>
-              <strong className="text-foreground">Vercel</strong> &mdash; hosts the application.
+              <strong className="text-foreground">Vercel</strong> &mdash; hosts the application and
+              provides the cookieless analytics and performance monitoring described above.
               See{' '}
               <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
                 Vercel&apos;s Privacy Policy
@@ -95,9 +111,11 @@ export default function PrivacyPage() {
 
         <Section title="Cookies & Local Storage">
           <p>
-            We use a session cookie provided by Supabase to keep you signed in. We do not use
-            tracking cookies, analytics cookies, or any third-party cookies. Your theme preference
-            is stored in your browser&apos;s local storage.
+            We use a session cookie provided by Supabase to keep you signed in. Our analytics and
+            performance monitoring are cookieless (see
+            Analytics &amp; Performance above), and we do not use advertising cookies, cross-site
+            tracking cookies, or any third-party cookies. Your theme preference is stored in your
+            browser&apos;s local storage.
           </p>
         </Section>
 


### PR DESCRIPTION
## Summary

Adds first-party visitor analytics and real-user performance monitoring so we can finally answer "where is the organic growth coming from?" and watch Core Web Vitals on real devices.

- Wires `@vercel/analytics` (`<Analytics />`) and `@vercel/speed-insights` (`<SpeedInsights />`) into the root layout.
- Both are cookieless and serve scripts same-origin (`/_vercel/*`) in production.

## Privacy disclosure

- New **Analytics & Performance** section in the privacy policy describing the cookieless pageview/referrer/device + performance-vitals collection.
- Updated the **Vercel** third-party entry (host → host + analytics provider) and reconciled the **Cookies & Local Storage** section so the "no analytics cookies" claim reads as *cookieless analytics*, not a contradiction.

## CSP

- Dev-only: allow `va.vercel-scripts.com` (`script-src`) and `vitals.vercel-analytics.com` (`connect-src`) so the analytics debug script loads without CSP violations during `npm run dev`.
- Production CSP is unchanged (scripts/beacons are same-origin), verified by inspecting the emitted header in both modes.

## Notes

- No `.npmrc` / `legacy-peer-deps`: an earlier attempt added it to dodge an ERESOLVE, but the conflict was stale Svelte/Vite packages, not a real one. A clean install resolves fine and keeps `@testing-library/dom` (a required peer of `@testing-library/react`) intact.
- **Manual step after merge:** enable Web Analytics and Speed Insights in the Vercel project dashboard (one-time, per-tab). Data only collects from a production deploy onward — no backfill.

## Verification

- `npm run lint` — clean
- `npm run build` — green
- `npm run test:run` — 28 files, 453 passed
- CSP header curled in dev (includes debug origins) and prod (excludes them)