### PR TITLE
Harden game-join: close two critical membership RLS holes

### DIFF
--- a/docs/security/2026-06-10-membership-rls-audit.md
+++ b/docs/security/2026-06-10-membership-rls-audit.md
@@ -1,0 +1,195 @@
+# Membership RLS Security Audit & Fix — 2026-06-10
+
+**Status:** Fixed in `schema.sql` + app code. Production DB needs the migration in §7.
+**Scope of this doc:** The two **critical** holes in the game-membership model — how they
+were found, how they were *verified* (including a false-pass that nearly hid one), the fix,
+and what remains open. Written so another session can review the reasoning end-to-end.
+
+---
+
+## 1. Risk model (why RLS is load-bearing)
+
+The browser talks to Postgres **directly** with the Supabase anon key
+(`supabase.from(...).insert(...)` runs client-side). There is no API tier in front of most
+writes. Therefore **RLS is the entire authorization layer** for client traffic — a policy
+that fails to forbid something *is* the vulnerability, because the attacker writes their own
+request and is not limited to what the UI sends.
+
+The weakest trust boundary in the app is **player → co-GM/GM**. Co-GM grants the power to edit
+the game, add/delete sessions, add play dates, and remove other (non-co-GM) members. The two
+critical findings both let an ordinary authenticated user cross that boundary.
+
+Relevant tables: `games` (owner = `gm_id`), `game_memberships` (`user_id`, `is_co_gm`),
+joined via an `invite_code` (nanoid-10, ~60 bits) that lives on `games`.
+
+---
+
+## 2. Critical finding A — co-GM privilege escalation on join
+
+**Where:** `supabase/schema.sql`, policy `"Users can join games"` (pre-fix):
+
+```sql
+CREATE POLICY "Users can join games" ON game_memberships
+  FOR INSERT WITH CHECK (
+    (select auth.uid()) = user_id
+    AND public.count_game_players(game_id) < 50
+  );
+```
+
+The `WITH CHECK` constrains *who* (`user_id = auth.uid()`) and *capacity* — but **nothing
+constrains `is_co_gm`**, and there is no INSERT trigger to reset it. So a crafted insert:
+
+```js
+supabase.from('game_memberships').insert({ game_id, user_id: myUid, is_co_gm: true })
+```
+
+makes the caller an instant co-GM of any game whose `game_id` they know. `is_co_gm` is only
+ever *meant* to be set by the GM via UPDATE (`toggleCoGm`), but the INSERT path let the client
+set it directly.
+
+---
+
+## 3. Critical finding B — no invite-code enforcement on join
+
+**Where:** same policy. The invite code is verified in exactly one place —
+`src/app/api/games/invite/[code]/route.ts` — but that route is a **display lookup** (code →
+game preview) for the join page. The actual write is a **separate** anon-key insert
+(`joinGame` → `src/lib/data/memberships.ts`) that never sees the code. RLS, the only check on
+that write, requires only `auth.uid() = user_id` and capacity.
+
+**Consequence:** any authenticated user who learns a game's UUID — which appears in every
+`/games/[id]` URL a member ever opened — can join uninvited. Combined with Finding A, a bare
+`game_id` is enough to seize co-GM control of a stranger's game.
+
+The structural root cause: a *row-level* INSERT policy was the wrong tool. The secret it needed
+to check (`invite_code`) lives on a **different table** (`games`), and a column it needed to
+constrain (`is_co_gm`) is **client-supplied**. RLS guards rows; it cannot express "look up a
+secret on another table and decide every column server-side."
+
+---
+
+## 4. Verification — and the false-pass that almost hid Finding A
+
+The first regression tests **passed when they should have failed** — a worse outcome than no
+test. Root-causing that (instead of trusting green) was the crux of the audit:
+
+1. **Symptom:** a direct membership insert via the existing `supabaseRestCall` helper returned
+   `403 / 42501 "new row violates row-level security policy"`, so no row appeared and the
+   "attacker is not a member" assertion passed.
+2. **Ruled out auth:** a throwaway `whoami()` RPC and a `debug_join_check()` RPC proved that at
+   REST time `auth.uid() = attacker.id`, `current_user = authenticated`, `count_players = 1`.
+   Every `WITH CHECK` input was satisfied — yet the insert was rejected.
+3. **psql ground truth:** simulating PostgREST's context (`SET ROLE authenticated` + injected
+   `request.jwt.claims`), the self-insert **succeeded**, and a **negative control**
+   (`user_id ≠ auth.uid()`) was correctly rejected — proving RLS *was* enforced and the policy
+   genuinely *allows* the non-member self-insert. The vulnerability is real.
+4. **The discriminator:** the same REST insert with `Prefer: return=minimal` → **201, row
+   created**; with `Prefer: return=representation` → **403 + rollback**.
+
+**Root cause of the false-pass:** `return=representation` makes PostgREST run a post-insert
+visibility SELECT. The `game_memberships` SELECT policy (`is_game_participant`) depends on the
+row *just inserted*, which the `SECURITY DEFINER` lookup can't see in that snapshot, so the
+representation SELECT fails and **rolls the insert back**. The shared helper hardcodes
+`return=representation`; the real app's `joinGame` uses `.insert()` with **no `.select()`**
+(`return=minimal`), which is why production joins — and the attack — actually succeed.
+
+**Fix to the test:** perform the attack with `return=minimal` (faithful to the real join path).
+The tests then fail red for the right reason (attacker becomes co-GM / member), and go green
+after the fix.
+
+---
+
+## 5. The fix
+
+**Strategy:** remove the direct INSERT policy entirely and funnel all joins through a
+`SECURITY DEFINER` RPC. With no permissive INSERT policy, authenticated users cannot
+self-insert at all — closing **both** A and B at once.
+
+- **New RPC** `public.join_game_by_invite(invite_code_param TEXT)` (`schema.sql`): resolves the
+  game **by invite code**, rejects unknown codes (`P0002`) and full games (`P0001`), no-ops for
+  the GM, and inserts the membership with `is_co_gm = FALSE` hard-coded. `SECURITY DEFINER` +
+  `SET search_path = ''`; `EXECUTE` revoked from `PUBLIC`, granted to `authenticated`.
+- **Removed** the `"Users can join games"` INSERT policy (replaced by an explanatory comment).
+- **App:** `joinGame(supabase, inviteCode)` now calls the RPC; `join/[code]/page.tsx` passes the
+  invite `code` and maps `P0001`/`P0002` to user-facing messages.
+
+**Why nothing legitimate breaks:** joins → RPC (definer, bypasses RLS); co-GM promotion →
+GM-only UPDATE; account-deletion transfers & test seeding → service-role client (bypasses RLS);
+GM game-creation never inserts a membership. `is_co_gm` can now only become true via the GM's
+UPDATE, governed by `"GMs can update memberships"`.
+
+---
+
+## 6. Test status
+
+New spec: `e2e/tests/rls/critical-security.spec.ts`
+
+- 3 attack tests (co-GM self-grant; join-by-id without code; direct rejoin-after-kick) — red
+  before the fix, **green** after (all three blocked).
+- 2 RPC tests — valid code joins as a regular player (`is_co_gm = false`); invalid code joins
+  nothing.
+
+Regression: `games/join-game`, `dashboard/games`, `rls/policy-enforcement`, `rls/rls-hardening`
+= **35 passed** (UI join flow works through the RPC). `npm run lint` ✅ · `npm run build` ✅.
+
+Reproduce: `npm run db:start` then
+`npx playwright test e2e/tests/rls/critical-security.spec.ts --project=chromium`.
+
+---
+
+## 7. Production deployment (required)
+
+`schema.sql` covers fresh installs and the CI/local DB (reset from it). The **existing
+production DB** needs a one-off migration (per `CLAUDE.md`, not committed beside the schema
+change). Deploy it **together with** the app code — they are coupled; after the policy drop the
+old direct-insert join path stops working.
+
+```sql
+DROP POLICY IF EXISTS "Users can join games" ON public.game_memberships;
+
+CREATE OR REPLACE FUNCTION public.join_game_by_invite(invite_code_param TEXT)
+RETURNS UUID AS $$
+DECLARE v_uid UUID := (SELECT auth.uid()); v_game_id UUID; v_gm_id UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000'; END IF;
+  SELECT id, gm_id INTO v_game_id, v_gm_id FROM public.games WHERE invite_code = invite_code_param;
+  IF v_game_id IS NULL THEN RAISE EXCEPTION 'Invalid invite code' USING ERRCODE = 'P0002'; END IF;
+  IF v_gm_id = v_uid THEN RETURN v_game_id; END IF;
+  IF public.count_game_players(v_game_id) >= 50 THEN RAISE EXCEPTION 'Game is full' USING ERRCODE = 'P0001'; END IF;
+  INSERT INTO public.game_memberships (game_id, user_id, is_co_gm)
+  VALUES (v_game_id, v_uid, FALSE) ON CONFLICT (game_id, user_id) DO NOTHING;
+  RETURN v_game_id;
+END; $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+
+REVOKE EXECUTE ON FUNCTION public.join_game_by_invite(TEXT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.join_game_by_invite(TEXT) TO authenticated;
+```
+
+---
+
+## 8. Still open (from the same audit, NOT addressed here)
+
+A reviewer should know these were found but deliberately left for follow-up:
+
+- **Missing `WITH CHECK` on UPDATE policies** for `sessions`, `availability`, `games` — lets
+  GM/co-GM/users mutate `game_id`/`confirmed_by`/`invite_code` they shouldn't. Fix pattern:
+  column-freeze triggers.
+- **Helper functions are `EXECUTE`-to-PUBLIC** (`count_game_players`, `is_game_participant`,
+  etc.) — count/membership oracles callable by anon via RPC. Revoke + grant to `authenticated`.
+- **`users.email` visible to all co-participants** via `shares_game_with`.
+- **Calendar feed keyed by the invite code** (`api/games/calendar/[code]`) leaks session
+  `location`/`notes` to anyone who ever saw an invite link; decouple to a rotatable token.
+- **`/api/test-auth`** gated only on `NODE_ENV`; add the `isLocalSupabase()` check and stop
+  committing `TEST_AUTH_SECRET`.
+
+---
+
+## 9. Reviewer checklist
+
+- [ ] Confirm no remaining authenticated INSERT path into `game_memberships` other than the RPC
+      (`grep "game_memberships" src | grep insert`).
+- [ ] Confirm the RPC forces `is_co_gm = FALSE` and resolves by `invite_code`, not `game_id`.
+- [ ] Confirm `EXECUTE` on the RPC is `authenticated`-only (not `PUBLIC`/`anon`).
+- [ ] Confirm the attack tests use `return=minimal` (else they false-pass — see §4).
+- [ ] Confirm the production migration in §7 is scheduled with the app deploy.
+```

--- a/e2e/tests/rls/critical-security.spec.ts
+++ b/e2e/tests/rls/critical-security.spec.ts
@@ -1,0 +1,352 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame, addPlayerToGame, getAdminClient } from '../../helpers/seed';
+
+// Local Supabase credentials (same legacy demo anon key used by the other RLS specs)
+const SUPABASE_URL = 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+/**
+ * CRITICAL security regression tests (from the RLS audit).
+ *
+ * These two findings are the highest-severity holes in the membership model.
+ * Both are exploited the same way: the browser talks to PostgREST directly with
+ * the anon key, so RLS is the ONLY authorization layer on writes. The membership
+ * INSERT policy (schema.sql "Users can join games") checks only
+ *   auth.uid() = user_id  AND  count_game_players(game_id) < 50
+ * and therefore:
+ *
+ *   A. Co-GM privilege escalation — nothing constrains `is_co_gm`, so a user can
+ *      self-insert a membership with `is_co_gm: true` and instantly become a co-GM
+ *      of any game whose id they know.
+ *   B. Missing invite-code enforcement — the invite code is verified only in the
+ *      /api/games/invite/[code] preview route (a display lookup); the actual write
+ *      is a separate anon-key insert that never sees the code. Any authenticated
+ *      user who learns a game's UUID (it appears in every /games/[id] URL) can join.
+ *
+ * STATUS: These assert the *desired secure* behavior, so they are expected to FAIL
+ * (red) against the current schema — that failure IS the proof of the vulnerability.
+ * They turn green once the membership INSERT path is hardened (constrain is_co_gm to
+ * false; route joins through an invite-code-checking SECURITY DEFINER RPC and revoke
+ * the direct INSERT).
+ *
+ * IMPORTANT — why `Prefer: return=minimal`:
+ * The attack insert is performed with `return=minimal`, exactly as the app's own
+ * `joinGame()` does (`supabase.from('game_memberships').insert({...})` with no
+ * `.select()`). The shared `supabaseRestCall` helper used elsewhere sends
+ * `return=representation`, which makes PostgREST run a post-insert visibility SELECT.
+ * For a brand-new self-join row, that SELECT fails its own `is_game_participant`
+ * policy (the row isn't visible to the SECURITY DEFINER lookup yet) and rolls the
+ * insert back — which would mask this vulnerability behind a misleading 403. Minimal
+ * return faithfully reproduces the real, successful join path.
+ */
+
+/**
+ * Perform an authenticated INSERT via the anon-key REST API with
+ * `Prefer: return=minimal` — the same request shape the shipped client bundle
+ * issues for a join. Returns the HTTP status only (no body on minimal return).
+ */
+async function authedInsertMinimal(
+  page: import('@playwright/test').Page,
+  table: string,
+  row: Record<string, unknown>
+): Promise<number> {
+  return page.evaluate(
+    async ({ url, anonKey, table, row }) => {
+      const cookies = document.cookie.split(';').map((c) => c.trim());
+      const authCookies = cookies.filter((c) => c.includes('auth-token')).sort();
+      let raw = '';
+      for (const c of authCookies) raw += decodeURIComponent(c.split('=').slice(1).join('='));
+      const tokenJson = raw.startsWith('base64-') ? atob(raw.slice('base64-'.length)) : raw;
+      const parsed = JSON.parse(tokenJson);
+      const accessToken = parsed.access_token || (Array.isArray(parsed) ? parsed[0] : '');
+      if (!accessToken) throw new Error('No access token found in cookies');
+
+      const response = await fetch(`${url}/rest/v1/${table}`, {
+        method: 'POST',
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        },
+        body: JSON.stringify(row),
+      });
+      return response.status;
+    },
+    { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY, table, row }
+  );
+}
+
+/**
+ * Call a PostgREST RPC as the authenticated browser user. Returns status + body.
+ */
+async function authedRpc(
+  page: import('@playwright/test').Page,
+  fn: string,
+  args: Record<string, unknown>
+): Promise<{ status: number; data: unknown }> {
+  return page.evaluate(
+    async ({ url, anonKey, fn, args }) => {
+      const cookies = document.cookie.split(';').map((c) => c.trim());
+      const authCookies = cookies.filter((c) => c.includes('auth-token')).sort();
+      let raw = '';
+      for (const c of authCookies) raw += decodeURIComponent(c.split('=').slice(1).join('='));
+      const tokenJson = raw.startsWith('base64-') ? atob(raw.slice('base64-'.length)) : raw;
+      const parsed = JSON.parse(tokenJson);
+      const accessToken = parsed.access_token || (Array.isArray(parsed) ? parsed[0] : '');
+      if (!accessToken) throw new Error('No access token found in cookies');
+
+      const response = await fetch(`${url}/rest/v1/rpc/${fn}`, {
+        method: 'POST',
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(args),
+      });
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch {
+        data = null;
+      }
+      return { status: response.status, data };
+    },
+    { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY, fn, args }
+  );
+}
+
+test.describe('CRITICAL: co-GM privilege escalation on join', () => {
+  test('a joining user cannot grant themselves co-GM via the membership insert', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+
+    // Victim GM owns a game (set up via admin, bypassing RLS).
+    const gm = await createTestUser(request, {
+      email: `victim-gm-cogm-${ts}@e2e.local`,
+      name: 'Victim GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Co-GM Escalation Target',
+      play_days: [5, 6],
+    });
+
+    // Attacker: an ordinary authenticated user who is NOT a member.
+    const attacker = await createTestUser(request, {
+      email: `attacker-cogm-${ts}@e2e.local`,
+      name: 'Co-GM Attacker',
+      is_gm: true,
+    });
+    await loginTestUser(page, {
+      email: attacker.email,
+      name: attacker.name,
+      is_gm: true,
+    });
+
+    // Self-insert a membership with is_co_gm: true, exactly as a crafted join would.
+    await authedInsertMinimal(page, 'game_memberships', {
+      game_id: game.id,
+      user_id: attacker.id,
+      is_co_gm: true,
+    });
+
+    // SECURITY INVARIANT (fix-agnostic): the attacker must never end up as a co-GM
+    // of a game they don't own — whether the fix rejects the insert outright or
+    // forces is_co_gm to false, the DB must not show them as co-GM.
+    const admin = getAdminClient();
+    const { data: rows } = await admin
+      .from('game_memberships')
+      .select('is_co_gm')
+      .eq('game_id', game.id)
+      .eq('user_id', attacker.id);
+
+    const grantedCoGm = (rows ?? []).some((r) => r.is_co_gm === true);
+    expect(grantedCoGm).toBe(false);
+  });
+});
+
+test.describe('CRITICAL: missing invite-code enforcement on join', () => {
+  test('an authenticated user cannot join a game by its id without the invite code', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+
+    // Victim GM owns a game. The attacker only ever learns the game UUID
+    // (e.g. leaked from a /games/[id] URL) — never the invite code.
+    const gm = await createTestUser(request, {
+      email: `victim-gm-join-${ts}@e2e.local`,
+      name: 'Victim GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Private Game',
+      play_days: [5, 6],
+    });
+
+    const attacker = await createTestUser(request, {
+      email: `attacker-join-${ts}@e2e.local`,
+      name: 'Uninvited Attacker',
+      is_gm: true,
+    });
+    await loginTestUser(page, {
+      email: attacker.email,
+      name: attacker.name,
+      is_gm: true,
+    });
+
+    // Direct self-insert keyed only by the known game_id — no invite code presented.
+    await authedInsertMinimal(page, 'game_memberships', {
+      game_id: game.id,
+      user_id: attacker.id,
+    });
+
+    // SECURITY INVARIANT: knowing the game's UUID is not sufficient to join it.
+    const admin = getAdminClient();
+    const { data: rows } = await admin
+      .from('game_memberships')
+      .select('user_id')
+      .eq('game_id', game.id)
+      .eq('user_id', attacker.id);
+
+    expect(rows ?? []).toHaveLength(0);
+  });
+
+  test('a removed player cannot silently rejoin via a direct membership insert', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+
+    const gm = await createTestUser(request, {
+      email: `gm-rejoin-${ts}@e2e.local`,
+      name: 'Rejoin GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Rejoin Target Game',
+      play_days: [5, 6],
+    });
+
+    // Player joins, then is removed by the GM (both via admin setup).
+    const player = await createTestUser(request, {
+      email: `removed-player-${ts}@e2e.local`,
+      name: 'Removed Player',
+      is_gm: false,
+    });
+    await addPlayerToGame(game.id, player.id);
+
+    const admin = getAdminClient();
+    await admin
+      .from('game_memberships')
+      .delete()
+      .eq('game_id', game.id)
+      .eq('user_id', player.id);
+
+    // The removed player still knows the game_id and tries to re-insert directly.
+    await loginTestUser(page, {
+      email: player.email,
+      name: player.name,
+      is_gm: false,
+    });
+
+    await authedInsertMinimal(page, 'game_memberships', {
+      game_id: game.id,
+      user_id: player.id,
+    });
+
+    // SECURITY INVARIANT: a removed player must not regain membership through an
+    // unmediated insert that bypasses the invite flow.
+    const { data: rows } = await admin
+      .from('game_memberships')
+      .select('user_id')
+      .eq('game_id', game.id)
+      .eq('user_id', player.id);
+
+    expect(rows ?? []).toHaveLength(0);
+  });
+});
+
+test.describe('join_game_by_invite RPC (the sanctioned join path)', () => {
+  test('a valid invite code joins the caller as a regular player, never co-GM', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+
+    const gm = await createTestUser(request, {
+      email: `gm-rpc-join-${ts}@e2e.local`,
+      name: 'RPC Join GM',
+      is_gm: true,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'RPC Join Game',
+      play_days: [5, 6],
+    });
+
+    const joiner = await createTestUser(request, {
+      email: `joiner-rpc-${ts}@e2e.local`,
+      name: 'Legit Joiner',
+      is_gm: false,
+    });
+    await loginTestUser(page, {
+      email: joiner.email,
+      name: joiner.name,
+      is_gm: false,
+    });
+
+    const res = await authedRpc(page, 'join_game_by_invite', {
+      invite_code_param: game.invite_code,
+    });
+    expect(res.status).toBe(200);
+
+    // The join succeeded and the player is a regular member (not co-GM).
+    const admin = getAdminClient();
+    const { data: rows } = await admin
+      .from('game_memberships')
+      .select('is_co_gm')
+      .eq('game_id', game.id)
+      .eq('user_id', joiner.id);
+
+    expect(rows).toHaveLength(1);
+    expect(rows![0].is_co_gm).toBe(false);
+  });
+
+  test('an invalid invite code joins nothing', async ({ page, request }) => {
+    const ts = Date.now();
+
+    const joiner = await createTestUser(request, {
+      email: `joiner-bad-${ts}@e2e.local`,
+      name: 'Bad Code Joiner',
+      is_gm: false,
+    });
+    await loginTestUser(page, {
+      email: joiner.email,
+      name: joiner.name,
+      is_gm: false,
+    });
+
+    const res = await authedRpc(page, 'join_game_by_invite', {
+      invite_code_param: `nonexistent-code-${ts}`,
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const admin = getAdminClient();
+    const { data: rows } = await admin
+      .from('game_memberships')
+      .select('user_id')
+      .eq('user_id', joiner.id);
+
+    expect(rows ?? []).toHaveLength(0);
+  });
+});

--- a/src/app/games/join/[code]/page.tsx
+++ b/src/app/games/join/[code]/page.tsx
@@ -79,12 +79,16 @@ export default function JoinGamePage() {
 
     setJoining(true);
 
-    const { error: joinError } = await joinGame(supabase, game.id, profile.id);
+    // Join via the invite code (RPC enforces the code, the player cap, and
+    // always joins as a regular player — never co-GM).
+    const { error: joinError } = await joinGame(supabase, code);
 
     if (joinError) {
-      // Check if it's a policy violation (likely player limit exceeded)
-      if (joinError.code === '42501') {
+      // P0001 = game full, P0002 = invalid invite code (see join_game_by_invite).
+      if (joinError.code === 'P0001') {
         setError(`This game is full (${USAGE_LIMITS.MAX_PLAYERS_PER_GAME} players maximum).`);
+      } else if (joinError.code === 'P0002') {
+        setError('This invite link is no longer valid.');
       } else {
         setError('Failed to join game. Please try again.');
       }

--- a/src/lib/data/memberships.ts
+++ b/src/lib/data/memberships.ts
@@ -61,8 +61,15 @@ export async function fetchUserOtherGames(
   return Array.from(gameMap.entries()).map(([id, name]) => ({ id, name }));
 }
 
-export async function joinGame(supabase: SupabaseClient, gameId: string, userId: string) {
-  return supabase.from('game_memberships').insert({ game_id: gameId, user_id: userId });
+/**
+ * Join a game via its invite code. Goes through the join_game_by_invite RPC
+ * (SECURITY DEFINER) rather than a direct game_memberships insert: the database
+ * has no direct INSERT policy, so this is the only sanctioned join path. The RPC
+ * verifies the invite code, enforces the player cap, and always joins as a
+ * regular player (never co-GM). Returns the joined game's id in `data`.
+ */
+export async function joinGame(supabase: SupabaseClient, inviteCode: string) {
+  return supabase.rpc('join_game_by_invite', { invite_code_param: inviteCode });
 }
 
 export async function leaveGame(supabase: SupabaseClient, gameId: string, userId: string) {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -326,6 +326,61 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
 
+-- Join a game using its invite code (the ONLY path for a player to join).
+-- This is the authorization boundary for joining: it verifies the invite code,
+-- enforces the player cap, and always inserts as a regular player (is_co_gm = FALSE).
+-- Routing joins through this function lets us close two critical holes that a direct
+-- INSERT policy could not:
+--   1. The invite code is a column on `games`, not `game_memberships`, so a row-level
+--      INSERT policy can't require it. Here we look the game up BY the code.
+--   2. A direct INSERT lets the client choose `is_co_gm`; here it is hard-coded false.
+-- SECURITY DEFINER (runs as owner, bypassing RLS) because there is no direct INSERT
+-- policy on game_memberships — this function is the only sanctioned insert path.
+CREATE OR REPLACE FUNCTION public.join_game_by_invite(invite_code_param TEXT)
+RETURNS UUID AS $$
+DECLARE
+  v_uid     UUID := (SELECT auth.uid());
+  v_game_id UUID;
+  v_gm_id   UUID;
+BEGIN
+  -- Must be authenticated.
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  -- Resolve the game by its invite code (the secret), not by a guessable id.
+  SELECT id, gm_id INTO v_game_id, v_gm_id
+  FROM public.games
+  WHERE invite_code = invite_code_param;
+
+  IF v_game_id IS NULL THEN
+    RAISE EXCEPTION 'Invalid invite code' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- The GM already owns the game; nothing to do (avoids a phantom membership row).
+  IF v_gm_id = v_uid THEN
+    RETURN v_game_id;
+  END IF;
+
+  -- Enforce the same player cap the old INSERT policy did (members + GM).
+  IF public.count_game_players(v_game_id) >= 50 THEN
+    RAISE EXCEPTION 'Game is full' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Always join as a regular player. Co-GM is granted later by the GM via UPDATE.
+  INSERT INTO public.game_memberships (game_id, user_id, is_co_gm)
+  VALUES (v_game_id, v_uid, FALSE)
+  ON CONFLICT (game_id, user_id) DO NOTHING;
+
+  RETURN v_game_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+
+-- Lock down execution: only signed-in users may call it (anon is rejected anyway,
+-- but don't expose the endpoint). Revoke the default PUBLIC grant first.
+REVOKE EXECUTE ON FUNCTION public.join_game_by_invite(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.join_game_by_invite(TEXT) TO authenticated;
+
 -- ============================================
 -- 5. Triggers
 -- ============================================
@@ -398,11 +453,12 @@ CREATE POLICY "GMs can delete own games" ON games
 -- Game memberships policies (uses helper function to avoid recursion)
 CREATE POLICY "Members can view memberships" ON game_memberships
   FOR SELECT USING (public.is_game_participant(game_id, (select auth.uid())));
-CREATE POLICY "Users can join games" ON game_memberships
-  FOR INSERT WITH CHECK (
-    (select auth.uid()) = user_id
-    AND public.count_game_players(game_id) < 50
-  );
+-- NOTE: There is deliberately NO direct INSERT policy for authenticated users.
+-- A row-level INSERT policy cannot verify the invite code (it lives on `games`,
+-- not `game_memberships`) and cannot stop a client from self-assigning
+-- is_co_gm = TRUE. Both holes are closed by funneling all joins through the
+-- SECURITY DEFINER function public.join_game_by_invite(), which is the only
+-- sanctioned insert path. Service-role/admin operations bypass RLS as usual.
 CREATE POLICY "Users, GMs, or co-GMs can delete memberships" ON game_memberships
   FOR DELETE USING (
     -- User can always remove themselves


### PR DESCRIPTION
## Summary

Closes two **critical** RLS holes in the game-membership model, found during a security audit of the RLS approach. Because the browser talks to Postgres directly with the anon key, RLS is the entire authorization layer for the membership `INSERT`. The old `"Users can join games"` policy checked only `auth.uid() = user_id` and the player cap, which allowed:

- **Co-GM privilege escalation** — a user could self-insert `{ game_id, user_id, is_co_gm: true }` and become co-GM of any game whose id they knew.
- **No invite-code enforcement** — a game's UUID (exposed in every `/games/[id]` URL) was enough to join uninvited; the invite code was only verified in the display-lookup route, never on the write.

## Fix

- Remove the direct `INSERT` policy on `game_memberships` entirely.
- Add `join_game_by_invite()` `SECURITY DEFINER` RPC: resolves the game **by invite code**, enforces the cap, hard-codes `is_co_gm = false`. `EXECUTE` granted to `authenticated` only.
- `joinGame()` and the join page now call the RPC with the invite code.

With no permissive INSERT policy, authenticated users can't self-insert at all — both holes close at once. GM creation never inserts a membership; co-GM promotion stays a GM-only `UPDATE`; admin/service-role ops bypass RLS as before.

## Tests

- New `e2e/tests/rls/critical-security.spec.ts` (5 tests): 3 attack tests (red → green after fix) + 2 RPC tests (valid code joins as a regular player; invalid code joins nothing).
- 35 existing join/RLS e2e tests still pass. `npm run lint` + `npm run build` green.

## ⚠️ Production deployment

`schema.sql` covers fresh installs and the CI/local DB (reset from it). The **existing production DB** needs the one-off migration in `docs/security/2026-06-10-membership-rls-audit.md` (§7), applied **together with** this app code — they're coupled (after the policy drop, the old direct-insert join path stops working).

## Review aid

Full end-to-end reasoning — including a false-pass in the first test attempt and its root cause (`Prefer: return=representation` vs `return=minimal`) — is in `docs/security/2026-06-10-membership-rls-audit.md`.