### PR TITLE
Fix CI: restore Data API grants revoked by Supabase CLI v2.106.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned: "latest" both drifts (v2.106.0 changed default grants under
+          # us) and flakes (GitHub API rate limit while resolving the tag)
+          version: 2.106.0
 
       - name: Start Supabase (background)
         run: |

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -521,3 +521,21 @@ CREATE POLICY "GMs and co-GMs can update play dates" ON game_play_dates
   FOR UPDATE USING (public.is_game_gm_or_co_gm(game_id, (select auth.uid())));
 CREATE POLICY "GMs and co-GMs can delete play dates" ON game_play_dates
   FOR DELETE USING (public.is_game_gm_or_co_gm(game_id, (select auth.uid())));
+
+-- ============================================================
+-- Data API role grants
+-- ============================================================
+-- Supabase CLI v2.106.0+ defaults [api].auto_expose_new_tables to false and
+-- revokes the legacy default privileges on new public-schema objects. These
+-- explicit grants restore the long-standing behavior this schema was built
+-- against; row-level access is still enforced by the RLS policies above.
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;


### PR DESCRIPTION
## Problem

Every e2e CI run since ~12:00 UTC today fails catastrophically (255 failed / 23 passed on #116, and a re-run of the previously-green main commit also failed). Root cause is not in any PR:

- The e2e workflow installs the Supabase CLI with `version: latest`.
- **Supabase CLI v2.106.0** (released 2026-06-11 12:01 UTC, between our last green run and the first red one) ships a breaking change: `[api].auto_expose_new_tables` now defaults to `false`, and local start/reset **revokes the legacy default privileges for new public-schema tables, sequences, and functions**.
- Our `schema.sql` relied on those defaults (it has a single explicit GRANT, for one function). On the new stack even `service_role` gets `permission denied for table games`, so test seeding throws and every authenticated page hangs at the loading spinner until timeout.

## Fix

1. **Explicit GRANTs in `schema.sql`** for `anon`, `authenticated`, `service_role` on all public tables/sequences/functions, plus matching `ALTER DEFAULT PRIVILEGES` — the durable migration path the release notes prescribe. This restores the exact pre-2.106 semantics; **RLS remains the security boundary** and is enabled on all 6 tables.
2. **Pin the CLI to `2.106.0`** in the workflow. `latest` both drifted under us and intermittently fails to resolve at all (GitHub API rate limit, observed on a re-run today).

No production migration is needed: existing hosted tables keep the grants they were created with; this affects fresh `supabase start`/`db reset` environments (CI, new local setups).

## Test plan

- [x] `npm run db:reset` applies the amended schema cleanly on the older local CLI (v2.98) — backward compatible
- [x] admin + api e2e specs: 19/19 pass locally against the amended schema
- [x] CI on this PR runs the full suite under the pinned v2.106.0 — the real proof, since only CI has the new image

After this merges, re-running the e2e check on #116 should go green (its failures were entirely this).