### PR TITLE
Server-render the landing page for SEO (+ client-only dice & discoverable content)

### DIFF
--- a/e2e/tests/home/landing-seo.spec.ts
+++ b/e2e/tests/home/landing-seo.spec.ts
@@ -26,12 +26,13 @@ test.describe('Landing page SEO', () => {
   test('renders the dashboard inline at / for an authenticated user', async ({ gmPage }) => {
     await gmPage.goto('/');
 
-    // URL stays at root — no redirect to /dashboard.
-    await expect(gmPage).toHaveURL('/');
-
     // "Your Games" is rendered by DashboardContent and never by the splash.
+    // Assert it first so the LONG timeout covers client-side auth resolution.
     await expect(gmPage.getByRole('heading', { name: /your games/i })).toBeVisible({
       timeout: TEST_TIMEOUTS.LONG,
     });
+
+    // URL stays at root — no redirect to /dashboard.
+    await expect(gmPage).toHaveURL('/');
   });
 });

--- a/e2e/tests/home/landing-seo.spec.ts
+++ b/e2e/tests/home/landing-seo.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Landing page SEO', () => {
+  test('serves server-rendered marketing HTML to logged-out visitors (no JS)', async ({
+    request,
+  }) => {
+    // `request` is a cookie-less API context → simulates a crawler / logged-out visitor.
+    const res = await request.get('/');
+    expect(res.ok()).toBeTruthy();
+
+    const html = await res.text();
+
+    // Strings unique to the SplashPage body. Their presence in the RAW response
+    // (no browser, no hydration) proves the marketing page was server-rendered,
+    // not the loading spinner shell.
+    // The `>...<` delimiters ensure we match rendered tag content (e.g.
+    // `<h3>Invite your party</h3>`), not the same text embedded inside the RSC
+    // flight `<script>` payload — so this still fails if SSR regresses to a
+    // client-only render.
+    expect(html).toContain('>Invite your party<');
+    expect(html).toContain('>Mark availability<');
+    expect(html).toContain('>Co-GM Support<');
+  });
+
+  test('renders the dashboard inline at / for an authenticated user', async ({ gmPage }) => {
+    await gmPage.goto('/');
+
+    // URL stays at root — no redirect to /dashboard.
+    await expect(gmPage).toHaveURL('/');
+
+    // "Your Games" is rendered by DashboardContent and never by the splash.
+    await expect(gmPage.getByRole('heading', { name: /your games/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+});

--- a/e2e/tests/home/landing-seo.spec.ts
+++ b/e2e/tests/home/landing-seo.spec.ts
@@ -11,6 +11,11 @@ test.describe('Landing page SEO', () => {
 
     const html = await res.text();
 
+    // Log the raw response size up front so it's visible on every run (including
+    // failures). It was ~500KB+ when the ~142 decorative dice were server-rendered.
+    const bytes = Buffer.byteLength(html);
+    console.log(`[landing-seo] raw / response size: ${bytes} bytes`);
+
     // Strings unique to the SplashPage body. Their presence in the RAW response
     // (no browser, no hydration) proves the marketing page was server-rendered,
     // not the loading spinner shell.
@@ -21,6 +26,31 @@ test.describe('Landing page SEO', () => {
     expect(html).toContain('>Invite your party<');
     expect(html).toContain('>Mark availability<');
     expect(html).toContain('>Co-GM Support<');
+
+    // Decorative dice are client-only (rendered after mount), so they must NOT
+    // appear in the server response. `lucide-dice` is the rendered-SVG marker
+    // (e.g. class "lucide lucide-dice-1") and is absent from globals.css, so it
+    // won't false-positive on inlined CSS the way the `dice-filled` class would.
+    expect(html).not.toContain('lucide-dice');
+
+    // Size backstop against mass-element bloat (the dice were ~518KB of the old
+    // ~598KB dev response). This runs against `next dev`, which is far heavier than
+    // production (unminified + HMR + verbose RSC payload): post-fix dev is ~80KB
+    // while production is ~31KB. The 150KB cap is a loose regression guard — it
+    // passes comfortably now but trips immediately if the dice (or similar) return
+    // to the server render. The precise dice guard is `not.toContain('lucide-dice')`
+    // above.
+    expect(bytes).toBeLessThan(150_000);
+  });
+
+  test('renders the decorative dice in the browser after hydration', async ({ page }) => {
+    await page.goto('/');
+
+    // Dice are client-only and fade in after mount. `.dice-filled` is the class
+    // on each die's <svg>; its presence proves the client renders them post-mount.
+    await expect(page.locator('.dice-filled').first()).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
   });
 
   test('renders the dashboard inline at / for an authenticated user', async ({ gmPage }) => {

--- a/e2e/tests/home/landing-seo.spec.ts
+++ b/e2e/tests/home/landing-seo.spec.ts
@@ -27,6 +27,14 @@ test.describe('Landing page SEO', () => {
     expect(html).toContain('>Mark availability<');
     expect(html).toContain('>Co-GM Support<');
 
+    // Discoverability copy must be server-rendered: these domain keywords let
+    // search/AI engines understand what the app is for. Use terms that are new to
+    // the page (not "calendar", which already appears via "Calendar Sync") and
+    // free of HTML-escaping ambiguity (avoid "D&D" → "D&amp;D").
+    expect(html).toContain('TTRPG');
+    expect(html).toContain('Pathfinder');
+    expect(html).toContain('board game');
+
     // Decorative dice are client-only (rendered after mount), so they must NOT
     // appear in the server response. `lucide-dice` is the rendered-SVG marker
     // (e.g. class "lucide lucide-dice-1") and is absent from globals.css, so it

--- a/e2e/tests/home/landing.spec.ts
+++ b/e2e/tests/home/landing.spec.ts
@@ -23,7 +23,7 @@ test.describe('Landing Page', () => {
     // Steps should be present
     await expect(page.getByRole('heading', { name: 'Invite your party' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Mark availability' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Book game nights' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book sessions' })).toBeVisible();
 
     // Features should be present
     await expect(page.getByRole('heading', { name: 'Multi-Game' })).toBeVisible();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,34 @@
-'use client';
-
-import { LoadingSpinner } from '@/components/ui';
-import { useAuth } from '@/contexts/AuthContext';
-import { DashboardContent } from '@/components/dashboard/DashboardContent';
+import { createClient } from '@/lib/supabase/server';
+import { chooseHomeView, type HomeView } from '@/lib/homeView';
 import { SplashPage } from '@/components/splash/SplashPage';
+import { HomeApp } from '@/components/home/HomeApp';
 
-export default function Home() {
-  const { profile, authStatus } = useAuth();
+// This route reads auth cookies and renders differently per request, so it is
+// always dynamically rendered. Declaring it explicitly also prevents Next.js's
+// build-time prerender attempt from tripping the page's getClaims try/catch.
+export const dynamic = 'force-dynamic';
 
-  // Show dashboard for authenticated users
-  if (profile) {
-    return <DashboardContent />;
+export default async function Home() {
+  // Fail safe toward the authenticated path: if reading the session throws
+  // unexpectedly, render the client gate (which resolves auth) rather than
+  // exposing a logged-in user to the public splash. `view` stays 'app' on error.
+  let view: HomeView = 'app';
+  try {
+    const supabase = await createClient();
+    const result = await supabase.auth.getClaims();
+    view = chooseHomeView(result);
+  } catch (err) {
+    // Surface unexpected failures in server logs so a consistently broken
+    // getClaims() path (e.g. missing env, library regression) is observable
+    // rather than silently degrading the logged-out/SEO render to HomeApp.
+    console.error('[home] getClaims threw unexpectedly; falling back to HomeApp:', err);
   }
 
-  // Show loading state while checking auth
-  if (authStatus === 'loading') {
-    return (
-      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
+  if (view === 'splash') {
+    // Logged-out visitors and crawlers (no auth cookie) get fully
+    // server-rendered marketing HTML.
+    return <SplashPage />;
   }
 
-  // Show splash page for unauthenticated users
-  return <SplashPage />;
+  return <HomeApp />;
 }

--- a/src/components/home/HomeApp.tsx
+++ b/src/components/home/HomeApp.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { LoadingSpinner } from '@/components/ui';
+import { useAuth } from '@/contexts/AuthContext';
+import { DashboardContent } from '@/components/dashboard/DashboardContent';
+import { SplashPage } from '@/components/splash/SplashPage';
+
+/**
+ * Client-side home gate. Rendered by the `/` server component whenever an auth
+ * session exists or might exist (valid or expired token). Resolves the user's
+ * profile and shows the dashboard; falls back to the splash only if the client
+ * ultimately resolves to logged-out (e.g. a revoked refresh token).
+ */
+export function HomeApp() {
+  const { profile, authStatus } = useAuth();
+
+  if (profile) {
+    return <DashboardContent />;
+  }
+
+  if (authStatus === 'loading') {
+    return (
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  return <SplashPage />;
+}

--- a/src/components/splash/FloatingDice.tsx
+++ b/src/components/splash/FloatingDice.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { Dice1, Dice2, Dice3, Dice4, Dice5, Dice6 } from 'lucide-react';
+
+// ─── Dice configuration ─────────────────────────────────────────────────────
+
+const DICE_ICONS = [Dice1, Dice2, Dice3, Dice4, Dice5, Dice6];
+
+const DICE_COUNT_DESKTOP = 100;
+const DICE_COUNT_MOBILE = 42;
+
+// Seeded PRNG for deterministic layout across renders
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface GeneratedDie {
+  face: number;
+  size: number;
+  opacity: number;
+  duration: number;
+  delay: number;
+  rotate: number;
+  x: number; // 0-100 percentage
+  y: number; // 0-100 percentage
+}
+
+function generateDice(count: number, seed: number): GeneratedDie[] {
+  const rand = mulberry32(seed);
+  const dice: GeneratedDie[] = [];
+
+  for (let i = 0; i < count; i++) {
+    dice.push({
+      face: Math.floor(rand() * 6),
+      size: Math.round(16 + rand() * 24), // 16-40px
+      opacity: 0.04 + rand() * 0.1, // 0.04-0.14
+      duration: 5 + rand() * 5, // 5-10s
+      delay: rand() * 8, // 0-8s
+      rotate: Math.round(-45 + rand() * 90), // -45 to 45 degrees
+      x: rand() * 100, // 0-100%
+      y: rand() * 100, // 0-100%
+    });
+  }
+
+  return dice;
+}
+
+const DICE_DESKTOP = generateDice(DICE_COUNT_DESKTOP, 42);
+const DICE_MOBILE = generateDice(DICE_COUNT_MOBILE, 9);
+
+function DiceField({ dice, className }: { dice: GeneratedDie[]; className?: string }) {
+  return (
+    <div className={`absolute inset-0 overflow-hidden pointer-events-none ${className ?? ''}`}>
+      {dice.map((die, i) => {
+        const Icon = DICE_ICONS[die.face];
+        return (
+          <div
+            key={i}
+            className="absolute"
+            style={{
+              left: `${die.x}%`,
+              top: `${die.y}%`,
+              transform: `rotate(${die.rotate}deg)`,
+            }}
+          >
+            <Icon
+              className="dice-filled animate-[float_6s_ease-in-out_infinite]"
+              style={{
+                color: `color-mix(in srgb, var(--primary) ${Math.round(die.opacity * 100)}%, transparent)`,
+                animationDuration: `${die.duration}s`,
+                animationDelay: `${die.delay}s`,
+              }}
+              size={die.size}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Stable no-op subscription: the hydration snapshot never changes after mount.
+const emptySubscribe = () => () => {};
+
+/**
+ * Returns false during SSR and the first hydration render, true afterward.
+ * Implemented with useSyncExternalStore (server snapshot = false, client snapshot
+ * = true) rather than a useState/useEffect mount flag, so it is hydration-safe AND
+ * avoids setting state in an effect (react-hooks/set-state-in-effect).
+ */
+function useHydrated() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+}
+
+/**
+ * Decorative floating-dice background for the hero. Rendered client-only: returns
+ * null until hydrated, so the (purely decorative) dice never appear in the
+ * server-rendered HTML — keeping the raw `/` response small. Server and first
+ * client render both produce null (no hydration mismatch); the dice fade in after
+ * mount.
+ */
+export function FloatingDice() {
+  const hydrated = useHydrated();
+
+  if (!hydrated) return null;
+
+  return (
+    <>
+      <DiceField dice={DICE_DESKTOP} className="hidden sm:block" />
+      <DiceField dice={DICE_MOBILE} className="sm:hidden" />
+    </>
+  );
+}

--- a/src/components/splash/SplashPage.tsx
+++ b/src/components/splash/SplashPage.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import Image from 'next/image';
 import {

--- a/src/components/splash/SplashPage.tsx
+++ b/src/components/splash/SplashPage.tsx
@@ -44,8 +44,8 @@ function HeroSection() {
           Track availability. Find the best night. Play more games.
         </p>
         <p className="text-sm sm:text-base text-muted-foreground mb-8 max-w-xl mx-auto">
-          A free tool for organizing recurring get-togethers &mdash; game nights, TTRPG
-          campaigns (D&amp;D, Pathfinder, and more), board game meetups, or any group that
+          A free tool for organizing recurring get-togethers, such as game nights, TTRPG
+          campaigns (D&amp;D, Daggerheart, etc.), board game nights, or any group that
           needs to find a date that works for everyone.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
@@ -70,15 +70,15 @@ function WhySection() {
     <div className="py-16 sm:py-24 bg-background">
       <div className="max-w-3xl mx-auto px-4 text-center">
         <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-6">
-          Scheduling, without the group-chat chaos
+          Scheduling, without the endless back-and-forth
         </h2>
         <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed">
           Finding a night when everyone&apos;s free is the hardest part of keeping a regular game
-          going. Can We Play? replaces the endless &ldquo;what about Thursday?&rdquo; messages:
-          each person marks the dates they can make, and the app highlights the nights that work
-          for the whole group. Whether you&apos;re running a long D&amp;D or Pathfinder campaign,
+          going. Can We Play? replaces lengthy message threads with a simple interface:
+          each person marks the dates they can make, and the app highlights the days that work
+          for the most people. Whether you&apos;re running a long D&amp;D or Pathfinder campaign,
           hosting a board game night, or organizing any recurring meetup, you can confirm a date
-          and export it straight to your calendar &mdash; free, no sign-up friction.
+          and export it straight to everyone&apos;s calendar. It&apos;s easy, ad-free, and costs nothing. Get playing!
         </p>
       </div>
     </div>
@@ -110,8 +110,8 @@ function HowItWorksSection() {
           <Step
             num={3}
             icon={<CalendarSearch className="size-6" />}
-            title="Book game nights"
-            desc="See which dates work best for the whole group and confirm sessions."
+            title="Book sessions"
+            desc="See which dates work best for the whole group and schedule in the shared calendar."
           />
         </div>
       </div>

--- a/src/components/splash/SplashPage.tsx
+++ b/src/components/splash/SplashPage.tsx
@@ -17,6 +17,7 @@ export function SplashPage() {
   return (
     <div className="min-h-[calc(100vh-4rem)]">
       <HeroSection />
+      <WhySection />
       <HowItWorksSection />
       <FeaturesSection />
     </div>
@@ -39,8 +40,13 @@ function HeroSection() {
           priority
         />
         <h1 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Can We Play?</h1>
-        <p className="text-lg sm:text-xl text-muted-foreground mb-8 max-w-lg mx-auto">
+        <p className="text-lg sm:text-xl text-muted-foreground mb-4 max-w-lg mx-auto">
           Track availability. Find the best night. Play more games.
+        </p>
+        <p className="text-sm sm:text-base text-muted-foreground mb-8 max-w-xl mx-auto">
+          A free tool for organizing recurring get-togethers &mdash; game nights, TTRPG
+          campaigns (D&amp;D, Pathfinder, and more), board game meetups, or any group that
+          needs to find a date that works for everyone.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <Link href="/login">
@@ -52,6 +58,28 @@ function HeroSection() {
             </Button>
           </Link>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Why ────────────────────────────────────────────────────────────────────
+
+function WhySection() {
+  return (
+    <div className="py-16 sm:py-24 bg-background">
+      <div className="max-w-3xl mx-auto px-4 text-center">
+        <h2 className="text-2xl sm:text-3xl font-bold text-foreground mb-6">
+          Scheduling, without the group-chat chaos
+        </h2>
+        <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+          Finding a night when everyone&apos;s free is the hardest part of keeping a regular game
+          going. Can We Play? replaces the endless &ldquo;what about Thursday?&rdquo; messages:
+          each person marks the dates they can make, and the app highlights the nights that work
+          for the whole group. Whether you&apos;re running a long D&amp;D or Pathfinder campaign,
+          hosting a board game night, or organizing any recurring meetup, you can confirm a date
+          and export it straight to your calendar &mdash; free, no sign-up friction.
+        </p>
       </div>
     </div>
   );

--- a/src/components/splash/SplashPage.tsx
+++ b/src/components/splash/SplashPage.tsx
@@ -7,66 +7,9 @@ import {
   Users,
   Layers,
   Shield,
-  Dice1,
-  Dice2,
-  Dice3,
-  Dice4,
-  Dice5,
-  Dice6,
 } from 'lucide-react';
 import { Button, EyebrowLabel } from '@/components/ui';
-
-// ─── Dice configuration ─────────────────────────────────────────────────────
-
-const DICE_ICONS = [Dice1, Dice2, Dice3, Dice4, Dice5, Dice6];
-
-const DICE_COUNT_DESKTOP = 100;
-const DICE_COUNT_MOBILE = 42;
-
-// Seeded PRNG for deterministic layout across renders
-function mulberry32(seed: number) {
-  return () => {
-    seed |= 0;
-    seed = (seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-interface GeneratedDie {
-  face: number;
-  size: number;
-  opacity: number;
-  duration: number;
-  delay: number;
-  rotate: number;
-  x: number; // 0-100 percentage
-  y: number; // 0-100 percentage
-}
-
-function generateDice(count: number, seed: number): GeneratedDie[] {
-  const rand = mulberry32(seed);
-  const dice: GeneratedDie[] = [];
-
-  for (let i = 0; i < count; i++) {
-    dice.push({
-      face: Math.floor(rand() * 6),
-      size: Math.round(16 + rand() * 24), // 16-40px
-      opacity: 0.04 + rand() * 0.1, // 0.04-0.14
-      duration: 5 + rand() * 5, // 5-10s
-      delay: rand() * 8, // 0-8s
-      rotate: Math.round(-45 + rand() * 90), // -45 to 45 degrees
-      x: rand() * 100, // 0-100%
-      y: rand() * 100, // 0-100%
-    });
-  }
-
-  return dice;
-}
-
-const DICE_DESKTOP = generateDice(DICE_COUNT_DESKTOP, 42);
-const DICE_MOBILE = generateDice(DICE_COUNT_MOBILE, 9);
+import { FloatingDice } from './FloatingDice';
 
 // ─── Main component ─────────────────────────────────────────────────────────
 
@@ -111,46 +54,6 @@ function HeroSection() {
         </div>
       </div>
     </div>
-  );
-}
-
-function DiceField({ dice, className }: { dice: GeneratedDie[]; className?: string }) {
-  return (
-    <div className={`absolute inset-0 overflow-hidden pointer-events-none ${className ?? ''}`}>
-      {dice.map((die, i) => {
-        const Icon = DICE_ICONS[die.face];
-        return (
-          <div
-            key={i}
-            className="absolute"
-            style={{
-              left: `${die.x}%`,
-              top: `${die.y}%`,
-              transform: `rotate(${die.rotate}deg)`,
-            }}
-          >
-            <Icon
-              className="dice-filled animate-[float_6s_ease-in-out_infinite]"
-              style={{
-                color: `color-mix(in srgb, var(--primary) ${Math.round(die.opacity * 100)}%, transparent)`,
-                animationDuration: `${die.duration}s`,
-                animationDelay: `${die.delay}s`,
-              }}
-              size={die.size}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function FloatingDice() {
-  return (
-    <>
-      <DiceField dice={DICE_DESKTOP} className="hidden sm:block" />
-      <DiceField dice={DICE_MOBILE} className="sm:hidden" />
-    </>
   );
 }
 

--- a/src/lib/homeView.test.ts
+++ b/src/lib/homeView.test.ts
@@ -17,4 +17,8 @@ describe('chooseHomeView', () => {
   it("returns 'splash' when data is present but has no claims and no error", () => {
     expect(chooseHomeView({ data: {}, error: null })).toBe('splash');
   });
+
+  it("returns 'splash' when data.claims is null and there is no error", () => {
+    expect(chooseHomeView({ data: { claims: null }, error: null })).toBe('splash');
+  });
 });

--- a/src/lib/homeView.test.ts
+++ b/src/lib/homeView.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { chooseHomeView } from './homeView';
+
+describe('chooseHomeView', () => {
+  it("returns 'app' for a valid session (claims present)", () => {
+    expect(chooseHomeView({ data: { claims: { sub: 'user-1' } }, error: null })).toBe('app');
+  });
+
+  it("returns 'app' for an expired/invalid token (error present)", () => {
+    expect(chooseHomeView({ data: null, error: { message: 'jwt expired' } })).toBe('app');
+  });
+
+  it("returns 'splash' when there is no session (data null, error null)", () => {
+    expect(chooseHomeView({ data: null, error: null })).toBe('splash');
+  });
+
+  it("returns 'splash' when data is present but has no claims and no error", () => {
+    expect(chooseHomeView({ data: {}, error: null })).toBe('splash');
+  });
+});

--- a/src/lib/homeView.ts
+++ b/src/lib/homeView.ts
@@ -1,0 +1,24 @@
+/**
+ * Decides which view the home route (`/`) should render, based on the result
+ * of `supabase.auth.getClaims()` read server-side.
+ *
+ * - Valid session  → getClaims returns { data: { claims }, error: null }   → 'app'
+ * - Expired/invalid → getClaims returns { data: null, error: <AuthError> } → 'app'
+ * - No session      → getClaims returns { data: null, error: null }        → 'splash'
+ *
+ * We only render the public splash when there is positively no session, so a
+ * returning user whose access token has expired is never flashed the marketing
+ * page (the client resolves their session and shows the dashboard). Crawlers
+ * send no auth cookie and therefore always land on 'splash'.
+ */
+export type HomeView = 'splash' | 'app';
+
+interface ClaimsResult {
+  data: { claims?: unknown } | null;
+  error: unknown;
+}
+
+export function chooseHomeView(result: ClaimsResult): HomeView {
+  const hasClaims = !!result.data?.claims;
+  return hasClaims || result.error ? 'app' : 'splash';
+}


### PR DESCRIPTION
## Summary

Three related changes that make the landing page discoverable by search engines and AI answer engines, then keep the response lean and content-rich:

1. **Server-render `/` for logged-out visitors.** `page.tsx` is now an async server component that reads the auth session via `getClaims()` and branches: no session → server-rendered `SplashPage` (every crawler lands here); valid/expired session → the client `HomeApp` gate (dashboard inline at `/`, unchanged). Previously the page was client-rendered, so crawlers received only a loading spinner.
2. **Decorative dice are client-only.** The ~142 floating-dice SVGs were ~87% of the response. `FloatingDice` now renders after hydration (via `useSyncExternalStore`), so they never appear in the server HTML — production `/` dropped to ~31KB (from hundreds of KB), with zero visual change.
3. **Discoverable content.** Added a descriptive, keyword-bearing hero line and a "why" section so the page actually states what it's for (game nights, TTRPG/D&D/Pathfinder campaigns, board game nights, any recurring meetup) — roughly tripling the real word count.

## Key implementation notes

- `chooseHomeView()` is a pure helper isolating the three-way auth branch (unit-tested without rendering RSCs).
- The home route is `export const dynamic = 'force-dynamic'` (it reads cookies) with a logged fail-safe toward the authenticated path.
- `SplashPage` is a shared component (no `'use client'`), renderable on both server and client.

## Testing

- **Unit:** `chooseHomeView` branch logic (458 unit tests pass overall).
- **E2E (`e2e/tests/home/`):**
  - Raw cookie-less GET of `/` asserts the marketing copy is in the server HTML (tag-delimited, so it fails if SSR ever regresses to client-only) — the actual SEO guarantee.
  - Authenticated user still gets the dashboard inline at `/`.
  - No `lucide-dice` in the server response; dice appear after hydration.
  - SEO keywords (`TTRPG`, `Pathfinder`, `board game`) present in server HTML.
  - Response-size backstop (dev `next dev` output, calibrated to ~150KB to catch mass-element regressions).
- Validated visually on desktop and mobile.

## Notes

- `NEXT_PUBLIC_APP_URL` confirmed set in production.
- Still open as follow-ups (not in this PR): FAQ section + `FAQPage` JSON-LD, footer, `SoftwareApplication`/`WebSite` JSON-LD, homepage canonical, title/description tuning.