### PR TITLE
Physics-based d20 rolling and tumbling dice animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,12 @@ RLS uses `auth.uid()` and helper functions (SECURITY DEFINER) like `is_game_part
 - `src/lib/bulkAvailability.ts` - Bulk availability marking logic
 - `src/lib/copyAvailability.ts` - Copy/filter availability entries between games
 - `src/lib/timezone.ts` - Timezone detection, display formatting, and conversion
+- `src/lib/quat.ts` - Dependency-free quaternion/vector math for the 3D dice
+- `src/lib/d20Geometry.ts` - Icosahedron vertices/faces/numbers shared by dice physics and rendering
+- `src/lib/diceConfig.ts` - Die/tray sizing shared by physics and renderer
+- `src/lib/dieRenderer.ts` - Canvas-2D d20 renderer (`D20Renderer`) driven by quaternion poses
+- `src/lib/dicePhysics.ts` - Headless cannon-es d20 roll simulation + playback (lazy-loaded; only the 404 roll needs the physics engine)
+- `src/lib/diceTumble.ts` - Perpetual tumble motion for the loading spinner (no physics engine)
 - `src/lib/themes.ts` - Theme configuration and utilities
 - `src/lib/url.ts` - URL validation (`safeCallbackUrl`) for open-redirect prevention
 - `src/contexts/ThemeContext.tsx` - Theme context (uses next-themes)

--- a/e2e/tests/home/not-found.spec.ts
+++ b/e2e/tests/home/not-found.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('404 page dice roll', () => {
+  test('rolls a physics d20 and shows the matching message', async ({
+    page,
+  }) => {
+    await page.goto('/this-page-does-not-exist');
+
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // The die canvas advertises the rolled number
+    const die = page.locator('canvas[aria-label^="D20 showing"]');
+    await expect(die).toBeVisible();
+    const label = await die.getAttribute('aria-label');
+    const rolled = Number(label?.replace('D20 showing ', ''));
+    expect(rolled).toBeGreaterThanOrEqual(1);
+    expect(rolled).toBeLessThanOrEqual(20);
+
+    // After the roll animation settles, the message names the same number
+    await expect(page.getByText(`You rolled a ${rolled}!`)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+
+  test('a natural 20 erupts in a gold celebration burst', async ({ page }) => {
+    // ?roll=20 forces the crit deterministically
+    await page.goto('/this-page-does-not-exist?roll=20');
+
+    await expect(page.getByText('You rolled a 20!')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // While the burst plays, the canvas holds far more gold than the die's
+    // single gold "20" glyph; after it ends, the gold count drops back
+    const countGold = () =>
+      page.evaluate(() => {
+        const c = document.querySelector(
+          'canvas[aria-label^="D20"]'
+        ) as HTMLCanvasElement;
+        const data = c
+          .getContext('2d')!
+          .getImageData(0, 0, c.width, c.height).data;
+        let gold = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          const [r, g, b, a] = [data[i], data[i + 1], data[i + 2], data[i + 3]];
+          if (a > 50 && r > 180 && g > 120 && b < 120) gold++;
+        }
+        return gold;
+      });
+
+    const duringBurst = await countGold();
+    await page.waitForTimeout(3000); // burst lasts ~2.2s
+    const afterBurst = await countGold();
+
+    expect(duringBurst).toBeGreaterThan(afterBurst * 2);
+  });
+
+  test('Roll Again re-rolls and shows a fresh result', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist');
+
+    await expect(page.getByText(/You rolled a \d+!/)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    await page.getByRole('button', { name: 'Roll Again' }).click();
+
+    // Message clears while the new roll is in flight, then returns
+    await expect(page.getByText(/You rolled a \d+!/)).toBeHidden();
+    await expect(page.getByText(/You rolled a \d+!/)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // The message must match the (possibly new) die label
+    const label = await page
+      .locator('canvas[aria-label^="D20 showing"]')
+      .getAttribute('aria-label');
+    const rolled = Number(label?.replace('D20 showing ', ''));
+    await expect(page.getByText(`You rolled a ${rolled}!`)).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.90.1",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
+        "cannon-es": "^0.20.0",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.563.0",
         "nanoid": "^5.1.6",
@@ -6487,6 +6488,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@supabase/supabase-js": "^2.90.1",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "cannon-es": "^0.20.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.563.0",
     "nanoid": "^5.1.6",

--- a/src/components/NotFoundContent.tsx
+++ b/src/components/NotFoundContent.tsx
@@ -1,43 +1,66 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 
-// Tabletop-themed messages indexed by d20 roll result (1-20)
+// Tabletop-themed messages indexed by d20 roll result (1-20).
+// The tone tracks the roll: low rolls fail embarrassingly, mid rolls fail
+// competently, high rolls almost succeed — but the page never exists.
 const ROLL_MESSAGES: Record<number, string> = {
-  1: 'Critical fail! You wandered into a page that doesn\'t exist.',
-  2: 'You rolled poorly. This page has been banished to another dimension.',
-  3: 'The dungeon master says this page was never written.',
-  4: 'Your navigation check failed. This isn\'t the page you\'re looking for.',
-  5: 'The page you seek has been claimed by a mimic.',
-  6: 'You fell into a pit trap. There\'s no page down here.',
-  7: 'A wandering monster ate this page before you got here.',
-  8: 'Your torch went out. You can\'t find this page in the dark.',
-  9: 'The tavern keeper has no knowledge of this page.',
-  10: 'You reached a dead end in the dungeon. Turn back.',
-  11: 'Not bad, but this page still doesn\'t exist.',
-  12: 'Decent roll, but this page is in another castle.',
-  13: 'Unlucky thirteen. This page has been cursed.',
-  14: 'Close, but the page dodged your attempt to find it.',
-  15: 'Solid roll! Too bad the page made its saving throw.',
-  16: 'Good effort, but this page has resistance to being found.',
-  17: 'Almost heroic, yet the page remains elusive.',
-  18: 'Impressive roll! But even heroes can\'t find pages that don\'t exist.',
-  19: 'So close to a crit! The page was here but just teleported away.',
-  20: 'Natural 20! ...but even a crit can\'t conjure a page from nothing.',
+  1: 'Critical failure. Not only is the page missing, you dropped your torch, and something in the dark just noticed you.',
+  2: 'You trip over your own boots and faceplant in the dungeon. The page was never even here.',
+  3: 'The trail goes cold immediately, you will never find this page ever again',
+  4: 'You search confidently in entirely the wrong direction.',
+  5: 'A goblin watches you hunt for a page that doesn\'t exist. He says nothing.',
+  6: 'You kick over some rubble. No page. Just rubble.',
+  7: 'You found a page! No, wait — that\'s a mimic.',
+  8: 'The map says the page should be right here. The map is wrong.',
+  9: 'You ask around the tavern. Nobody\'s heard of this page, and one patron is pretty sure you made it up.',
+  10: 'A perfectly average roll. The page remains perfectly missing.',
+  11: 'Solid effort. The dungeon is unmoved.',
+  12: 'You search the room thoroughly and find everything except the page.',
+  13: 'Good instincts, wrong dungeon.',
+  14: 'The page dodges. Nimble little thing.',
+  15: 'A strong roll, but the page made its saving throw.',
+  16: 'Impressive. If this page existed, you absolutely would have found it.',
+  17: 'Your tracking is flawless. The trail simply ends at a cliff.',
+  18: 'A heroic effort. The bards will sing of the page you almost found.',
+  19: 'One short of glory. The page was here moments ago — you can still smell the ink.',
+  20: 'Natural 20! Alas, even a critical success can\'t find a page that was never written. Take inspiration as consolation.',
 };
 
+const noopSubscribe = () => () => {};
+
+// ?roll=N forces every roll while present (handy for trying the nat-20
+// celebration, and for tests). Client-only: the die never renders during SSR.
+function nextRoll(): number {
+  if (typeof window !== 'undefined') {
+    const forced = Number(
+      new URLSearchParams(window.location.search).get('roll')
+    );
+    if (Number.isInteger(forced) && forced >= 1 && forced <= 20) {
+      return forced;
+    }
+  }
+  return Math.ceil(Math.random() * 20);
+}
+
 export function NotFoundContent() {
-  const [rollResult, setRollResult] = useState(
-    () => Math.ceil(Math.random() * 20)
+  // The die only renders client-side: rollResult is random, so anything
+  // derived from it in SSR HTML would mismatch on hydration
+  const isClient = useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false
   );
+  const [rollResult, setRollResult] = useState(nextRoll);
   const [rollKey, setRollKey] = useState(0);
   const [showMessage, setShowMessage] = useState(false);
 
   const reroll = useCallback(() => {
     setShowMessage(false);
-    setRollResult(Math.ceil(Math.random() * 20));
+    setRollResult(nextRoll());
     setRollKey((k) => k + 1);
   }, []);
 
@@ -47,21 +70,24 @@ export function NotFoundContent() {
 
   return (
     <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4">
-      <div className="text-center max-w-md">
+      {/* w-full: a definite width so the roll canvas (width:100%) doesn't
+          collapse to its intrinsic size while the message text is hidden */}
+      <div className="w-full max-w-md text-center">
         <h1 className="text-6xl font-bold text-foreground mb-2">404</h1>
         <p className="text-lg text-muted-foreground mb-8">Page not found</p>
 
-        {/* suppressHydrationWarning: random rollResult differs between SSR and client */}
-        <div className="flex justify-center mb-6" suppressHydrationWarning>
-          <LoadingSpinner
-            key={rollKey}
-            size="xl"
-            rollResult={rollResult}
-            onRollComplete={handleRollComplete}
-          />
+        {/* aspect-16/10 reserves the canvas's space before the client roll starts */}
+        <div className="w-full aspect-16/10 mb-6">
+          {isClient && (
+            <LoadingSpinner
+              key={rollKey}
+              rollResult={rollResult}
+              onRollComplete={handleRollComplete}
+            />
+          )}
         </div>
 
-        <div className="min-h-16 mb-8" suppressHydrationWarning>
+        <div className="min-h-16 mb-8">
           {showMessage && (
             <p className="text-muted-foreground animate-in fade-in duration-500">
               <span className="font-semibold text-foreground">

--- a/src/components/ui/LoadingSpinner.tsx
+++ b/src/components/ui/LoadingSpinner.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import {
+  D20Renderer,
+  SPINNER_CAMERA,
+  TRAY_CAMERA,
+  readDieTheme,
+} from '@/lib/dieRenderer';
+import { TumbleDriver } from '@/lib/diceTumble';
+import { CritBurst } from '@/lib/critBurst';
 
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
-  /** When true, shows the crit face (20) facing forward without animation */
-  staticCritFace?: boolean;
-  /** When set (1-20), rolls the die and stops on this number. Numbers appear on all faces. */
+  /** When set (1-20), throws the die with physics and lands on this number. */
   rollResult?: number;
   /** Called when the roll animation finishes (only used with rollResult) */
   onRollComplete?: () => void;
@@ -21,309 +27,15 @@ const sizes = {
   xl: 192,
 };
 
-// Icosahedron geometry using golden ratio
-const PHI = (1 + Math.sqrt(5)) / 2;
-
-// 12 vertices of an icosahedron (normalized)
-const VERTICES: [number, number, number][] = [
-  [0, 1, PHI],
-  [0, -1, PHI],
-  [0, 1, -PHI],
-  [0, -1, -PHI],
-  [1, PHI, 0],
-  [-1, PHI, 0],
-  [1, -PHI, 0],
-  [-1, -PHI, 0],
-  [PHI, 0, 1],
-  [-PHI, 0, 1],
-  [PHI, 0, -1],
-  [-PHI, 0, -1],
-].map(([x, y, z]) => {
-  const len = Math.sqrt(x * x + y * y + z * z);
-  return [x / len, y / len, z / len] as [number, number, number];
-});
-
-// 20 triangular faces of the icosahedron (vertex indices, counter-clockwise)
-const FACES: [number, number, number][] = [
-  // Top cap (around vertex 0)
-  [0, 1, 8],
-  [0, 8, 4],
-  [0, 4, 5],
-  [0, 5, 9],
-  [0, 9, 1],
-  // Upper middle band
-  [1, 6, 8],
-  [8, 6, 10],
-  [8, 10, 4],
-  [4, 10, 2],
-  [4, 2, 5],
-  [5, 2, 11],
-  [5, 11, 9],
-  [9, 11, 7],
-  [9, 7, 1],
-  [1, 7, 6],
-  // Bottom cap (around vertex 3)
-  [3, 6, 7],
-  [3, 7, 11],
-  [3, 11, 2],
-  [3, 2, 10],
-  [3, 10, 6],
-];
-
-// The "crit" face - face index 0 will have "20" on it
-const CRIT_FACE_INDEX = 0;
-
-// Number assignment for each face (index = face index, value = number on that face)
-// Opposite faces sum to 21, following standard d20 convention
-const FACE_NUMBERS = [
-  20, 14, 8, 16, 2, 12, 10, 6, 18, 4, 9, 11, 15, 3, 17, 13, 7, 1, 19, 5,
-];
-
-// Pre-compute face normals via cross product (outward-pointing for CCW winding)
-const FACE_NORMALS: [number, number, number][] = FACES.map(([i, j, k]) => {
-  const v0 = VERTICES[i], v1 = VERTICES[j], v2 = VERTICES[k];
-  const e1x = v1[0] - v0[0], e1y = v1[1] - v0[1], e1z = v1[2] - v0[2];
-  const e2x = v2[0] - v0[0], e2y = v2[1] - v0[1], e2z = v2[2] - v0[2];
-  const nx = e1y * e2z - e1z * e2y;
-  const ny = e1z * e2x - e1x * e2z;
-  const nz = e1x * e2y - e1y * e2x;
-  const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-  return [nx / len, ny / len, nz / len] as [number, number, number];
-});
-
-// Pre-compute the Euler angles (rotateX, rotateY) that orient each face toward +Z
-// Given rotation order Rz(az)*Ry(ay)*Rx(ax), we solve for angles that map
-// the face normal to (0, 0, 1):
-//   ax = atan2(ny, nz) → zeroes out the y-component after Rx
-//   ay = atan2(-nx, sqrt(ny²+nz²)) → zeroes out the x-component after Ry
-const FACE_ORIENTATIONS: [number, number, number][] = FACE_NORMALS.map(([nx, ny, nz]) => {
-  const ax = Math.atan2(ny, nz);
-  const ay = Math.atan2(-nx, Math.sqrt(ny * ny + nz * nz));
-  return [ax, ay, 0] as [number, number, number];
-});
-
-// Project 3D to 2D with perspective
-// perspective = 4: Camera distance from origin. Higher values = less distortion, flatter look.
-//                  4 gives a subtle 3D effect without extreme foreshortening.
-function project(
-  point: [number, number, number],
-  scale: number,
-  offsetX: number,
-  offsetY: number
-): [number, number, number] {
-  const perspective = 4;
-  const z = point[2] + perspective;
-  const factor = perspective / z;
-  return [point[0] * factor * scale + offsetX, point[1] * factor * scale + offsetY, point[2]];
-}
-
-// Parse color string (hex or HSL) to HSL components
-function parseColor(color: string): { h: number; s: number; l: number } | null {
-  // Handle hex colors like #7c3aed or #fff
-  if (color.startsWith('#')) {
-    let hex = color.slice(1);
-    if (hex.length === 3) {
-      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-    }
-    const r = parseInt(hex.slice(0, 2), 16) / 255;
-    const g = parseInt(hex.slice(2, 4), 16) / 255;
-    const b = parseInt(hex.slice(4, 6), 16) / 255;
-
-    const max = Math.max(r, g, b);
-    const min = Math.min(r, g, b);
-    const l = (max + min) / 2;
-
-    if (max === min) {
-      return { h: 0, s: 0, l: l * 100 };
-    }
-
-    const d = max - min;
-    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-    let h = 0;
-    if (max === r) {
-      h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
-    } else if (max === g) {
-      h = ((b - r) / d + 2) / 6;
-    } else {
-      h = ((r - g) / d + 4) / 6;
-    }
-
-    return { h: h * 360, s: s * 100, l: l * 100 };
-  }
-
-  // Handle "221.2 83.2% 53.3%" format (Tailwind CSS variables)
-  const match = color.match(/^([\d.]+)\s+([\d.]+)%?\s+([\d.]+)%?$/);
-  if (match) {
-    return {
-      h: parseFloat(match[1]),
-      s: parseFloat(match[2]),
-      l: parseFloat(match[3]),
-    };
-  }
-
-  return null;
-}
-
-// Draw a number on a triangular face using perspective-correct affine transform
-function drawFaceNumber(
-  ctx: CanvasRenderingContext2D,
-  faceIndex: number,
-  face: [number, number, number],
-  transformed: [number, number, number][],
-  scale: number,
-  center: number,
-  showAllNumbers: boolean,
-  dpr: number,
-  verticalCenterCache: Map<string, number>,
-) {
-  const [i, j, k] = face;
-  const v0 = transformed[i];
-  const v1 = transformed[j];
-  const v2 = transformed[k];
-
-  // Calculate face centroid in 3D
-  const centroid3D: [number, number, number] = [
-    (v0[0] + v1[0] + v2[0]) / 3,
-    (v0[1] + v1[1] + v2[1]) / 3,
-    (v0[2] + v1[2] + v2[2]) / 3,
-  ];
-
-  // Use v0 as fixed "up" reference for consistent text orientation
-  // This keeps the text stable as the die rotates (no flipping)
-  const upDir: [number, number, number] = [
-    v0[0] - centroid3D[0],
-    v0[1] - centroid3D[1],
-    v0[2] - centroid3D[2],
-  ];
-  const upLen = Math.sqrt(upDir[0] ** 2 + upDir[1] ** 2 + upDir[2] ** 2);
-  const localY: [number, number, number] = [
-    upDir[0] / upLen,
-    upDir[1] / upLen,
-    upDir[2] / upLen,
-  ];
-
-  // Calculate face normal (edge1 x edge2)
-  const edge1: [number, number, number] = [v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]];
-  const edge2: [number, number, number] = [v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]];
-  const faceNormal: [number, number, number] = [
-    edge1[1] * edge2[2] - edge1[2] * edge2[1],
-    edge1[2] * edge2[0] - edge1[0] * edge2[2],
-    edge1[0] * edge2[1] - edge1[1] * edge2[0],
-  ];
-  const normalLen = Math.sqrt(
-    faceNormal[0] ** 2 + faceNormal[1] ** 2 + faceNormal[2] ** 2
-  );
-  const normalizedNormal: [number, number, number] = [
-    faceNormal[0] / normalLen,
-    faceNormal[1] / normalLen,
-    faceNormal[2] / normalLen,
-  ];
-
-  // localX = normal x localY (right direction when facing the face)
-  // Combined with negated Y transform, this gives correct non-mirrored text
-  const localX: [number, number, number] = [
-    normalizedNormal[1] * localY[2] - normalizedNormal[2] * localY[1],
-    normalizedNormal[2] * localY[0] - normalizedNormal[0] * localY[2],
-    normalizedNormal[0] * localY[1] - normalizedNormal[1] * localY[0],
-  ];
-
-  // Project centroid and offset points to get 2D transform
-  const textScale = 0.4; // Scale factor for text size relative to face
-  const centroidProj = project(centroid3D, scale, center, center);
-
-  // Project points offset along local X and Y axes
-  const xOffset3D: [number, number, number] = [
-    centroid3D[0] + localX[0] * textScale,
-    centroid3D[1] + localX[1] * textScale,
-    centroid3D[2] + localX[2] * textScale,
-  ];
-  const yOffset3D: [number, number, number] = [
-    centroid3D[0] + localY[0] * textScale,
-    centroid3D[1] + localY[1] * textScale,
-    centroid3D[2] + localY[2] * textScale,
-  ];
-
-  const xOffsetProj = project(xOffset3D, scale, center, center);
-  const yOffsetProj = project(yOffset3D, scale, center, center);
-
-  // Calculate the 2D transform vectors
-  // Note: Y axis is negated because canvas text has top in -Y direction,
-  // but we want the top of the number to point toward the apex
-  const ax = xOffsetProj[0] - centroidProj[0];
-  const ay = xOffsetProj[1] - centroidProj[1];
-  const bx = centroidProj[0] - yOffsetProj[0]; // negated
-  const by = centroidProj[1] - yOffsetProj[1]; // negated
-
-  // Apply affine transform with DPR scaling (setTransform replaces the context's
-  // DPR scale, so we must factor it into the transform matrix directly)
-  ctx.save();
-  ctx.setTransform(ax * dpr, ay * dpr, bx * dpr, by * dpr, centroidProj[0] * dpr, centroidProj[1] * dpr);
-
-  const number = showAllNumbers ? FACE_NUMBERS[faceIndex] : 20;
-  const text = String(number);
-  const isCrit = number === 20;
-
-  // Draw text with offset toward base of triangle for better visual centering
-  const fontSize = 1.1; // In transform units
-  const textY = 0.45; // Y offset moves toward base (away from apex)
-  ctx.font = `bold ${fontSize}px sans-serif`;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'alphabetic';
-
-  // Use pre-cached vertical center offset instead of calling measureText per-face per-frame
-  const verticalCenter = verticalCenterCache.get(text) ?? 0;
-
-  if (isCrit) {
-    // Gold text with dark outline for the 20 face
-    ctx.strokeStyle = 'rgba(0, 0, 0, 0.8)';
-    ctx.lineWidth = 0.1;
-    ctx.lineJoin = 'round';
-    ctx.strokeText(text, 0, textY + verticalCenter);
-    ctx.fillStyle = 'hsl(45, 100%, 50%)';
-    ctx.fillText(text, 0, textY + verticalCenter);
-  } else {
-    // White text with dark outline for all other faces
-    ctx.strokeStyle = 'rgba(0, 0, 0, 0.6)';
-    ctx.lineWidth = 0.08;
-    ctx.lineJoin = 'round';
-    ctx.strokeText(text, 0, textY + verticalCenter);
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
-    ctx.fillText(text, 0, textY + verticalCenter);
-  }
-
-  ctx.restore();
-}
-
-// Quartic ease-out for smooth deceleration
-function easeOutQuart(t: number): number {
-  return 1 - Math.pow(1 - t, 4);
-}
-
 export function LoadingSpinner({
   size = 'md',
   className = '',
-  staticCritFace = false,
   rollResult,
   onRollComplete,
 }: LoadingSpinnerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const animationRef = useRef<number>(0);
-  const rollCompleteCalledRef = useRef(false);
   const dimension = sizes[size];
-
-  // For roll mode: random start angles, computed once per rollResult change
-  const rollStartRef = useRef<[number, number, number] | null>(null);
-
-  // Store parsed theme colors in a ref to avoid animation restarts on theme change.
-  // The MutationObserver updates this ref directly; the render loop reads it each frame.
-  const colorsRef = useRef<{
-    primaryHSL: ReturnType<typeof parseColor>;
-    foregroundHSL: ReturnType<typeof parseColor>;
-  }>({
-    primaryHSL: parseColor('#7c3aed'),
-    foregroundHSL: parseColor('#3b0764'),
-  });
+  const isRollMode = rollResult != null && rollResult >= 1 && rollResult <= 20;
 
   // Store onRollComplete in a ref so the render effect doesn't restart
   // when the parent passes an unstable callback reference.
@@ -332,286 +44,123 @@ export function LoadingSpinner({
     onRollCompleteRef.current = onRollComplete;
   });
 
-  // Listen for theme changes via MutationObserver on document root.
-  // Parses HSL once per theme change instead of every animation frame.
-  useEffect(() => {
-    const updateColors = () => {
-      const style = getComputedStyle(document.documentElement);
-      const primary = style.getPropertyValue('--primary').trim() || '#7c3aed';
-      const foreground = style.getPropertyValue('--foreground').trim() || '#3b0764';
-      colorsRef.current = {
-        primaryHSL: parseColor(primary),
-        foregroundHSL: parseColor(foreground),
-      };
-    };
-    updateColors();
-
-    const observer = new MutationObserver(updateColors);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'style'] });
-    return () => observer.disconnect();
-  }, []);
-
-  // Generate new random start angles when rollResult changes
-  useEffect(() => {
-    if (rollResult != null) {
-      rollStartRef.current = [
-        Math.random() * Math.PI * 2,
-        Math.random() * Math.PI * 2,
-        Math.random() * Math.PI * 2,
-      ];
-      rollCompleteCalledRef.current = false;
-    }
-  }, [rollResult]);
-
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    const renderer = new D20Renderer(
+      canvas,
+      isRollMode ? TRAY_CAMERA : SPINNER_CAMERA,
+      readDieTheme(),
+      isRollMode ? { shadow: true, numbers: 'all' } : { shadow: false, numbers: 'crit' }
+    );
 
-    // Scale canvas buffer for crisp rendering on HiDPI/Retina displays.
-    // CSS size stays at `dimension`; physical buffer is `dimension * dpr`.
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = dimension * dpr;
-    canvas.height = dimension * dpr;
-    ctx.scale(dpr, dpr);
+    // Track theme changes (the app supports live theme switching). The roll
+    // loop stops once the die settles, so redraw the final pose explicitly.
+    let redrawSettled: (() => void) | null = null;
+    const themeObserver = new MutationObserver(() => {
+      renderer.setTheme(readDieTheme());
+      redrawSettled?.();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
 
-    let startTime: number | null = null;
-    const isRollMode = rollResult != null && rollResult >= 1 && rollResult <= 20;
-    const showAllNumbers = isRollMode;
-
-    // Roll animation config
-    const ROLL_DURATION = 2.0; // seconds
-    const EXTRA_SPINS = 3; // full rotations added for visual effect
-
-    // Find target face index for rollResult
-    let targetFaceIndex = 0;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    let resizeObserver: ResizeObserver | null = null;
     if (isRollMode) {
-      targetFaceIndex = FACE_NUMBERS.indexOf(rollResult);
-      if (targetFaceIndex === -1) targetFaceIndex = 0;
+      // Roll mode fills its container (wide tray view)
+      const resize = () =>
+        renderer.resize(canvas.clientWidth, canvas.clientHeight, dpr);
+      resize();
+      resizeObserver = new ResizeObserver(resize);
+      resizeObserver.observe(canvas);
+    } else {
+      renderer.resize(dimension, dimension, dpr);
     }
 
-    // Rotation speeds (radians per second) for spinning mode
-    // These values have irrational ratios to each other (~0.636, ~2.75, ~0.364), ensuring
-    // the die never returns to exactly the same orientation - creating perpetual, organic motion.
-    const speedX = 0.7;
-    const speedY = 1.1;
-    const speedZ = 0.4;
+    let raf = 0;
+    let cancelled = false;
 
-    // Pre-calculated angles to orient face 0 (crit face) toward viewer
-    // These rotate the die so the "20" face normal aligns with +Z axis
-    const staticAngleX = -0.46;
-    const staticAngleY = -0.32;
+    if (isRollMode) {
+      // cannon-es loads on demand: only roll mode pays for the physics engine
+      import('@/lib/dicePhysics').then((physics) => {
+        if (cancelled) return;
+        const sim = physics.simulateRoll();
+        const playback = physics.createPlayback(
+          sim,
+          rollResult,
+          performance.now()
+        );
+        let burst: CritBurst | null = null;
+        let settled = false;
+        let last: number | null = null;
+        const loop = (now: number) => {
+          const dt = last == null ? 0 : (now - last) / 1000;
+          last = now;
+          const { p, q } = physics.evalPlayback(playback, now);
 
-    const scale = dimension * 0.35;
-    const center = dimension / 2;
-    const perspective = 4;
-
-    // Pre-allocate buffers to avoid per-frame GC pressure.
-    // These arrays are mutated in-place during each render frame instead of
-    // creating new arrays via .map() on every requestAnimationFrame callback.
-    const transformed: [number, number, number][] = VERTICES.map(
-      () => [0, 0, 0] as [number, number, number]
-    );
-    const projected: [number, number, number][] = VERTICES.map(
-      () => [0, 0, 0] as [number, number, number]
-    );
-    const facesWithDepth = FACES.map((face, faceIndex) => ({
-      face,
-      faceIndex,
-      centerZ: 0,
-      lightIntensity: 0,
-      normalizedNormalZ: 0,
-    }));
-
-    // Pre-cache text vertical-center offsets for all d20 numbers.
-    // Canvas measureText is transform-independent for a given font size,
-    // so we measure once at effect setup rather than per-face per-frame.
-    const verticalCenterCache = new Map<string, number>();
-    ctx.save();
-    ctx.font = 'bold 1.1px sans-serif';
-    for (let n = 1; n <= 20; n++) {
-      const text = String(n);
-      const metrics = ctx.measureText(text);
-      const ascent = metrics.actualBoundingBoxAscent;
-      const descent = metrics.actualBoundingBoxDescent;
-      verticalCenterCache.set(text, ascent - (ascent + descent));
-    }
-    ctx.restore();
-
-    const render = (timestamp: number) => {
-      if (!startTime) startTime = timestamp;
-      const elapsed = (timestamp - startTime) / 1000;
-
-      let angleX: number, angleY: number, angleZ: number;
-
-      if (isRollMode) {
-        const startAngles = rollStartRef.current || [0, 0, 0];
-        const targetAngles = FACE_ORIENTATIONS[targetFaceIndex];
-
-        const t = Math.min(elapsed / ROLL_DURATION, 1);
-        const eased = easeOutQuart(t);
-
-        // Interpolate from random start to target, adding extra full spins
-        angleX = startAngles[0] + (targetAngles[0] + EXTRA_SPINS * Math.PI * 2 - startAngles[0]) * eased;
-        angleY = startAngles[1] + (targetAngles[1] + EXTRA_SPINS * Math.PI * 2 - startAngles[1]) * eased;
-        angleZ = startAngles[2] + (targetAngles[2] - startAngles[2]) * eased;
-      } else if (staticCritFace) {
-        angleX = staticAngleX;
-        angleY = staticAngleY;
-        angleZ = 0;
-      } else {
-        angleX = elapsed * speedX;
-        angleY = elapsed * speedY;
-        angleZ = elapsed * speedZ;
-      }
-
-      ctx.clearRect(0, 0, dimension, dimension);
-
-      // Transform vertices in-place via inlined rotateX → rotateY → rotateZ chain.
-      // Trig is computed once outside the loop to avoid redundant Math.cos/sin per vertex.
-      const cosX = Math.cos(angleX), sinX = Math.sin(angleX);
-      const cosY = Math.cos(angleY), sinY = Math.sin(angleY);
-      const cosZ = Math.cos(angleZ), sinZ = Math.sin(angleZ);
-
-      for (let i = 0; i < VERTICES.length; i++) {
-        const [vx, vy, vz] = VERTICES[i];
-        // rotateX: [x, y*cos-z*sin, y*sin+z*cos]
-        const ry = vy * cosX - vz * sinX;
-        const rz = vy * sinX + vz * cosX;
-        // rotateY: [x*cos+z*sin, y, -x*sin+z*cos]
-        const mx = vx * cosY + rz * sinY;
-        const mz = -vx * sinY + rz * cosY;
-        // rotateZ: [x*cos-y*sin, x*sin+y*cos, z]
-        transformed[i][0] = mx * cosZ - ry * sinZ;
-        transformed[i][1] = mx * sinZ + ry * cosZ;
-        transformed[i][2] = mz;
-      }
-
-      // Project to 2D in-place
-      for (let i = 0; i < VERTICES.length; i++) {
-        const tz = transformed[i][2] + perspective;
-        const factor = perspective / tz;
-        projected[i][0] = transformed[i][0] * factor * scale + center;
-        projected[i][1] = transformed[i][1] * factor * scale + center;
-        projected[i][2] = transformed[i][2];
-      }
-
-      // Read theme colors from ref (updated by MutationObserver, not per-frame)
-      const { primaryHSL, foregroundHSL } = colorsRef.current;
-
-      // Update face depth and lighting data in-place (inlined cross product).
-      // Must read vertex indices from the stored .face, not FACES[fi], because
-      // the sort from the previous frame reorders facesWithDepth.
-      for (let fi = 0; fi < facesWithDepth.length; fi++) {
-        const [i, j, k] = facesWithDepth[fi].face;
-        const v0 = transformed[i], v1 = transformed[j], v2 = transformed[k];
-        facesWithDepth[fi].centerZ = (v0[2] + v1[2] + v2[2]) / 3;
-
-        const e1x = v1[0] - v0[0], e1y = v1[1] - v0[1], e1z = v1[2] - v0[2];
-        const e2x = v2[0] - v0[0], e2y = v2[1] - v0[1], e2z = v2[2] - v0[2];
-        const nx = e1y * e2z - e1z * e2y;
-        const ny = e1z * e2x - e1x * e2z;
-        const nz = e1x * e2y - e1y * e2x;
-        const normalLength = Math.sqrt(nx * nx + ny * ny + nz * nz);
-
-        facesWithDepth[fi].lightIntensity = normalLength > 0 ? (nz / normalLength + 1) / 2 : 0.5;
-        facesWithDepth[fi].normalizedNormalZ = normalLength > 0 ? nz / normalLength : 0;
-      }
-
-      // Sort faces back to front
-      facesWithDepth.sort((a, b) => a.centerZ - b.centerZ);
-
-      // Detect theme: dark themes have light foreground (high L)
-      const isDarkTheme = foregroundHSL ? foregroundHSL.l > 50 : false;
-
-      // Draw filled faces
-      facesWithDepth.forEach(
-        ({ face, faceIndex, lightIntensity, normalizedNormalZ }) => {
-          const [i, j, k] = face;
-          const [x0, y0] = projected[i];
-          const [x1, y1] = projected[j];
-          const [x2, y2] = projected[k];
-
-          const isCritFace = faceIndex === CRIT_FACE_INDEX;
-          const faceIsVisible = normalizedNormalZ > 0;
-
-          ctx.beginPath();
-          ctx.moveTo(x0, y0);
-          ctx.lineTo(x1, y1);
-          ctx.lineTo(x2, y2);
-          ctx.closePath();
-
-          // Face fill with lighting - all faces use primary color
-          const hue = primaryHSL?.h ?? 220;
-          const sat = primaryHSL?.s ?? 80;
-
-          let minL: number, maxL: number;
-          if (isDarkTheme) {
-            minL = 40;
-            maxL = 70;
-          } else {
-            minL = 35;
-            maxL = 60;
-          }
-          const adjustedLightness = minL + lightIntensity * (maxL - minL);
-
-          ctx.fillStyle = `hsl(${hue}, ${sat}%, ${adjustedLightness}%)`;
-          ctx.fill();
-
-          // Edge stroke
-          if (isDarkTheme) {
-            ctx.strokeStyle = `hsl(${hue}, 60%, 25%)`;
-          } else {
-            ctx.strokeStyle = `hsl(${hue}, 50%, 25%)`;
-          }
-          ctx.lineWidth = Math.max(0.5, dimension / 48);
-          ctx.lineJoin = 'round';
-          ctx.stroke();
-
-          // Draw numbers on visible faces
-          if (faceIsVisible) {
-            if (showAllNumbers) {
-              drawFaceNumber(ctx, faceIndex, face, transformed, scale, center, true, dpr, verticalCenterCache);
-            } else if (isCritFace) {
-              drawFaceNumber(ctx, faceIndex, face, transformed, scale, center, false, dpr, verticalCenterCache);
+          if (playback.done && !settled) {
+            settled = true;
+            redrawSettled = () => renderer.render(p, q);
+            onRollCompleteRef.current?.();
+            if (rollResult === 20) {
+              // Nat 20: the die erupts where it landed
+              const { x, y, radius } = renderer.screenPosition(p);
+              burst = new CritBurst(x, y, radius);
             }
           }
-        }
-      );
 
-      // Continue animation or signal completion
-      if (isRollMode) {
-        if (elapsed < ROLL_DURATION) {
-          animationRef.current = requestAnimationFrame(render);
-        } else {
-          // Animation complete — fire callback via ref
-          if (!rollCompleteCalledRef.current && onRollCompleteRef.current) {
-            rollCompleteCalledRef.current = true;
-            onRollCompleteRef.current();
+          burst?.step(dt);
+          renderer.render(
+            p,
+            q,
+            burst && !burst.done
+              ? {
+                  underlay: (ctx) => burst!.drawBack(ctx),
+                  overlay: (ctx) => burst!.drawFront(ctx),
+                }
+              : undefined
+          );
+
+          if (!playback.done || (burst && !burst.done)) {
+            raf = requestAnimationFrame(loop);
           }
-        }
-      } else if (!staticCritFace) {
-        animationRef.current = requestAnimationFrame(render);
-      }
-    };
-
-    animationRef.current = requestAnimationFrame(render);
+        };
+        raf = requestAnimationFrame(loop);
+      });
+    } else {
+      // Perpetual physics-feel tumble (pure quaternion motion, no engine)
+      const driver = new TumbleDriver();
+      let last: number | null = null;
+      const loop = (now: number) => {
+        const dt = last == null ? 0 : (now - last) / 1000;
+        last = now;
+        renderer.render([0, 0, 0], driver.step(dt));
+        raf = requestAnimationFrame(loop);
+      };
+      raf = requestAnimationFrame(loop);
+    }
 
     return () => {
-      cancelAnimationFrame(animationRef.current);
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      themeObserver.disconnect();
+      resizeObserver?.disconnect();
     };
-  }, [dimension, staticCritFace, rollResult]);
+  }, [dimension, isRollMode, rollResult]);
 
   return (
     <canvas
       ref={canvasRef}
-      width={dimension}
-      height={dimension}
       className={className}
-      aria-label={rollResult != null ? `D20 showing ${rollResult}` : 'Loading'}
-      style={{ width: dimension, height: dimension }}
+      aria-label={isRollMode ? `D20 showing ${rollResult}` : 'Loading'}
+      style={
+        isRollMode
+          ? { width: '100%', aspectRatio: '16 / 10' }
+          : { width: dimension, height: dimension }
+      }
     />
   );
 }

--- a/src/lib/critBurst.test.ts
+++ b/src/lib/critBurst.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { CritBurst } from './critBurst';
+
+describe('CritBurst', () => {
+  it('runs for its duration, then reports done', () => {
+    const burst = new CritBurst(100, 100, 50);
+    expect(burst.done).toBe(false);
+    let steps = 0;
+    while (!burst.done && steps < 1000) {
+      burst.step(1 / 60);
+      steps++;
+    }
+    expect(burst.done).toBe(true);
+    // ~2.2s at 60fps
+    expect(steps).toBeGreaterThan(100);
+    expect(steps).toBeLessThan(200);
+  });
+
+  it('clamps huge dt so a background tab cannot fast-forward wildly', () => {
+    const burst = new CritBurst(0, 0, 50);
+    burst.step(30); // clamped to 50ms
+    expect(burst.done).toBe(false);
+  });
+
+  it('drawing is side-effect-only and works on a plain 2d context', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 200;
+    const ctx = canvas.getContext('2d');
+    // jsdom may not implement canvas 2d; skip the draw check there
+    if (!ctx) return;
+    const burst = new CritBurst(100, 100, 40);
+    burst.step(0.1);
+    expect(() => {
+      burst.drawBack(ctx);
+      burst.drawFront(ctx);
+    }).not.toThrow();
+  });
+});

--- a/src/lib/critBurst.ts
+++ b/src/lib/critBurst.ts
@@ -1,0 +1,123 @@
+// Nat-20 celebration: gold light rays erupting from behind the die, a
+// shockwave ring, and a spray of sparks. Pure canvas-2D, sized relative to
+// the die's on-screen radius so it scales from phone to desktop.
+
+const DURATION = 2.2; // seconds
+const RAY_COUNT = 12;
+const SPARK_COUNT = 80;
+
+interface Spark {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  age: number;
+  life: number;
+  size: number;
+  hue: number;
+  white: boolean;
+}
+
+export class CritBurst {
+  done = false;
+  private t = 0;
+  private sparks: Spark[] = [];
+
+  /**
+   * @param cx,cy  burst origin in CSS pixels (the die's screen center)
+   * @param scale  the die's on-screen radius in CSS pixels
+   */
+  constructor(
+    private cx: number,
+    private cy: number,
+    private scale: number
+  ) {
+    for (let i = 0; i < SPARK_COUNT; i++) {
+      const ang = Math.random() * Math.PI * 2;
+      const speed = scale * (2 + Math.random() * 5);
+      this.sparks.push({
+        x: cx,
+        y: cy - scale * 0.2,
+        vx: Math.cos(ang) * speed,
+        // Upward bias so the spray fountains over the die
+        vy: Math.sin(ang) * speed - scale * (1 + Math.random() * 1.5),
+        age: 0,
+        life: 0.7 + Math.random() * 0.9,
+        size: scale * (0.04 + Math.random() * 0.05),
+        hue: 40 + Math.random() * 15,
+        white: Math.random() < 0.25,
+      });
+    }
+  }
+
+  step(dtRaw: number) {
+    const dt = Math.min(Math.max(dtRaw, 0), 0.05);
+    this.t += dt;
+    const gravity = this.scale * 6;
+    for (const s of this.sparks) {
+      s.age += dt;
+      s.vy += gravity * dt;
+      s.vx *= 1 - 0.9 * dt; // air drag
+      s.x += s.vx * dt;
+      s.y += s.vy * dt;
+    }
+    if (this.t >= DURATION) this.done = true;
+  }
+
+  /** Light rays + shockwave ring — draw BEHIND the die */
+  drawBack(ctx: CanvasRenderingContext2D) {
+    const { t, cx, cy, scale } = this;
+    // Envelope: quick rise, long fade
+    const rise = Math.min(t / 0.2, 1);
+    const fall = Math.max(0, 1 - Math.max(0, t - (DURATION - 0.7)) / 0.7);
+    const env = rise * fall;
+    if (env <= 0) return;
+
+    ctx.save();
+    ctx.translate(cx, cy - scale * 0.2);
+    ctx.rotate(t * 0.35);
+    ctx.fillStyle = 'hsl(45, 100%, 60%)';
+    for (let i = 0; i < RAY_COUNT; i++) {
+      const ang = (i / RAY_COUNT) * Math.PI * 2;
+      const len = scale * (2.4 + 0.5 * Math.sin(t * 3 + i * 1.7));
+      ctx.globalAlpha = env * (i % 2 === 0 ? 0.2 : 0.12);
+      ctx.beginPath();
+      ctx.moveTo(Math.cos(ang) * scale * 0.5, Math.sin(ang) * scale * 0.5);
+      ctx.lineTo(Math.cos(ang - 0.07) * len, Math.sin(ang - 0.07) * len);
+      ctx.lineTo(Math.cos(ang + 0.07) * len, Math.sin(ang + 0.07) * len);
+      ctx.closePath();
+      ctx.fill();
+    }
+    ctx.restore();
+
+    // Shockwave ring in the first half second
+    const ringT = t / 0.45;
+    if (ringT < 1) {
+      ctx.save();
+      ctx.globalAlpha = 0.5 * (1 - ringT);
+      ctx.strokeStyle = 'hsl(48, 100%, 70%)';
+      ctx.lineWidth = scale * 0.12 * (1 - ringT) + 1;
+      ctx.beginPath();
+      ctx.arc(cx, cy - scale * 0.2, scale * (0.9 + ringT * 2.6), 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+
+  /** Spark spray — draw IN FRONT of the die */
+  drawFront(ctx: CanvasRenderingContext2D) {
+    ctx.save();
+    for (const s of this.sparks) {
+      const a = 1 - s.age / s.life;
+      if (a <= 0) continue;
+      ctx.globalAlpha = a;
+      ctx.fillStyle = s.white
+        ? 'hsl(50, 100%, 88%)'
+        : `hsl(${s.hue}, 100%, 60%)`;
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, s.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+}

--- a/src/lib/d20Geometry.test.ts
+++ b/src/lib/d20Geometry.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  D20_VERTICES,
+  D20_FACES,
+  D20_FACE_NUMBERS,
+  D20_FACE_NORMALS,
+  D20_INRADIUS,
+} from './d20Geometry';
+
+describe('d20Geometry', () => {
+  it('has 12 unit vertices, 20 faces, 20 numbers', () => {
+    expect(D20_VERTICES).toHaveLength(12);
+    expect(D20_FACES).toHaveLength(20);
+    expect(D20_FACE_NUMBERS).toHaveLength(20);
+    for (const v of D20_VERTICES) {
+      expect(Math.hypot(...v)).toBeCloseTo(1, 12);
+    }
+  });
+
+  it('numbers 1-20 each appear exactly once', () => {
+    expect([...D20_FACE_NUMBERS].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 20 }, (_, i) => i + 1)
+    );
+  });
+
+  it('face normals are outward-pointing unit vectors', () => {
+    D20_FACE_NORMALS.forEach((n, fi) => {
+      expect(Math.hypot(...n)).toBeCloseTo(1, 10);
+      // Outward: normal points away from the origin (toward the face centroid)
+      const [i, j, k] = D20_FACES[fi];
+      const cx =
+        (D20_VERTICES[i][0] + D20_VERTICES[j][0] + D20_VERTICES[k][0]) / 3;
+      const cy =
+        (D20_VERTICES[i][1] + D20_VERTICES[j][1] + D20_VERTICES[k][1]) / 3;
+      const cz =
+        (D20_VERTICES[i][2] + D20_VERTICES[j][2] + D20_VERTICES[k][2]) / 3;
+      expect(cx * n[0] + cy * n[1] + cz * n[2]).toBeGreaterThan(0);
+    });
+  });
+
+  it('opposite faces sum to 21, following real d20 convention', () => {
+    D20_FACE_NORMALS.forEach((n, fi) => {
+      // The opposite face has the antiparallel normal
+      const opposite = D20_FACE_NORMALS.findIndex(
+        (m) =>
+          Math.abs(m[0] + n[0]) < 1e-9 &&
+          Math.abs(m[1] + n[1]) < 1e-9 &&
+          Math.abs(m[2] + n[2]) < 1e-9
+      );
+      expect(opposite).toBeGreaterThanOrEqual(0);
+      expect(D20_FACE_NUMBERS[fi] + D20_FACE_NUMBERS[opposite]).toBe(21);
+    });
+  });
+
+  it('inradius matches the analytic icosahedron value', () => {
+    // For circumradius 1: r_in = φ² / (√3 · √(φ + 2))
+    const phi = (1 + Math.sqrt(5)) / 2;
+    const expected = (phi * phi) / (Math.sqrt(3) * Math.sqrt(phi + 2));
+    expect(D20_INRADIUS).toBeCloseTo(expected, 10);
+  });
+});

--- a/src/lib/d20Geometry.ts
+++ b/src/lib/d20Geometry.ts
@@ -1,0 +1,85 @@
+// Shared d20 (icosahedron) geometry data.
+// This mirrors the constants in LoadingSpinner.tsx; once the physics-based
+// renderer ships, LoadingSpinner should import from here too.
+
+// Golden ratio
+export const PHI = (1 + Math.sqrt(5)) / 2;
+
+// 12 vertices of an icosahedron, normalized to the unit sphere (circumradius 1)
+export const D20_VERTICES: [number, number, number][] = [
+  [0, 1, PHI],
+  [0, -1, PHI],
+  [0, 1, -PHI],
+  [0, -1, -PHI],
+  [1, PHI, 0],
+  [-1, PHI, 0],
+  [1, -PHI, 0],
+  [-1, -PHI, 0],
+  [PHI, 0, 1],
+  [-PHI, 0, 1],
+  [PHI, 0, -1],
+  [-PHI, 0, -1],
+].map(([x, y, z]) => {
+  const len = Math.sqrt(x * x + y * y + z * z);
+  return [x / len, y / len, z / len] as [number, number, number];
+});
+
+// 20 triangular faces (vertex indices, counter-clockwise viewed from outside)
+export const D20_FACES: [number, number, number][] = [
+  // Top cap (around vertex 0)
+  [0, 1, 8],
+  [0, 8, 4],
+  [0, 4, 5],
+  [0, 5, 9],
+  [0, 9, 1],
+  // Upper middle band
+  [1, 6, 8],
+  [8, 6, 10],
+  [8, 10, 4],
+  [4, 10, 2],
+  [4, 2, 5],
+  [5, 2, 11],
+  [5, 11, 9],
+  [9, 11, 7],
+  [9, 7, 1],
+  [1, 7, 6],
+  // Bottom cap (around vertex 3)
+  [3, 6, 7],
+  [3, 7, 11],
+  [3, 11, 2],
+  [3, 2, 10],
+  [3, 10, 6],
+];
+
+// Number printed on each face (index = face index). Opposite faces sum to 21.
+export const D20_FACE_NUMBERS = [
+  20, 14, 8, 16, 2, 12, 10, 6, 18, 4, 9, 11, 15, 3, 17, 13, 7, 1, 19, 5,
+];
+
+// Outward-pointing unit normal per face
+export const D20_FACE_NORMALS: [number, number, number][] = D20_FACES.map(
+  ([i, j, k]) => {
+    const v0 = D20_VERTICES[i],
+      v1 = D20_VERTICES[j],
+      v2 = D20_VERTICES[k];
+    const e1x = v1[0] - v0[0],
+      e1y = v1[1] - v0[1],
+      e1z = v1[2] - v0[2];
+    const e2x = v2[0] - v0[0],
+      e2y = v2[1] - v0[1],
+      e2z = v2[2] - v0[2];
+    const nx = e1y * e2z - e1z * e2y;
+    const ny = e1z * e2x - e1x * e2z;
+    const nz = e1x * e2y - e1y * e2x;
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    return [nx / len, ny / len, nz / len] as [number, number, number];
+  }
+);
+
+// Distance from the center to each face plane (inradius), for a circumradius-1 die
+export const D20_INRADIUS = (() => {
+  const [i] = D20_FACES[0];
+  const v = D20_VERTICES[i];
+  const n = D20_FACE_NORMALS[0];
+  return Math.abs(v[0] * n[0] + v[1] * n[1] + v[2] * n[2]);
+})();

--- a/src/lib/diceConfig.ts
+++ b/src/lib/diceConfig.ts
@@ -1,0 +1,11 @@
+// Shared sizing for the physics d20: the renderer and the physics simulation
+// must agree on these so the drawn die matches its collision hull.
+
+/** Circumradius of the die in world units */
+export const DIE_RADIUS = 1.3;
+
+/** Half-width of the invisible tray the 404 die rolls in */
+export const ARENA_HALF_X = 4.0;
+
+/** Half-depth of the invisible tray */
+export const ARENA_HALF_Z = 2.8;

--- a/src/lib/dicePhysics.test.ts
+++ b/src/lib/dicePhysics.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DIE_REST_HEIGHT,
+  createPlayback,
+  evalPlayback,
+  faceMappingQuat,
+  findUpFace,
+  simulateRoll,
+} from './dicePhysics';
+import { D20_FACE_NUMBERS, D20_FACE_NORMALS, D20_VERTICES } from './d20Geometry';
+import { quatApply } from './quat';
+
+describe('simulateRoll', () => {
+  // One shared roll for the suite; each simulation is ~1-2ms but there's no
+  // need to re-roll per assertion.
+  const sim = simulateRoll();
+
+  it('produces frames and a result consistent with the landed face', () => {
+    expect(sim.frames.length).toBeGreaterThan(0);
+    expect(sim.naturalResult).toBeGreaterThanOrEqual(1);
+    expect(sim.naturalResult).toBeLessThanOrEqual(20);
+    expect(D20_FACE_NUMBERS[sim.landedFace]).toBe(sim.naturalResult);
+    const lastQ = sim.frames[sim.frames.length - 1].q;
+    expect(findUpFace(lastQ)).toBe(sim.landedFace);
+  });
+
+  it('lands flat (within the cocked-roll rejection threshold)', () => {
+    // simulateRoll retries cocked throws; only if all 10 attempts land
+    // cocked (vanishingly rare) could flatness be lower.
+    expect(sim.flatness).toBeGreaterThan(Math.cos((8 * Math.PI) / 180));
+  });
+
+  it('tumbles long enough to read as a real throw', () => {
+    expect(sim.frames.length / 60).toBeGreaterThanOrEqual(1.4);
+  });
+});
+
+describe('faceMappingQuat', () => {
+  it('maps the source face normal onto the target face normal', () => {
+    for (const [from, to] of [
+      [0, 5],
+      [3, 17],
+      [19, 0],
+      [7, 7],
+    ] as const) {
+      const r = faceMappingQuat(from, to);
+      const mapped = quatApply(r, D20_FACE_NORMALS[from]);
+      const target = D20_FACE_NORMALS[to];
+      for (let i = 0; i < 3; i++) {
+        expect(mapped[i]).toBeCloseTo(target[i], 9);
+      }
+    }
+  });
+
+  it('is an icosahedral symmetry: every vertex maps onto a vertex', () => {
+    const r = faceMappingQuat(2, 14);
+    for (const v of D20_VERTICES) {
+      const m = quatApply(r, v);
+      const matches = D20_VERTICES.some(
+        (w) =>
+          Math.abs(w[0] - m[0]) < 1e-9 &&
+          Math.abs(w[1] - m[1]) < 1e-9 &&
+          Math.abs(w[2] - m[2]) < 1e-9
+      );
+      expect(matches).toBe(true);
+    }
+  });
+});
+
+describe('playback', () => {
+  it('starts at the first frame and clamps pre-start timestamps', () => {
+    const sim = simulateRoll();
+    const playback = createPlayback(sim, null, 1000);
+    // rAF timestamps can precede the start time captured in a click handler
+    const { p } = evalPlayback(playback, 990);
+    expect(p[0]).toBeCloseTo(sim.frames[0].p[0], 6);
+    expect(playback.done).toBe(false);
+  });
+
+  it('finishes flat, at rest height, showing the forced number', () => {
+    const sim = simulateRoll();
+    const forced = sim.naturalResult === 20 ? 1 : 20;
+    const playback = createPlayback(sim, forced, 0);
+    // First eval past the frames starts the settle snap; the second, a full
+    // second later, is well past the 250ms snap duration
+    const end = (sim.frames.length / 60 + 5) * 1000;
+    evalPlayback(playback, end);
+    const { p, q } = evalPlayback(playback, end + 1000);
+    expect(playback.done).toBe(true);
+    expect(p[1]).toBeCloseTo(DIE_REST_HEIGHT, 6);
+    expect(D20_FACE_NUMBERS[findUpFace(q)]).toBe(forced);
+    // Perfectly flat after the settle snap
+    const worldN = quatApply(q, D20_FACE_NORMALS[findUpFace(q)]);
+    expect(worldN[1]).toBeCloseTo(1, 6);
+  });
+
+  it('shows the natural result when no result is forced', () => {
+    const sim = simulateRoll();
+    const playback = createPlayback(sim, null, 0);
+    const end = (sim.frames.length / 60 + 5) * 1000;
+    evalPlayback(playback, end);
+    const { q } = evalPlayback(playback, end + 1000);
+    expect(D20_FACE_NUMBERS[findUpFace(q)]).toBe(sim.naturalResult);
+  });
+});

--- a/src/lib/dicePhysics.ts
+++ b/src/lib/dicePhysics.ts
@@ -1,0 +1,320 @@
+// Headless d20 roll simulation with cannon-es.
+// Produces renderer-agnostic frames (position + quaternion) that any view —
+// WebGL or canvas-2D — can play back. Deliberately free of three.js.
+
+import * as CANNON from 'cannon-es';
+import {
+  D20_VERTICES,
+  D20_FACES,
+  D20_FACE_NUMBERS,
+  D20_FACE_NORMALS,
+  D20_INRADIUS,
+} from '@/lib/d20Geometry';
+import {
+  type Quat,
+  type Vec3,
+  QUAT_IDENTITY,
+  quatApply,
+  quatFromMat3,
+  quatFromUnitVectors,
+  quatMultiply,
+  quatSlerp,
+  vecCross,
+  vecNormalize,
+  vecSub,
+} from '@/lib/quat';
+
+import { DIE_RADIUS, ARENA_HALF_X, ARENA_HALF_Z } from '@/lib/diceConfig';
+
+// ── Tuning constants ──
+
+export const GRAVITY = -38; // stronger than earth gravity for a snappy, game-feel roll
+export const PHYSICS_DT = 1 / 60;
+export const MAX_SIM_SECONDS = 8;
+export const MIN_ROLL_SECONDS = 1.4; // re-throw dud rolls that settle too quickly
+export const SETTLE_SNAP_SECONDS = 0.25; // final ease that lays the die perfectly flat
+export const DIE_REST_HEIGHT = D20_INRADIUS * DIE_RADIUS;
+
+export interface RecordedFrame {
+  p: Vec3;
+  q: Quat;
+}
+
+// A landing counts as flat when the up-face normal is within ~8° of vertical;
+// the settle snap then has almost nothing to correct and is imperceptible.
+const FLAT_THRESHOLD = Math.cos((8 * Math.PI) / 180);
+
+export interface RollSimulation {
+  frames: RecordedFrame[];
+  landedFace: number;
+  naturalResult: number;
+  steps: number;
+  slept: boolean;
+  /** Up-face normal's world y at rest (1 = perfectly flat) */
+  flatness: number;
+  /** How many throws were simulated before one was accepted */
+  attempts: number;
+}
+
+// Which face index points up for a given orientation?
+export function findUpFace(q: Quat): number {
+  let best = 0;
+  let bestY = -Infinity;
+  for (let f = 0; f < D20_FACE_NORMALS.length; f++) {
+    const worldY = quatApply(q, D20_FACE_NORMALS[f])[1];
+    if (worldY > bestY) {
+      bestY = worldY;
+      best = f;
+    }
+  }
+  return best;
+}
+
+// Orthonormal basis for a face as matrix columns (u toward apex vertex, w, n).
+// Using the same apex-vertex convention for every face makes the resulting
+// frame-to-frame rotation a symmetry of the icosahedron.
+function faceBasis(faceIndex: number): [Vec3, Vec3, Vec3] {
+  const [i, j, k] = D20_FACES[faceIndex];
+  const v0 = D20_VERTICES[i];
+  const v1 = D20_VERTICES[j];
+  const v2 = D20_VERTICES[k];
+  const centroid: Vec3 = [
+    (v0[0] + v1[0] + v2[0]) / 3,
+    (v0[1] + v1[1] + v2[1]) / 3,
+    (v0[2] + v1[2] + v2[2]) / 3,
+  ];
+  const n = D20_FACE_NORMALS[faceIndex];
+  const u = vecNormalize(vecSub(v0, centroid));
+  const w = vecCross(n, u);
+  return [u, w, n];
+}
+
+// Rotation (an icosahedral symmetry) that maps face `from` onto face `to`,
+// apex vertex to apex vertex. Applied as a pre-rotation on the rendered die,
+// it relabels the numbers without changing the physics.
+export function faceMappingQuat(from: number, to: number): Quat {
+  const bf = faceBasis(from);
+  const bt = faceBasis(to);
+  // R = M_to * M_fromᵀ, where M columns are the basis vectors
+  const m = [0, 1, 2].map((row) =>
+    [0, 1, 2].map((col) => {
+      let sum = 0;
+      for (let k = 0; k < 3; k++) sum += bt[k][row] * bf[k][col];
+      return sum;
+    })
+  );
+  return quatFromMat3(m);
+}
+
+function simulateOnce(): RollSimulation {
+  const world = new CANNON.World({ gravity: new CANNON.Vec3(0, GRAVITY, 0) });
+  world.allowSleep = true;
+
+  const dieMaterial = new CANNON.Material('die');
+  const trayMaterial = new CANNON.Material('tray');
+  world.addContactMaterial(
+    new CANNON.ContactMaterial(dieMaterial, trayMaterial, {
+      friction: 0.25,
+      restitution: 0.42,
+    })
+  );
+
+  // Invisible tray: floor, four walls, and a low ceiling to keep the die in frame
+  const trayPlanes: Array<{ pos: Vec3; euler: Vec3 }> = [
+    { pos: [0, 0, 0], euler: [-Math.PI / 2, 0, 0] }, // floor (normal +y)
+    { pos: [-ARENA_HALF_X, 0, 0], euler: [0, Math.PI / 2, 0] }, // left → +x
+    { pos: [ARENA_HALF_X, 0, 0], euler: [0, -Math.PI / 2, 0] }, // right → -x
+    { pos: [0, 0, -ARENA_HALF_Z], euler: [0, 0, 0] }, // back → +z
+    { pos: [0, 0, ARENA_HALF_Z], euler: [0, Math.PI, 0] }, // front → -z
+    { pos: [0, 6.5, 0], euler: [Math.PI / 2, 0, 0] }, // ceiling → -y (above any spawn/bounce)
+  ];
+  for (const { pos, euler } of trayPlanes) {
+    const body = new CANNON.Body({
+      mass: 0,
+      shape: new CANNON.Plane(),
+      material: trayMaterial,
+    });
+    body.position.set(...pos);
+    body.quaternion.setFromEuler(...euler);
+    world.addBody(body);
+  }
+
+  // The die: a convex hull of the same icosahedron the renderers draw
+  const shape = new CANNON.ConvexPolyhedron({
+    vertices: D20_VERTICES.map(
+      ([x, y, z]) =>
+        new CANNON.Vec3(x * DIE_RADIUS, y * DIE_RADIUS, z * DIE_RADIUS)
+    ),
+    faces: D20_FACES.map((f) => [...f]),
+  });
+  const die = new CANNON.Body({
+    mass: 1,
+    shape,
+    material: dieMaterial,
+    linearDamping: 0.08,
+    angularDamping: 0.12,
+  });
+  die.allowSleep = true;
+  die.sleepSpeedLimit = 0.4;
+  die.sleepTimeLimit = 0.35;
+
+  // Random throw: in from the left edge with strong tumble, already falling
+  // so the die never hangs in the air at the start of the roll
+  die.position.set(
+    -ARENA_HALF_X + 0.9,
+    2.6 + Math.random() * 1.0,
+    -ARENA_HALF_Z + 1 + Math.random() * (2 * ARENA_HALF_Z - 2)
+  );
+  die.quaternion.setFromEuler(
+    Math.random() * Math.PI * 2,
+    Math.random() * Math.PI * 2,
+    Math.random() * Math.PI * 2
+  );
+  die.velocity.set(
+    7 + Math.random() * 4,
+    -2 - Math.random() * 3,
+    (Math.random() - 0.5) * 6
+  );
+  die.angularVelocity.set(
+    (Math.random() - 0.5) * 50,
+    (Math.random() - 0.5) * 30,
+    (Math.random() - 0.5) * 50
+  );
+  world.addBody(die);
+
+  const frames: RecordedFrame[] = [];
+  const maxSteps = Math.ceil(MAX_SIM_SECONDS / PHYSICS_DT);
+  let slept = false;
+  let steps = 0;
+  for (; steps < maxSteps; steps++) {
+    world.step(PHYSICS_DT);
+    frames.push({
+      p: [die.position.x, die.position.y, die.position.z],
+      q: [
+        die.quaternion.x,
+        die.quaternion.y,
+        die.quaternion.z,
+        die.quaternion.w,
+      ],
+    });
+    if (die.sleepState === CANNON.Body.SLEEPING) {
+      slept = true;
+      break;
+    }
+  }
+
+  const lastQ = frames[frames.length - 1].q;
+  const landedFace = findUpFace(lastQ);
+  const flatness = quatApply(lastQ, D20_FACE_NORMALS[landedFace])[1];
+  return {
+    frames,
+    landedFace,
+    naturalResult: D20_FACE_NUMBERS[landedFace],
+    steps,
+    slept,
+    flatness,
+    attempts: 1,
+  };
+}
+
+// A good throw tumbles long enough to satisfy AND lands flat — a cocked die
+// would need a visible artificial rotation to display its result.
+function isGoodThrow(sim: RollSimulation): boolean {
+  return (
+    sim.frames.length * PHYSICS_DT >= MIN_ROLL_SECONDS &&
+    sim.flatness >= FLAT_THRESHOLD
+  );
+}
+
+// Simulate throws (each ~1-2ms) until one is good; keep the best fallback
+export function simulateRoll(): RollSimulation {
+  let best = simulateOnce();
+  let attempts = 1;
+  while (!isGoodThrow(best) && attempts < 10) {
+    const next = simulateOnce();
+    attempts++;
+    // Prefer flat over long, then the flattest landing
+    const bestScore =
+      (best.flatness >= FLAT_THRESHOLD ? 2 : 0) +
+      (best.frames.length * PHYSICS_DT >= MIN_ROLL_SECONDS ? 1 : 0) +
+      best.flatness;
+    const nextScore =
+      (next.flatness >= FLAT_THRESHOLD ? 2 : 0) +
+      (next.frames.length * PHYSICS_DT >= MIN_ROLL_SECONDS ? 1 : 0) +
+      next.flatness;
+    if (nextScore > bestScore) best = next;
+  }
+  return { ...best, attempts };
+}
+
+// ── Playback ──
+// Evaluates a recorded roll at wall-clock time, including the final settle
+// snap. Both renderers consume this, so their motion is identical.
+
+export interface RollPlayback {
+  sim: RollSimulation;
+  qRelabel: Quat; // identity unless the result is forced
+  startTime: number;
+  snapStart: number | null;
+  done: boolean;
+}
+
+export function createPlayback(
+  sim: RollSimulation,
+  forcedResult: number | null,
+  startTime: number
+): RollPlayback {
+  let qRelabel = QUAT_IDENTITY;
+  if (forcedResult != null) {
+    const desiredFace = D20_FACE_NUMBERS.indexOf(forcedResult);
+    if (desiredFace !== -1 && desiredFace !== sim.landedFace) {
+      qRelabel = faceMappingQuat(desiredFace, sim.landedFace);
+    }
+  }
+  return { sim, qRelabel, startTime, snapStart: null, done: false };
+}
+
+export function evalPlayback(
+  playback: RollPlayback,
+  now: number
+): { p: Vec3; q: Quat } {
+  const { frames } = playback.sim;
+  // Clamp: the first animation-frame timestamp can precede the
+  // performance.now() captured in the click handler
+  const t = Math.max(0, (now - playback.startTime) / 1000);
+  const idx = t / PHYSICS_DT;
+  const i0 = Math.min(Math.floor(idx), frames.length - 1);
+
+  if (i0 < frames.length - 1) {
+    const f0 = frames[i0];
+    const f1 = frames[i0 + 1];
+    const alpha = idx - i0;
+    const p: Vec3 = [
+      f0.p[0] + (f1.p[0] - f0.p[0]) * alpha,
+      f0.p[1] + (f1.p[1] - f0.p[1]) * alpha,
+      f0.p[2] + (f1.p[2] - f0.p[2]) * alpha,
+    ];
+    return { p, q: quatMultiply(quatSlerp(f0.q, f1.q, alpha), playback.qRelabel) };
+  }
+
+  // Settle snap: ease the die perfectly flat onto its landed face
+  const last = frames[frames.length - 1];
+  if (playback.snapStart == null) playback.snapStart = now;
+  const s = Math.min(
+    (now - playback.snapStart) / (SETTLE_SNAP_SECONDS * 1000),
+    1
+  );
+  const ease = 1 - Math.pow(1 - s, 3);
+
+  const worldN = quatApply(last.q, D20_FACE_NORMALS[playback.sim.landedFace]);
+  const qAlign = quatFromUnitVectors(worldN, [0, 1, 0]);
+  const qFlat = quatMultiply(qAlign, last.q);
+  const q = quatMultiply(quatSlerp(last.q, qFlat, ease), playback.qRelabel);
+  const p: Vec3 = [
+    last.p[0],
+    last.p[1] + (DIE_REST_HEIGHT - last.p[1]) * ease,
+    last.p[2],
+  ];
+  if (s >= 1) playback.done = true;
+  return { p, q };
+}

--- a/src/lib/diceTumble.test.ts
+++ b/src/lib/diceTumble.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_TUMBLE_PARAMS, TumbleDriver } from './diceTumble';
+
+describe('TumbleDriver', () => {
+  it('keeps the orientation a unit quaternion across many steps', () => {
+    const driver = new TumbleDriver();
+    for (let i = 0; i < 10_000; i++) {
+      const q = driver.step(1 / 60);
+      expect(Number.isFinite(q[0])).toBe(true);
+      expect(Math.hypot(...q)).toBeCloseTo(1, 9);
+    }
+  });
+
+  it('actually rotates over time', () => {
+    const driver = new TumbleDriver();
+    const q0 = [...driver.q];
+    for (let i = 0; i < 60; i++) driver.step(1 / 60);
+    const q1 = driver.q;
+    // A second of tumbling at >= ~2 rad/s must move the orientation
+    const dot = Math.abs(
+      q0[0] * q1[0] + q0[1] * q1[1] + q0[2] * q1[2] + q0[3] * q1[3]
+    );
+    expect(dot).toBeLessThan(0.99);
+  });
+
+  it('clamps huge dt (background tab wake-up) instead of jumping wildly', () => {
+    const driver = new TumbleDriver();
+    const before = [...driver.q];
+    const q = driver.step(30); // 30s pause
+    // Rotation this frame is bounded by maxSpeed * 50ms — far less than a
+    // full revolution, so the angle between before/after stays small-ish
+    const dot = Math.abs(
+      before[0] * q[0] + before[1] * q[1] + before[2] * q[2] + before[3] * q[3]
+    );
+    expect(dot).toBeGreaterThan(0.8);
+    expect(Math.hypot(...q)).toBeCloseTo(1, 9);
+  });
+
+  it('negative dt is treated as no time passing', () => {
+    const driver = new TumbleDriver();
+    const before = [...driver.q];
+    const q = driver.step(-5);
+    q.forEach((v, i) => expect(v).toBeCloseTo(before[i], 12));
+  });
+
+  it('default params are sane', () => {
+    expect(DEFAULT_TUMBLE_PARAMS.baseSpeed).toBeGreaterThan(0);
+    expect(DEFAULT_TUMBLE_PARAMS.flickIntervalSec).toBeGreaterThan(0);
+    expect(DEFAULT_TUMBLE_PARAMS.flickStrength).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/diceTumble.ts
+++ b/src/lib/diceTumble.ts
@@ -1,0 +1,106 @@
+// Perpetual "die turning in the air" motion for loading states.
+// No physics engine: a freely tumbling icosahedron is just quaternion
+// integration. The physical feel comes from the angular velocity profile —
+// periodic flicks (a hand jostling the die) that decay back to a cruising
+// speed under drag, plus a slowly wandering spin axis so the motion never
+// becomes a constant-rate rotation.
+
+import {
+  type Quat,
+  type Vec3,
+  quatFromAxisAngle,
+  quatMultiply,
+  quatNormalize,
+} from '@/lib/quat';
+
+export interface TumbleParams {
+  /** rad/s the spin relaxes toward between flicks */
+  baseSpeed: number;
+  /** average seconds between flicks */
+  flickIntervalSec: number;
+  /** rad/s added by a flick */
+  flickStrength: number;
+}
+
+export const DEFAULT_TUMBLE_PARAMS: TumbleParams = {
+  baseSpeed: 2.2,
+  flickIntervalSec: 2.4,
+  flickStrength: 6,
+};
+
+// Uniformly distributed direction on the unit sphere
+function randomDir(): Vec3 {
+  const z = Math.random() * 2 - 1;
+  const t = Math.random() * Math.PI * 2;
+  const r = Math.sqrt(1 - z * z);
+  return [r * Math.cos(t), r * Math.sin(t), z];
+}
+
+export class TumbleDriver {
+  q: Quat;
+  private omega: Vec3;
+  private untilFlick: number;
+
+  constructor(params: TumbleParams = DEFAULT_TUMBLE_PARAMS) {
+    this.q = quatFromAxisAngle(randomDir(), Math.random() * Math.PI * 2);
+    const d = randomDir();
+    this.omega = [
+      d[0] * params.baseSpeed,
+      d[1] * params.baseSpeed,
+      d[2] * params.baseSpeed,
+    ];
+    // Stagger the first flick so multiple dice don't pulse in sync
+    this.untilFlick = Math.random() * params.flickIntervalSec;
+  }
+
+  /** Advance the tumble by dt seconds and return the new orientation */
+  step(dtRaw: number, params: TumbleParams = DEFAULT_TUMBLE_PARAMS): Quat {
+    // Clamp so a background-tab pause doesn't produce a giant rotation jump
+    const dt = Math.min(Math.max(dtRaw, 0), 0.05);
+
+    this.untilFlick -= dt;
+    if (this.untilFlick <= 0) {
+      const d = randomDir();
+      const k = params.flickStrength * (0.7 + Math.random() * 0.6);
+      this.omega = [
+        this.omega[0] + d[0] * k,
+        this.omega[1] + d[1] * k,
+        this.omega[2] + d[2] * k,
+      ];
+      this.untilFlick = params.flickIntervalSec * (0.6 + Math.random() * 0.8);
+    }
+
+    let speed = Math.hypot(this.omega[0], this.omega[1], this.omega[2]);
+    if (speed < 1e-6) {
+      const d = randomDir();
+      this.omega = [
+        d[0] * params.baseSpeed,
+        d[1] * params.baseSpeed,
+        d[2] * params.baseSpeed,
+      ];
+      speed = params.baseSpeed;
+    }
+
+    // Drag: speed eases back toward the base between flicks
+    const newSpeed =
+      params.baseSpeed + (speed - params.baseSpeed) * Math.exp(-1.3 * dt);
+
+    // Slow axis wander so the spin axis precesses organically
+    const w = randomDir();
+    const wander = 0.4 * dt;
+    let ax = this.omega[0] / speed + w[0] * wander;
+    let ay = this.omega[1] / speed + w[1] * wander;
+    let az = this.omega[2] / speed + w[2] * wander;
+    const axisLen = Math.hypot(ax, ay, az);
+    ax /= axisLen;
+    ay /= axisLen;
+    az /= axisLen;
+    this.omega = [ax * newSpeed, ay * newSpeed, az * newSpeed];
+
+    // Integrate: world-frame angular velocity pre-multiplies the orientation
+    this.q = quatNormalize(
+      quatMultiply(quatFromAxisAngle([ax, ay, az], newSpeed * dt), this.q)
+    );
+    return this.q;
+  }
+}

--- a/src/lib/dieRenderer.ts
+++ b/src/lib/dieRenderer.ts
@@ -1,0 +1,391 @@
+// Canvas-2D d20 renderer driven by an orientation quaternion (+ optional
+// world position for rolls). Faces are drawn as projected, depth-sorted,
+// Lambert-shaded polygons — no WebGL, no dependencies beyond the geometry
+// and quaternion helpers.
+
+import {
+  D20_VERTICES,
+  D20_FACES,
+  D20_FACE_NUMBERS,
+  D20_FACE_NORMALS,
+} from '@/lib/d20Geometry';
+import { DIE_RADIUS } from '@/lib/diceConfig';
+import {
+  type Quat,
+  type Vec3,
+  quatApply,
+  vecCross,
+  vecDot,
+  vecNormalize,
+  vecSub,
+} from '@/lib/quat';
+
+export interface DieCamera {
+  pos: Vec3;
+  look: Vec3;
+  fovDeg: number;
+}
+
+/** Angled overhead view framing the roll tray (404 page) */
+export const TRAY_CAMERA: DieCamera = {
+  pos: [0, 9.6, 4.6],
+  look: [0, 0.3, 0],
+  fovDeg: 42,
+};
+
+/** Straight-on close view where the die fills the frame (loading spinner) */
+export const SPINNER_CAMERA: DieCamera = {
+  pos: [0, 0, 4.2],
+  look: [0, 0, 0],
+  fovDeg: 42,
+};
+
+export interface DieTheme {
+  h: number;
+  s: number;
+  l: number;
+  isDark: boolean;
+}
+
+export interface D20RendererOptions {
+  /** Draw the floor contact shadow (default true; off for spinner mode) */
+  shadow?: boolean;
+  /** Which face numbers to draw: every face, or only the gold 20 (default 'all') */
+  numbers?: 'all' | 'crit';
+}
+
+// Parse a CSS color custom property: Tailwind HSL triple ("262.1 83.3% 57.8%")
+// or hex ("#7c3aed" / "#fff")
+function parseColorToHSL(
+  raw: string
+): { h: number; s: number; l: number } | null {
+  const triple = raw.match(/^([\d.]+)\s+([\d.]+)%?\s+([\d.]+)%?$/);
+  if (triple) {
+    return {
+      h: parseFloat(triple[1]),
+      s: parseFloat(triple[2]),
+      l: parseFloat(triple[3]),
+    };
+  }
+  if (raw.startsWith('#')) {
+    let hex = raw.slice(1);
+    if (hex.length === 3) {
+      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    const r = parseInt(hex.slice(0, 2), 16) / 255;
+    const g = parseInt(hex.slice(2, 4), 16) / 255;
+    const b = parseInt(hex.slice(4, 6), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return { h: 0, s: 0, l: l * 100 };
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h = 0;
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+    return { h: h * 360, s: s * 100, l: l * 100 };
+  }
+  return null;
+}
+
+/** Read the die's theme from the document's CSS variables */
+export function readDieTheme(): DieTheme {
+  const style = getComputedStyle(document.documentElement);
+  const primary =
+    parseColorToHSL(style.getPropertyValue('--primary').trim()) ?? {
+      h: 262,
+      s: 83,
+      l: 58,
+    };
+  const foreground = parseColorToHSL(
+    style.getPropertyValue('--foreground').trim()
+  );
+  // Dark themes have a light foreground
+  return { ...primary, isDark: (foreground?.l ?? 10) > 50 };
+}
+
+const LIGHT_DIR = vecNormalize([4, 12, 4]);
+const TEXT_SCALE = 0.4 * DIE_RADIUS; // world-space size of the number quad
+
+export class D20Renderer {
+  private ctx: CanvasRenderingContext2D;
+  private dpr = 1;
+  private w = 0;
+  private h = 0;
+  // Camera basis
+  private camPos: Vec3;
+  private fwd: Vec3;
+  private right: Vec3;
+  private up: Vec3;
+  private focal: number;
+  private theme: DieTheme;
+  private shadow: boolean;
+  private numbers: 'all' | 'crit';
+  private verticalCenterCache = new Map<string, number>();
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    camera: DieCamera,
+    theme: DieTheme,
+    opts: D20RendererOptions = {}
+  ) {
+    this.ctx = canvas.getContext('2d')!;
+    this.theme = theme;
+    this.shadow = opts.shadow ?? true;
+    this.numbers = opts.numbers ?? 'all';
+    this.camPos = camera.pos;
+    this.fwd = vecNormalize(vecSub(camera.look, camera.pos));
+    this.right = vecNormalize(vecCross(this.fwd, [0, 1, 0]));
+    this.up = vecCross(this.right, this.fwd);
+    this.focal = 1 / Math.tan(((camera.fovDeg / 2) * Math.PI) / 180);
+
+    // Pre-cache text vertical-center offsets (transform-independent)
+    this.ctx.save();
+    this.ctx.font = 'bold 1.1px sans-serif';
+    for (let n = 1; n <= 20; n++) {
+      const text = String(n);
+      const m = this.ctx.measureText(text);
+      this.verticalCenterCache.set(
+        text,
+        m.actualBoundingBoxAscent -
+          (m.actualBoundingBoxAscent + m.actualBoundingBoxDescent)
+      );
+    }
+    this.ctx.restore();
+  }
+
+  setTheme(theme: DieTheme) {
+    this.theme = theme;
+  }
+
+  resize(w: number, h: number, dpr: number) {
+    this.w = w;
+    this.h = h;
+    this.dpr = dpr;
+    this.canvas.width = w * dpr;
+    this.canvas.height = h * dpr;
+  }
+
+  // Perspective-project a world point to canvas pixels (+ camera depth)
+  private project(pt: Vec3): [number, number, number] {
+    const d = vecSub(pt, this.camPos);
+    const zv = vecDot(d, this.fwd);
+    const xv = vecDot(d, this.right);
+    const yv = vecDot(d, this.up);
+    const k = (this.focal * this.h) / 2 / zv;
+    return [this.w / 2 + xv * k, this.h / 2 - yv * k, zv];
+  }
+
+  /**
+   * Draw a frame. Optional hooks draw extra effects in CSS-pixel space:
+   * `underlay` after the clear but behind the die, `overlay` on top of it.
+   */
+  render(
+    p: Vec3 | null,
+    q: Quat | null,
+    hooks?: {
+      underlay?: (ctx: CanvasRenderingContext2D) => void;
+      overlay?: (ctx: CanvasRenderingContext2D) => void;
+    }
+  ) {
+    const { ctx, dpr, w, h } = this;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    if (!p || !q) return;
+
+    hooks?.underlay?.(ctx);
+    if (this.shadow) this.drawShadow(p);
+    this.drawDie(p, q);
+    hooks?.overlay?.(ctx);
+  }
+
+  /** A world point's canvas position in CSS pixels, plus the die's
+   *  approximate on-screen radius there — for positioning effects. */
+  screenPosition(p: Vec3): { x: number; y: number; radius: number } {
+    const c = this.project(p);
+    const edge = this.project([p[0] + DIE_RADIUS, p[1], p[2]]);
+    return { x: c[0], y: c[1], radius: Math.abs(edge[0] - c[0]) };
+  }
+
+  // Contact shadow: a projected ellipse on the floor that fades with height
+  private drawShadow(p: Vec3) {
+    const { ctx, dpr } = this;
+    const height = Math.max(0, p[1]);
+    const alpha = 0.32 * Math.max(0.12, 1 - height * 0.12);
+    const r = DIE_RADIUS * 0.92 * (1 - Math.min(height * 0.04, 0.3));
+
+    const center: Vec3 = [p[0], 0.01, p[2]];
+    const c = this.project(center);
+    const px = this.project([center[0] + r, center[1], center[2]]);
+    const pz = this.project([center[0], center[1], center[2] + r]);
+
+    ctx.save();
+    ctx.setTransform(
+      (px[0] - c[0]) * dpr,
+      (px[1] - c[1]) * dpr,
+      (pz[0] - c[0]) * dpr,
+      (pz[1] - c[1]) * dpr,
+      c[0] * dpr,
+      c[1] * dpr
+    );
+    ctx.beginPath();
+    ctx.arc(0, 0, 1, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(0, 0, 0, ${alpha})`;
+    ctx.fill();
+    ctx.restore();
+  }
+
+  private drawDie(p: Vec3, q: Quat) {
+    const { ctx, theme } = this;
+
+    // Transform vertices to world space, project to screen
+    const world: Vec3[] = D20_VERTICES.map((v) => {
+      const r = quatApply(q, [
+        v[0] * DIE_RADIUS,
+        v[1] * DIE_RADIUS,
+        v[2] * DIE_RADIUS,
+      ]);
+      return [r[0] + p[0], r[1] + p[1], r[2] + p[2]];
+    });
+    const screen = world.map((v) => this.project(v));
+
+    // Approximate on-screen die radius for stroke width scaling
+    const c0 = this.project(p);
+    const cEdge = this.project([p[0] + DIE_RADIUS, p[1], p[2]]);
+    const screenRadius = Math.abs(cEdge[0] - c0[0]);
+
+    // Depth-sort faces back to front (larger camera depth first)
+    const order = D20_FACES.map((face, faceIndex) => {
+      const depth =
+        (screen[face[0]][2] + screen[face[1]][2] + screen[face[2]][2]) / 3;
+      return { face, faceIndex, depth };
+    }).sort((a, b) => b.depth - a.depth);
+
+    const { h, s, isDark } = theme;
+    const minL = isDark ? 28 : 30;
+    const maxL = isDark ? 68 : 62;
+
+    for (const { face, faceIndex } of order) {
+      const [i, j, k] = face;
+      const nWorld = quatApply(q, D20_FACE_NORMALS[faceIndex]);
+      const faceCenter: Vec3 = [
+        (world[i][0] + world[j][0] + world[k][0]) / 3,
+        (world[i][1] + world[j][1] + world[k][1]) / 3,
+        (world[i][2] + world[j][2] + world[k][2]) / 3,
+      ];
+      const toCam = vecNormalize(vecSub(this.camPos, faceCenter));
+      const visible = vecDot(nWorld, toCam) > 0;
+
+      // Lambert shading against a fixed top-right key light. The low ambient
+      // floor keeps real contrast between lit and shaded faces.
+      const lambert = Math.max(0, vecDot(nWorld, LIGHT_DIR));
+      const intensity = 0.12 + 0.88 * lambert;
+      // Plastic sheen: a Blinn-Phong-style highlight on faces angled between
+      // the light and the camera, so the brightest face visibly pops
+      const halfVec = vecNormalize([
+        LIGHT_DIR[0] + toCam[0],
+        LIGHT_DIR[1] + toCam[1],
+        LIGHT_DIR[2] + toCam[2],
+      ]);
+      const spec = Math.pow(Math.max(0, vecDot(nWorld, halfVec)), 14);
+      const lightness = Math.min(
+        minL + intensity * (maxL - minL) + spec * 12,
+        maxL + 14
+      );
+
+      ctx.beginPath();
+      ctx.moveTo(screen[i][0], screen[i][1]);
+      ctx.lineTo(screen[j][0], screen[j][1]);
+      ctx.lineTo(screen[k][0], screen[k][1]);
+      ctx.closePath();
+      ctx.fillStyle = `hsl(${h}, ${s}%, ${lightness}%)`;
+      ctx.fill();
+      ctx.strokeStyle = `hsl(${h}, ${isDark ? 60 : 50}%, 25%)`;
+      ctx.lineWidth = Math.max(1, screenRadius / 24);
+      ctx.lineJoin = 'round';
+      ctx.stroke();
+
+      if (visible && (this.numbers === 'all' || faceIndex === 0)) {
+        this.drawFaceNumber(faceIndex, world[i], world[j], world[k], nWorld);
+      }
+    }
+  }
+
+  // Draw the face number via an affine transform built from three projected
+  // anchor points, so the glyph tracks the face in perspective.
+  private drawFaceNumber(
+    faceIndex: number,
+    v0: Vec3,
+    v1: Vec3,
+    v2: Vec3,
+    nWorld: Vec3
+  ) {
+    const { ctx, dpr } = this;
+    const centroid: Vec3 = [
+      (v0[0] + v1[0] + v2[0]) / 3,
+      (v0[1] + v1[1] + v2[1]) / 3,
+      (v0[2] + v1[2] + v2[2]) / 3,
+    ];
+    // Text-up points toward the apex vertex (v0)
+    const localY = vecNormalize(vecSub(v0, centroid));
+    // localY × n (not n × localY): the projection flips screen-y, which flips
+    // chirality, so the right-direction must flip too or numbers mirror
+    const localX = vecCross(localY, nWorld);
+
+    const cProj = this.project(centroid);
+    const xProj = this.project([
+      centroid[0] + localX[0] * TEXT_SCALE,
+      centroid[1] + localX[1] * TEXT_SCALE,
+      centroid[2] + localX[2] * TEXT_SCALE,
+    ]);
+    const yProj = this.project([
+      centroid[0] + localY[0] * TEXT_SCALE,
+      centroid[1] + localY[1] * TEXT_SCALE,
+      centroid[2] + localY[2] * TEXT_SCALE,
+    ]);
+
+    const ax = xProj[0] - cProj[0];
+    const ay = xProj[1] - cProj[1];
+    // Negated: canvas text +y is downward, we want it pointing away from apex
+    const bx = cProj[0] - yProj[0];
+    const by = cProj[1] - yProj[1];
+
+    ctx.save();
+    ctx.setTransform(
+      ax * dpr,
+      ay * dpr,
+      bx * dpr,
+      by * dpr,
+      cProj[0] * dpr,
+      cProj[1] * dpr
+    );
+
+    const num = D20_FACE_NUMBERS[faceIndex];
+    const text = String(num);
+    const isCrit = num === 20;
+    const textY = 0.45 + (this.verticalCenterCache.get(text) ?? 0);
+
+    ctx.font = 'bold 1.1px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'alphabetic';
+    ctx.strokeStyle = isCrit ? 'rgba(0, 0, 0, 0.8)' : 'rgba(0, 0, 0, 0.6)';
+    ctx.lineWidth = isCrit ? 0.1 : 0.08;
+    ctx.lineJoin = 'round';
+    ctx.strokeText(text, 0, textY);
+    ctx.fillStyle = isCrit ? 'hsl(45, 100%, 50%)' : 'rgba(255, 255, 255, 0.9)';
+    ctx.fillText(text, 0, textY);
+
+    // Underline 6 and 9 so orientation is unambiguous
+    if (num === 6 || num === 9) {
+      ctx.beginPath();
+      ctx.moveTo(-0.28, 0.62);
+      ctx.lineTo(0.28, 0.62);
+      ctx.lineWidth = 0.09;
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}

--- a/src/lib/quat.test.ts
+++ b/src/lib/quat.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type Quat,
+  type Vec3,
+  QUAT_IDENTITY,
+  quatApply,
+  quatFromAxisAngle,
+  quatFromMat3,
+  quatFromUnitVectors,
+  quatMultiply,
+  quatNormalize,
+  quatSlerp,
+  vecNormalize,
+} from './quat';
+
+const closeTo = (a: number[], b: number[], eps = 1e-10) => {
+  expect(a.length).toBe(b.length);
+  a.forEach((v, i) => expect(Math.abs(v - b[i])).toBeLessThan(eps));
+};
+
+describe('quat', () => {
+  it('identity leaves vectors unchanged', () => {
+    closeTo(quatApply(QUAT_IDENTITY, [1, 2, 3]), [1, 2, 3]);
+  });
+
+  it('multiply composes rotations (apply b then a)', () => {
+    const rotX90 = quatFromAxisAngle([1, 0, 0], Math.PI / 2);
+    const rotY90 = quatFromAxisAngle([0, 1, 0], Math.PI / 2);
+    const composed = quatMultiply(rotY90, rotX90);
+    const direct = quatApply(rotY90, quatApply(rotX90, [0, 0, 1]));
+    closeTo(quatApply(composed, [0, 0, 1]), direct);
+  });
+
+  it('axis-angle rotates by the given angle', () => {
+    const q = quatFromAxisAngle([0, 0, 1], Math.PI / 2);
+    closeTo(quatApply(q, [1, 0, 0]), [0, 1, 0]);
+  });
+
+  it('fromUnitVectors maps a onto b', () => {
+    const a = vecNormalize([1, 2, -0.5]);
+    const b = vecNormalize([-0.3, 1, 2]);
+    closeTo(quatApply(quatFromUnitVectors(a, b), a), b);
+  });
+
+  it('fromUnitVectors handles opposite vectors', () => {
+    const a: Vec3 = [0, 1, 0];
+    closeTo(quatApply(quatFromUnitVectors(a, [0, -1, 0]), a), [0, -1, 0]);
+  });
+
+  it('slerp hits both endpoints and stays normalized midway', () => {
+    const a = quatFromAxisAngle([1, 0, 0], 0.3);
+    const b = quatFromAxisAngle([0, 1, 0], 1.9);
+    closeTo(quatSlerp(a, b, 0), a);
+    closeTo(quatSlerp(a, b, 1), b, 1e-9);
+    const mid = quatSlerp(a, b, 0.5);
+    expect(Math.hypot(...mid)).toBeCloseTo(1, 10);
+  });
+
+  it('fromMat3 agrees with axis-angle', () => {
+    const angle = 1.1;
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    // Rotation about z by `angle` as a row-major matrix
+    const m = [
+      [c, -s, 0],
+      [s, c, 0],
+      [0, 0, 1],
+    ];
+    const expected = quatFromAxisAngle([0, 0, 1], angle);
+    const got = quatFromMat3(m);
+    // q and -q are the same rotation
+    const sign = Math.sign(got[3] * expected[3]) || 1;
+    closeTo(
+      got.map((v) => v * sign),
+      [...expected]
+    );
+  });
+
+  it('normalize returns a unit quaternion', () => {
+    const q = quatNormalize([1, 2, 3, 4] as Quat);
+    expect(Math.hypot(...q)).toBeCloseTo(1, 12);
+  });
+});

--- a/src/lib/quat.ts
+++ b/src/lib/quat.ts
@@ -1,0 +1,156 @@
+// Minimal quaternion / vector math, dependency-free.
+// Used by the dice physics playback so the canvas-2D renderer needs no three.js.
+
+export type Quat = [number, number, number, number]; // x, y, z, w
+export type Vec3 = [number, number, number];
+
+export const QUAT_IDENTITY: Quat = [0, 0, 0, 1];
+
+export function quatMultiply(a: Quat, b: Quat): Quat {
+  const [ax, ay, az, aw] = a;
+  const [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+}
+
+export function quatApply(q: Quat, v: Vec3): Vec3 {
+  // v' = v + 2w(q×v) + 2(q×(q×v))
+  const [qx, qy, qz, qw] = q;
+  const [vx, vy, vz] = v;
+  const tx = 2 * (qy * vz - qz * vy);
+  const ty = 2 * (qz * vx - qx * vz);
+  const tz = 2 * (qx * vy - qy * vx);
+  return [
+    vx + qw * tx + qy * tz - qz * ty,
+    vy + qw * ty + qz * tx - qx * tz,
+    vz + qw * tz + qx * ty - qy * tx,
+  ];
+}
+
+export function quatSlerp(a: Quat, b: Quat, t: number): Quat {
+  let [bx, by, bz, bw] = b;
+  const [ax, ay, az, aw] = a;
+  let dot = ax * bx + ay * by + az * bz + aw * bw;
+  // Take the shortest path
+  if (dot < 0) {
+    bx = -bx;
+    by = -by;
+    bz = -bz;
+    bw = -bw;
+    dot = -dot;
+  }
+  if (dot > 0.9995) {
+    // Nearly identical: linear interpolation, then normalize
+    const x = ax + (bx - ax) * t;
+    const y = ay + (by - ay) * t;
+    const z = az + (bz - az) * t;
+    const w = aw + (bw - aw) * t;
+    const len = Math.sqrt(x * x + y * y + z * z + w * w);
+    return [x / len, y / len, z / len, w / len];
+  }
+  const theta = Math.acos(dot);
+  const sinTheta = Math.sin(theta);
+  const sa = Math.sin((1 - t) * theta) / sinTheta;
+  const sb = Math.sin(t * theta) / sinTheta;
+  return [
+    ax * sa + bx * sb,
+    ay * sa + by * sb,
+    az * sa + bz * sb,
+    aw * sa + bw * sb,
+  ];
+}
+
+export function quatNormalize(q: Quat): Quat {
+  const len = Math.sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+  return [q[0] / len, q[1] / len, q[2] / len, q[3] / len];
+}
+
+export function quatFromAxisAngle(axis: Vec3, angle: number): Quat {
+  const half = angle / 2;
+  const s = Math.sin(half);
+  return [axis[0] * s, axis[1] * s, axis[2] * s, Math.cos(half)];
+}
+
+// Rotation taking unit vector a onto unit vector b (minimal arc)
+export function quatFromUnitVectors(a: Vec3, b: Vec3): Quat {
+  const w = 1 + (a[0] * b[0] + a[1] * b[1] + a[2] * b[2]);
+  let x: number, y: number, z: number;
+  if (w < 1e-8) {
+    // Opposite vectors: rotate 180° around any axis orthogonal to a
+    if (Math.abs(a[0]) > Math.abs(a[2])) {
+      x = -a[1];
+      y = a[0];
+      z = 0;
+    } else {
+      x = 0;
+      y = -a[2];
+      z = a[1];
+    }
+    const len = Math.sqrt(x * x + y * y + z * z);
+    return [x / len, y / len, z / len, 0];
+  }
+  x = a[1] * b[2] - a[2] * b[1];
+  y = a[2] * b[0] - a[0] * b[2];
+  z = a[0] * b[1] - a[1] * b[0];
+  const len = Math.sqrt(x * x + y * y + z * z + w * w);
+  return [x / len, y / len, z / len, w / len];
+}
+
+// Quaternion from a 3x3 rotation matrix given as rows (Shepperd's method)
+export function quatFromMat3(m: number[][]): Quat {
+  const tr = m[0][0] + m[1][1] + m[2][2];
+  let x: number, y: number, z: number, w: number;
+  if (tr > 0) {
+    const s = Math.sqrt(tr + 1) * 2;
+    w = s / 4;
+    x = (m[2][1] - m[1][2]) / s;
+    y = (m[0][2] - m[2][0]) / s;
+    z = (m[1][0] - m[0][1]) / s;
+  } else if (m[0][0] > m[1][1] && m[0][0] > m[2][2]) {
+    const s = Math.sqrt(1 + m[0][0] - m[1][1] - m[2][2]) * 2;
+    w = (m[2][1] - m[1][2]) / s;
+    x = s / 4;
+    y = (m[0][1] + m[1][0]) / s;
+    z = (m[0][2] + m[2][0]) / s;
+  } else if (m[1][1] > m[2][2]) {
+    const s = Math.sqrt(1 + m[1][1] - m[0][0] - m[2][2]) * 2;
+    w = (m[0][2] - m[2][0]) / s;
+    x = (m[0][1] + m[1][0]) / s;
+    y = s / 4;
+    z = (m[1][2] + m[2][1]) / s;
+  } else {
+    const s = Math.sqrt(1 + m[2][2] - m[0][0] - m[1][1]) * 2;
+    w = (m[1][0] - m[0][1]) / s;
+    x = (m[0][2] + m[2][0]) / s;
+    y = (m[1][2] + m[2][1]) / s;
+    z = s / 4;
+  }
+  return [x, y, z, w];
+}
+
+// ── Small Vec3 helpers ──
+
+export function vecCross(a: Vec3, b: Vec3): Vec3 {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+export function vecSub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+export function vecDot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+export function vecNormalize(a: Vec3): Vec3 {
+  const len = Math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
+  return [a[0] / len, a[1] / len, a[2] / len];
+}


### PR DESCRIPTION
## Summary

Replaces the constant-rate spinning die with realistic physics, like the dice rollers in VTTs:

- **404 page** — a real thrown d20: simulated headlessly with cannon-es (random throw into an invisible tray, bounces, friction, sleep detection), recorded, then played back on the canvas. The predetermined result is applied by relabeling faces with an icosahedral symmetry rotation, so the motion is untouched physics. Throws that settle cocked or too quickly are silently re-simulated (~1–2ms each). Rolling a **natural 20 erupts in a gold light-ray/spark celebration burst**. `?roll=N` forces rolls deterministically (used by e2e; handy for demos).
- **Loading spinner** — perpetual physics-feel tumble: drifting spin axis, periodic flicks that decay under drag. Pure quaternion integration, no physics engine.
- **Shading** — Lambert lighting with a low ambient floor plus a Blinn-Phong specular highlight, so the die reads properly 3D.

## Architecture

| Module | Role |
|---|---|
| `src/lib/quat.ts` | Dependency-free quaternion/vector math |
| `src/lib/d20Geometry.ts` | Shared icosahedron vertices/faces/numbers |
| `src/lib/diceConfig.ts` | Die/tray sizing shared by physics + renderer |
| `src/lib/dieRenderer.ts` | Canvas-2D `D20Renderer` driven by quaternion poses, theme-aware |
| `src/lib/dicePhysics.ts` | Headless cannon-es simulation + playback |
| `src/lib/diceTumble.ts` | Engine-free tumble for the spinner |
| `src/lib/critBurst.ts` | Nat-20 particle celebration |

**Bundle impact**: the only new dependency is cannon-es, in a lazy chunk (**~23KB gzip**) loaded solely when the 404 page rolls. The spinner path adds only quaternion math. (three.js was evaluated on a comparison test page and rejected — the canvas renderer matched it closely at a fraction of the size.)

Also fixes two pre-existing issues surfaced along the way: a 404 flex-layout circularity that collapsed the roll canvas to its intrinsic size, and a hydration mismatch from the SSR'd random roll (now client-only via `useSyncExternalStore`).

## Test plan

- [x] 29 new unit tests: quat algebra invariants, d20 geometry (opposite faces sum to 21, analytic inradius), physics (flat landings, icosahedral relabel maps vertices onto vertices, forced playback ends with the forced face up), tumble stability, crit burst lifecycle
- [x] New e2e spec `e2e/tests/home/not-found.spec.ts`: roll message matches the die's aria-label, Roll Again re-rolls, nat-20 burst verified by gold-pixel counting
- [x] Full suite: 487/487 unit tests, lint, production build
- [x] Verified in browser: 404 roll + crit burst and spinner sizes, light/dark themes, desktop and 390px mobile