### PR TITLE
Admin: Top Users leaderboards and read-only game peek view

### DIFF
--- a/e2e/tests/admin/dashboard.spec.ts
+++ b/e2e/tests/admin/dashboard.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { loginTestUser, createTestUser } from '../../helpers/test-auth';
-import { createTestGame, addPlayerToGame, createTestSession } from '../../helpers/seed';
+import { createTestGame, addPlayerToGame, createTestSession, getPlayDates } from '../../helpers/seed';
 import { TEST_TIMEOUTS } from '../../constants';
 
 test.describe('Admin Dashboard', () => {
@@ -193,6 +193,52 @@ test.describe('Admin Dashboard', () => {
     // Should see metric columns
     await expect(page.getByText(/players/i)).toBeVisible();
     await expect(page.getByText(/fill rate/i)).toBeVisible();
+  });
+
+  test('top users tab shows GM and player leaderboards', async ({ page, request }) => {
+    const ts = Date.now();
+    const admin = await createTestUser(request, {
+      email: `admin-top-${ts}@e2e.local`,
+      name: 'Admin Top User',
+      is_gm: true,
+      is_admin: true,
+    });
+    const player = await createTestUser(request, {
+      email: `player-top-${ts}@e2e.local`,
+      name: 'Top Player One',
+      is_gm: false,
+      is_admin: false,
+    });
+
+    const game = await createTestGame({
+      gm_id: admin.id,
+      name: 'Top Users Game',
+      play_days: [5, 6],
+    });
+    await addPlayerToGame(game.id, player.id);
+    await createTestSession({
+      game_id: game.id,
+      date: getPlayDates([5, 6], 2)[0],
+      confirmed_by: admin.id,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: true,
+      is_admin: true,
+    });
+
+    await page.goto('/admin');
+    await page.getByRole('button', { name: /top users/i }).click();
+
+    const gmsTable = page.getByTestId('top-gms-table');
+    await expect(gmsTable).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+    await expect(gmsTable.getByText('Admin Top User')).toBeVisible();
+
+    const playersTable = page.getByTestId('top-players-table');
+    await expect(playersTable).toBeVisible();
+    await expect(playersTable.getByText('Top Player One')).toBeVisible();
   });
 
   test('activity tab shows recent users and games', async ({ page, request }) => {

--- a/e2e/tests/admin/dashboard.spec.ts
+++ b/e2e/tests/admin/dashboard.spec.ts
@@ -239,6 +239,16 @@ test.describe('Admin Dashboard', () => {
     const playersTable = page.getByTestId('top-players-table');
     await expect(playersTable).toBeVisible();
     await expect(playersTable.getByText('Top Player One')).toBeVisible();
+
+    // Expanding a player row reveals their games as links to the peek view
+    await playersTable.getByText('Top Player One').click();
+    const gameLink = playersTable.getByRole('link', { name: /top users game/i });
+    await expect(gameLink).toBeVisible();
+    await gameLink.click();
+    await expect(page).toHaveURL(`/admin/games/${game.id}`, { timeout: TEST_TIMEOUTS.LONG });
+    await expect(page.getByTestId('admin-peek-banner')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
   });
 
   test('activity tab shows recent users and games', async ({ page, request }) => {

--- a/e2e/tests/admin/peek.spec.ts
+++ b/e2e/tests/admin/peek.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  addPlayerToGame,
+  createTestSession,
+  setAvailability,
+  getPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Admin Game Peek', () => {
+  test('admin can view a game they are not a member of, read-only', async ({ page, request }) => {
+    const ts = Date.now();
+    const gm = await createTestUser(request, {
+      email: `peek-gm-${ts}@e2e.local`,
+      name: 'Peek GM',
+      is_gm: true,
+      is_admin: false,
+    });
+    const player = await createTestUser(request, {
+      email: `peek-player-${ts}@e2e.local`,
+      name: 'Peek Player',
+      is_gm: false,
+      is_admin: false,
+    });
+    const admin = await createTestUser(request, {
+      email: `peek-admin-${ts}@e2e.local`,
+      name: 'Peek Admin',
+      is_gm: false,
+      is_admin: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Peek Test Campaign',
+      play_days: [5, 6],
+    });
+    await addPlayerToGame(game.id, player.id);
+
+    const dates = getPlayDates([5, 6], 2);
+    await setAvailability(
+      player.id,
+      game.id,
+      dates.map((date) => ({ date, status: 'available' as const }))
+    );
+    await createTestSession({
+      game_id: game.id,
+      date: dates[0],
+      confirmed_by: gm.id,
+    });
+
+    // The admin is NOT a member of this game — only the peek view can show it
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+    await page.goto(`/admin/games/${game.id}`);
+
+    // Read-only banner and game header
+    await expect(page.getByTestId('admin-peek-banner')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.getByRole('heading', { name: 'Peek Test Campaign' })).toBeVisible();
+
+    // Overview shows the party but no management controls
+    await expect(page.getByTestId('overview-tab-content')).toBeVisible();
+    await expect(page.getByText('Peek Player').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /^edit$/i })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /copy invite link/i })).toHaveCount(0);
+
+    // Availability tab: read-only calendar without bulk actions, per-player view
+    await page.getByRole('button', { name: /^availability$/i }).click();
+    await expect(page.getByTestId('availability-tab-content')).toBeVisible();
+    await expect(page.getByText(/mark all/i)).toHaveCount(0);
+    await page.getByTestId('peek-view-as-select').selectOption(player.id);
+    await expect(page.getByTestId('availability-tab-content')).toBeVisible();
+
+    // Schedule tab renders with no scheduling actions
+    await page.getByRole('button', { name: /^schedule$/i }).click();
+    await expect(page.getByTestId('schedule-tab-content')).toBeVisible();
+    await expect(page.getByRole('button', { name: /schedule game/i })).toHaveCount(0);
+  });
+
+  test('non-admin cannot access the peek page or snapshot API', async ({ page, request }) => {
+    const ts = Date.now();
+    const gm = await createTestUser(request, {
+      email: `peek-noadm-gm-${ts}@e2e.local`,
+      name: 'Peek NoAdmin GM',
+      is_gm: true,
+      is_admin: false,
+    });
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Peek Forbidden Game',
+      play_days: [5, 6],
+    });
+    const user = await createTestUser(request, {
+      email: `peek-noadm-user-${ts}@e2e.local`,
+      name: 'Peek NoAdmin User',
+      is_gm: false,
+      is_admin: false,
+    });
+
+    await loginTestUser(page, {
+      email: user.email,
+      name: user.name,
+      is_gm: false,
+      is_admin: false,
+    });
+
+    // Snapshot API rejects non-admins
+    const res = await page.request.get(`/api/admin/games/${game.id}`);
+    expect(res.status()).toBe(403);
+
+    // Peek page redirects non-admins away
+    await page.goto(`/admin/games/${game.id}`);
+    await expect(page).toHaveURL('/dashboard', { timeout: TEST_TIMEOUTS.LONG });
+  });
+
+  test('admin sees not-found state for a missing game', async ({ page, request }) => {
+    const admin = await createTestUser(request, {
+      email: `peek-404-admin-${Date.now()}@e2e.local`,
+      name: 'Peek 404 Admin',
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await page.goto('/admin/games/00000000-0000-0000-0000-000000000000');
+    await expect(page.getByText(/game not found/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+});

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Eye } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useAuthRedirect } from '@/hooks/useAuthRedirect';
+import { useUserPreferences } from '@/hooks/useUserPreferences';
+import { useGameDerivedState } from '@/hooks/useGameDerivedState';
+import { LoadingSpinner } from '@/components/ui';
+import { OverviewTabContent } from '@/components/games/overview/OverviewTabContent';
+import { AvailabilityTabContent } from '@/components/games/availability/AvailabilityTabContent';
+import { ScheduleTabContent } from '@/components/games/schedule/ScheduleTabContent';
+import type { AvailabilityEntry } from '@/components/calendar/AvailabilityCalendar';
+import type {
+  Availability,
+  GamePlayDate,
+  GameSession,
+  GameWithMembers,
+} from '@/types';
+
+type Tab = 'overview' | 'availability' | 'schedule';
+
+interface GameSnapshot {
+  game: GameWithMembers;
+  availability: Availability[];
+  sessions: GameSession[];
+  playDates: GamePlayDate[];
+}
+
+// Read-only admin peek at any game. All data comes from a GET-only admin API
+// and every mutation callback is a no-op, so nothing here can modify the game.
+const READ_ONLY_ERROR = { success: false as const, error: 'Read-only admin view' };
+const noopAsync = async () => {};
+const noopMutation = async () => READ_ONLY_ERROR;
+
+export default function AdminGamePeekPage() {
+  const { authStatus, profile } = useAuth();
+  const { weekStartDay, use24h, timezone: userTimezone } = useUserPreferences();
+  const params = useParams();
+  const gameId = params.id as string;
+
+  const [snapshot, setSnapshot] = useState<GameSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [viewAsUserId, setViewAsUserId] = useState<string>('');
+
+  useAuthRedirect({ requireAdmin: true });
+
+  useEffect(() => {
+    async function fetchSnapshot() {
+      if (!profile?.is_admin || !gameId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/admin/games/${gameId}`);
+        if (res.status === 404) {
+          setError('Game not found');
+          return;
+        }
+        if (!res.ok) {
+          throw new Error('Failed to fetch game');
+        }
+        const data: GameSnapshot = await res.json();
+        setSnapshot(data);
+        setViewAsUserId(data.game.gm_id);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSnapshot();
+  }, [profile?.is_admin, gameId]);
+
+  const game = snapshot?.game ?? null;
+  const allAvailability = useMemo(() => snapshot?.availability ?? [], [snapshot]);
+  const sessions = useMemo(() => snapshot?.sessions ?? [], [snapshot]);
+  const playDates = useMemo(() => snapshot?.playDates ?? [], [snapshot]);
+
+  const {
+    extraDateStrings,
+    playDateNotes,
+    specialPlayDatesSet,
+    windowStart,
+    windowEnd,
+    completionByUserId,
+    suggestions,
+  } = useGameDerivedState(game, allAvailability, playDates);
+
+  // The calendar shows one player's availability at a time, keyed by date.
+  const viewAsAvailability = useMemo(() => {
+    const map: Record<string, AvailabilityEntry> = {};
+    for (const a of allAvailability) {
+      if (a.user_id !== viewAsUserId) continue;
+      map[a.date] = {
+        status: a.status,
+        comment: a.comment,
+        available_after: a.available_after,
+        available_until: a.available_until,
+      };
+    }
+    return map;
+  }, [allAvailability, viewAsUserId]);
+
+  if (authStatus === 'loading' || !profile?.is_admin) {
+    return (
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error || !game) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-muted-foreground">{error ?? 'Game not found'}</p>
+        <Link href="/admin" className="text-primary hover:underline text-sm mt-2 inline-block">
+          ← Back to admin dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const allPlayers = [game.gm, ...game.members];
+  const confirmedSessions = sessions.filter((s) => s.status === 'confirmed');
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Read-only banner */}
+      <div
+        className="mb-6 flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 p-3"
+        data-testid="admin-peek-banner"
+      >
+        <Eye className="size-4 shrink-0 text-primary" />
+        <p className="text-sm text-primary">
+          Admin read-only view — you can inspect this game, but all actions are disabled.
+        </p>
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <Link href="/admin" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back to admin dashboard
+        </Link>
+        <h1 className="text-2xl font-bold text-foreground mt-2">{game.name}</h1>
+        <p className="text-muted-foreground mt-1">GM: {game.gm.name}</p>
+        {game.description && (
+          <p className="text-muted-foreground mt-4">{game.description}</p>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-border mb-6">
+        <nav className="-mb-px flex gap-4 sm:gap-6">
+          {(['overview', 'availability', 'schedule'] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`py-3 px-1 border-b-2 font-medium text-sm capitalize transition-colors ${
+                activeTab === tab
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {activeTab === 'overview' && (
+        <OverviewTabContent
+          playDays={game.play_days}
+          windowStart={windowStart}
+          windowEnd={windowEnd}
+          allPlayers={allPlayers}
+          members={game.members}
+          gmId={game.gm_id}
+          isGm={false}
+          isCoGm={false}
+          completionByUserId={completionByUserId}
+          inviteCode={game.invite_code}
+          onToggleCoGm={noopAsync}
+          onRemovePlayer={() => {}}
+          schedulingWindowMonths={game.scheduling_window_months}
+          defaultStartTime={game.default_start_time}
+          defaultEndTime={game.default_end_time}
+          timezone={game.timezone}
+          minPlayersNeeded={game.min_players_needed || 0}
+          confirmedSessions={confirmedSessions}
+          use24h={use24h}
+          adHocOnly={game.ad_hoc_only}
+          campaignStartDate={game.campaign_start_date}
+          campaignEndDate={game.campaign_end_date}
+          gameName={game.name}
+          subscribeUrl=""
+        />
+      )}
+
+      {activeTab === 'availability' && (
+        <div className="space-y-5">
+          <div className="flex items-center gap-2">
+            <label htmlFor="view-as-player" className="text-sm text-muted-foreground">
+              Viewing availability for
+            </label>
+            <select
+              id="view-as-player"
+              value={viewAsUserId}
+              onChange={(e) => setViewAsUserId(e.target.value)}
+              className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm"
+              data-testid="peek-view-as-select"
+            >
+              {allPlayers.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                  {p.id === game.gm_id ? ' (GM)' : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <AvailabilityTabContent
+            windowStart={windowStart}
+            windowEnd={windowEnd}
+            currentUserId={viewAsUserId}
+            completionByUserId={completionByUserId}
+            playDays={game.play_days}
+            availability={viewAsAvailability}
+            onToggle={() => {}}
+            confirmedSessions={confirmedSessions}
+            extraPlayDates={extraDateStrings}
+            isGmOrCoGm={false}
+            onToggleExtraDate={() => {}}
+            weekStartDay={weekStartDay}
+            use24h={use24h}
+            otherGames={[]}
+            onCopyFromGame={async () => 0}
+            playDateNotes={playDateNotes}
+            onUpdatePlayDateNote={() => {}}
+            hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}
+            adHocOnly={game.ad_hoc_only}
+            readOnly
+          />
+        </div>
+      )}
+
+      {activeTab === 'schedule' && (
+        <ScheduleTabContent
+          suggestions={suggestions}
+          sessions={sessions}
+          members={[{ ...game.gm, is_co_gm: false }, ...game.members]}
+          gmId={game.gm_id}
+          isGm={false}
+          gameName={game.name}
+          gameDescription={game.description}
+          playDays={game.play_days}
+          windowStart={windowStart}
+          windowEnd={windowEnd}
+          specialPlayDates={specialPlayDatesSet}
+          playDateNotes={playDateNotes}
+          defaultStartTime={game.default_start_time}
+          defaultEndTime={game.default_end_time}
+          timezone={game.timezone}
+          userTimezone={userTimezone}
+          use24h={use24h}
+          weekStartDay={weekStartDay}
+          minPlayersNeeded={game.min_players_needed || 0}
+          completionByUserId={completionByUserId}
+          subscribeUrl=""
+          onConfirm={noopMutation}
+          onUpdateSession={noopMutation}
+          onCancel={noopMutation}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import { Avatar, Card, CardContent, CardHeader, LoadingSpinner } from '@/components/ui';
 import EngagementCharts from '@/components/admin/EngagementCharts';
 import type { HealthBreakdown, HealthGrade } from '@/lib/gameHealth';
+import type { TopUsersResult, TopGmEntry, TopPlayerEntry } from '@/lib/topUsers';
 
-type Tab = 'overview' | 'games' | 'activity';
+type Tab = 'overview' | 'games' | 'topUsers' | 'activity';
 
 interface AdminStats {
   totalUsers: number;
@@ -53,6 +55,7 @@ export default function AdminPage() {
   const [activeTab, setActiveTab] = useState<Tab>('overview');
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [games, setGames] = useState<GameWithEngagement[]>([]);
+  const [topUsers, setTopUsers] = useState<TopUsersResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -66,20 +69,23 @@ export default function AdminPage() {
       setError(null);
 
       try {
-        const [statsRes, gamesRes] = await Promise.all([
+        const [statsRes, gamesRes, topUsersRes] = await Promise.all([
           fetch('/api/admin/stats'),
           fetch('/api/admin/games'),
+          fetch('/api/admin/top-users'),
         ]);
 
-        if (!statsRes.ok || !gamesRes.ok) {
+        if (!statsRes.ok || !gamesRes.ok || !topUsersRes.ok) {
           throw new Error('Failed to fetch admin data');
         }
 
         const statsData = await statsRes.json();
         const gamesData = await gamesRes.json();
+        const topUsersData = await topUsersRes.json();
 
         setStats(statsData);
         setGames(gamesData.games);
+        setTopUsers(topUsersData);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');
       } finally {
@@ -110,6 +116,7 @@ export default function AdminPage() {
   const tabs: { id: Tab; label: string }[] = [
     { id: 'overview', label: 'Overview' },
     { id: 'games', label: 'Games' },
+    { id: 'topUsers', label: 'Top Users' },
     { id: 'activity', label: 'Activity' },
   ];
 
@@ -146,6 +153,7 @@ export default function AdminPage() {
         <>
           {activeTab === 'overview' && stats && <OverviewTab stats={stats} games={games} />}
           {activeTab === 'games' && <GamesTab games={games} />}
+          {activeTab === 'topUsers' && topUsers && <TopUsersTab topUsers={topUsers} />}
           {activeTab === 'activity' && stats && <ActivityTab stats={stats} />}
         </>
       )}
@@ -296,7 +304,15 @@ function GamesTab({ games }: { games: GameWithEngagement[] }) {
                       {game.healthGrade} {game.healthScore}
                     </span>
                   </td>
-                  <td className="py-3 px-2 font-medium text-foreground">{game.name}</td>
+                  <td className="py-3 px-2 font-medium text-foreground">
+                    <Link
+                      href={`/admin/games/${game.id}`}
+                      className="hover:text-primary hover:underline"
+                      title="Open read-only admin view"
+                    >
+                      {game.name}
+                    </Link>
+                  </td>
                   <td className="py-3 px-2 text-muted-foreground">{game.gm?.name ?? 'Unknown'}</td>
                   <td className="py-3 px-2 text-center text-foreground">{game.playerCount}</td>
                   <td className="py-3 px-2 text-center text-foreground">{game.sessionCount}</td>
@@ -363,6 +379,108 @@ function SortableHeader({
         )}
       </button>
     </th>
+  );
+}
+
+function UserCell({ user }: { user: TopGmEntry['user'] }) {
+  return (
+    <div className="flex items-center gap-3 min-w-0">
+      <Avatar userId={user.id} name={user.name} avatarUrl={user.avatar_url} size={30} />
+      <div className="min-w-0">
+        <p className="font-medium text-foreground truncate">{user.name}</p>
+        <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+      </div>
+    </div>
+  );
+}
+
+function TopUsersTab({ topUsers }: { topUsers: TopUsersResult }) {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+      {/* Top GMs */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-card-foreground">Top GMs</h2>
+          <p className="text-sm text-muted-foreground">Ranked by sessions booked across owned games</p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" data-testid="top-gms-table">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left py-3 px-2 font-medium text-muted-foreground">#</th>
+                  <th className="text-left py-3 px-2 font-medium text-muted-foreground">GM</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Games</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Sessions</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Upcoming</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Players</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topUsers.topGms.map((entry: TopGmEntry, i: number) => (
+                  <tr key={entry.user.id} className="border-b border-border/50 hover:bg-muted/50">
+                    <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
+                    <td className="py-3 px-2"><UserCell user={entry.user} /></td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.gamesOwned}</td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.sessionsBooked}</td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.upcomingSessions}</td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.playersHosted}</td>
+                  </tr>
+                ))}
+                {topUsers.topGms.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-8 text-center text-muted-foreground">
+                      No GMs with games yet
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Top Players */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-card-foreground">Top Players</h2>
+          <p className="text-sm text-muted-foreground">Ranked by sessions scheduled in games they joined</p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" data-testid="top-players-table">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left py-3 px-2 font-medium text-muted-foreground">#</th>
+                  <th className="text-left py-3 px-2 font-medium text-muted-foreground">Player</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Games</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Sessions</th>
+                  <th className="text-center py-3 px-2 font-medium text-muted-foreground">Dates Marked</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topUsers.topPlayers.map((entry: TopPlayerEntry, i: number) => (
+                  <tr key={entry.user.id} className="border-b border-border/50 hover:bg-muted/50">
+                    <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
+                    <td className="py-3 px-2"><UserCell user={entry.user} /></td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.gamesJoined}</td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.sessionsScheduled}</td>
+                    <td className="py-3 px-2 text-center text-foreground">{entry.datesMarked}</td>
+                  </tr>
+                ))}
+                {topUsers.topPlayers.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                      No players have joined games yet
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { ChevronRight, Eye } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import { Avatar, Card, CardContent, CardHeader, LoadingSpinner } from '@/components/ui';
@@ -382,9 +383,12 @@ function SortableHeader({
   );
 }
 
-function UserCell({ user }: { user: TopGmEntry['user'] }) {
+function UserCell({ user, expanded }: { user: TopGmEntry['user']; expanded: boolean }) {
   return (
-    <div className="flex items-center gap-3 min-w-0">
+    <div className="flex items-center gap-2 min-w-0">
+      <ChevronRight
+        className={`size-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`}
+      />
       <Avatar userId={user.id} name={user.name} avatarUrl={user.avatar_url} size={30} />
       <div className="min-w-0">
         <p className="font-medium text-foreground truncate">{user.name}</p>
@@ -394,14 +398,48 @@ function UserCell({ user }: { user: TopGmEntry['user'] }) {
   );
 }
 
+/** Expanded sub-row listing a user's games as links to the admin peek view. */
+function UserGamesRow({ games, colSpan }: { games: TopGmEntry['games']; colSpan: number }) {
+  return (
+    <tr className="border-b border-border/50 bg-muted/30" data-testid="user-games-row">
+      <td colSpan={colSpan} className="p-2">
+        <div className="flex flex-wrap gap-2 pl-8">
+          {games.map((g) => (
+            <Link
+              key={g.id}
+              href={`/admin/games/${g.id}`}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary hover:bg-primary/20 transition-colors"
+              title="Open read-only admin view"
+            >
+              <Eye className="size-3" />
+              {g.name}
+            </Link>
+          ))}
+          {games.length === 0 && (
+            <span className="text-xs text-muted-foreground">No games</span>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
 function TopUsersTab({ topUsers }: { topUsers: TopUsersResult }) {
+  const [expandedGm, setExpandedGm] = useState<string | null>(null);
+  const [expandedPlayer, setExpandedPlayer] = useState<string | null>(null);
+
+  const toggle = (setter: typeof setExpandedGm) => (userId: string) =>
+    setter((prev) => (prev === userId ? null : userId));
+
   return (
     <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
       {/* Top GMs */}
       <Card>
         <CardHeader>
           <h2 className="text-lg font-semibold text-card-foreground">Top GMs</h2>
-          <p className="text-sm text-muted-foreground">Ranked by sessions booked across owned games</p>
+          <p className="text-sm text-muted-foreground">
+            Ranked by sessions booked across owned games · click a row to see their games
+          </p>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
@@ -418,14 +456,25 @@ function TopUsersTab({ topUsers }: { topUsers: TopUsersResult }) {
               </thead>
               <tbody>
                 {topUsers.topGms.map((entry: TopGmEntry, i: number) => (
-                  <tr key={entry.user.id} className="border-b border-border/50 hover:bg-muted/50">
-                    <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
-                    <td className="py-3 px-2"><UserCell user={entry.user} /></td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.gamesOwned}</td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.sessionsBooked}</td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.upcomingSessions}</td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.playersHosted}</td>
-                  </tr>
+                  <Fragment key={entry.user.id}>
+                    <tr
+                      className="border-b border-border/50 hover:bg-muted/50 cursor-pointer select-none"
+                      onClick={() => toggle(setExpandedGm)(entry.user.id)}
+                      aria-expanded={expandedGm === entry.user.id}
+                    >
+                      <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
+                      <td className="py-3 px-2">
+                        <UserCell user={entry.user} expanded={expandedGm === entry.user.id} />
+                      </td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.gamesOwned}</td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.sessionsBooked}</td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.upcomingSessions}</td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.playersHosted}</td>
+                    </tr>
+                    {expandedGm === entry.user.id && (
+                      <UserGamesRow games={entry.games} colSpan={6} />
+                    )}
+                  </Fragment>
                 ))}
                 {topUsers.topGms.length === 0 && (
                   <tr>
@@ -444,7 +493,9 @@ function TopUsersTab({ topUsers }: { topUsers: TopUsersResult }) {
       <Card>
         <CardHeader>
           <h2 className="text-lg font-semibold text-card-foreground">Top Players</h2>
-          <p className="text-sm text-muted-foreground">Ranked by sessions scheduled in games they joined</p>
+          <p className="text-sm text-muted-foreground">
+            Ranked by sessions scheduled in games they joined · click a row to see their games
+          </p>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
@@ -460,13 +511,24 @@ function TopUsersTab({ topUsers }: { topUsers: TopUsersResult }) {
               </thead>
               <tbody>
                 {topUsers.topPlayers.map((entry: TopPlayerEntry, i: number) => (
-                  <tr key={entry.user.id} className="border-b border-border/50 hover:bg-muted/50">
-                    <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
-                    <td className="py-3 px-2"><UserCell user={entry.user} /></td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.gamesJoined}</td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.sessionsScheduled}</td>
-                    <td className="py-3 px-2 text-center text-foreground">{entry.datesMarked}</td>
-                  </tr>
+                  <Fragment key={entry.user.id}>
+                    <tr
+                      className="border-b border-border/50 hover:bg-muted/50 cursor-pointer select-none"
+                      onClick={() => toggle(setExpandedPlayer)(entry.user.id)}
+                      aria-expanded={expandedPlayer === entry.user.id}
+                    >
+                      <td className="py-3 px-2 text-muted-foreground">{i + 1}</td>
+                      <td className="py-3 px-2">
+                        <UserCell user={entry.user} expanded={expandedPlayer === entry.user.id} />
+                      </td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.gamesJoined}</td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.sessionsScheduled}</td>
+                      <td className="py-3 px-2 text-center text-foreground">{entry.datesMarked}</td>
+                    </tr>
+                    {expandedPlayer === entry.user.id && (
+                      <UserGamesRow games={entry.games} colSpan={5} />
+                    )}
+                  </Fragment>
                 ))}
                 {topUsers.topPlayers.length === 0 && (
                   <tr>

--- a/src/app/api/admin/games/[id]/route.ts
+++ b/src/app/api/admin/games/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/api/admin';
+import {
+  fetchGameWithGM,
+  fetchGameMembers,
+  fetchAllAvailability,
+  fetchGameSessions,
+  fetchGamePlayDates,
+} from '@/lib/data';
+
+/**
+ * Read-only snapshot of a game for the admin peek view. Uses the service-role
+ * client because the admin is typically not a participant, so RLS would hide
+ * the game from a normal client. Returns the same shapes the game detail UI
+ * consumes (GameWithMembers, Availability[], GameSession[], GamePlayDate[]).
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  try {
+    const result = await requireAdmin();
+    if (result instanceof NextResponse) return result;
+    const { admin } = result;
+
+    const { id } = await params;
+
+    const { data: game, error: gameError } = await fetchGameWithGM(admin, id);
+    if (gameError || !game) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+
+    const [membersRes, availabilityRes, sessionsRes, playDatesRes] = await Promise.all([
+      fetchGameMembers(admin, id),
+      fetchAllAvailability(admin, id),
+      fetchGameSessions(admin, id),
+      fetchGamePlayDates(admin, id),
+    ]);
+
+    return NextResponse.json({
+      game: { ...game, members: membersRes.data },
+      availability: availabilityRes.data ?? [],
+      sessions: sessionsRes.data ?? [],
+      playDates: playDatesRes.data ?? [],
+    });
+  } catch (error) {
+    console.error('Admin game snapshot error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/top-users/route.ts
+++ b/src/app/api/admin/top-users/route.ts
@@ -10,7 +10,7 @@ export async function GET(): Promise<Response> {
 
     const [users, games, memberships, sessions, availability] = await Promise.all([
       paginate<TopUserProfile>(admin, 'users', 'id, name, email, avatar_url'),
-      paginate<{ id: string; gm_id: string }>(admin, 'games', 'id, gm_id'),
+      paginate<{ id: string; gm_id: string; name: string }>(admin, 'games', 'id, gm_id, name'),
       paginate<{ game_id: string; user_id: string }>(admin, 'game_memberships', 'game_id, user_id'),
       paginate<{ game_id: string; date: string }>(admin, 'sessions', 'game_id, date'),
       paginate<{ user_id: string }>(admin, 'availability', 'user_id'),

--- a/src/app/api/admin/top-users/route.ts
+++ b/src/app/api/admin/top-users/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin, paginate } from '@/lib/api/admin';
+import { computeTopUsers, type TopUserProfile } from '@/lib/topUsers';
+
+export async function GET(): Promise<Response> {
+  try {
+    const result = await requireAdmin();
+    if (result instanceof NextResponse) return result;
+    const { admin } = result;
+
+    const [users, games, memberships, sessions, availability] = await Promise.all([
+      paginate<TopUserProfile>(admin, 'users', 'id, name, email, avatar_url'),
+      paginate<{ id: string; gm_id: string }>(admin, 'games', 'id, gm_id'),
+      paginate<{ game_id: string; user_id: string }>(admin, 'game_memberships', 'game_id, user_id'),
+      paginate<{ game_id: string; date: string }>(admin, 'sessions', 'game_id, date'),
+      paginate<{ user_id: string }>(admin, 'availability', 'user_id'),
+    ]);
+
+    return NextResponse.json(
+      computeTopUsers({ users, games, memberships, sessions, availability })
+    );
+  } catch (error) {
+    console.error('Admin top users error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -2,35 +2,19 @@
 
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter, useParams } from "next/navigation";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { Button, LoadingSpinner, Modal, useToast } from "@/components/ui";
 import { OverviewTabContent } from "@/components/games/overview/OverviewTabContent";
-import {
-  User,
-  DateSuggestion,
-} from "@/types";
+import { User } from "@/types";
 import { AvailabilityTabContent } from "@/components/games/availability/AvailabilityTabContent";
 import { ScheduleTabContent } from "@/components/games/schedule/ScheduleTabContent";
-import {
-  addMonths,
-  endOfMonth,
-  eachDayOfInterval,
-  getDay,
-  format,
-  isAfter,
-  isBefore,
-  startOfDay,
-  parseISO,
-} from "date-fns";
-import { getPlayDatesInWindow } from "@/lib/availability";
-import { calculateDateSuggestions } from "@/lib/suggestions";
 import { useUserPreferences } from "@/hooks/useUserPreferences";
 import { useGameMeta } from "@/hooks/useGameMeta";
 import { useAvailability } from "@/hooks/useAvailability";
 import { useSessions } from "@/hooks/useSessions";
 import { usePlayDates } from "@/hooks/usePlayDates";
-import { getSchedulingWindow } from "@/lib/scheduling";
+import { useGameDerivedState } from "@/hooks/useGameDerivedState";
 
 type Tab = "overview" | "availability" | "schedule";
 
@@ -76,7 +60,6 @@ export default function GameDetailPage() {
 
   // UI state
   const [activeTab, setActiveTab] = useState<Tab>("overview");
-  const [suggestions, setSuggestions] = useState<DateSuggestion[]>([]);
   const [playerToRemove, setPlayerToRemove] = useState<User | null>(null);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
@@ -87,69 +70,20 @@ export default function GameDetailPage() {
   const canDoGmActions = !!(isGm || isCoGm);
   const isMember = game?.members.some((m) => m.id === profile?.id);
 
-  const playDateEntries = useMemo(() => {
-    return gamePlayDates
-      .map((r) => ({ date: r.date, note: r.note }))
-      .sort((a, b) => a.date.localeCompare(b.date));
-  }, [gamePlayDates]);
-
-  // Only dates that are true extra dates (not regular play days with notes)
-  const extraDateStrings = useMemo(() => {
-    const regularDays = new Set(game?.play_days ?? []);
-    return playDateEntries
-      .filter((d) => !regularDays.has(getDay(parseISO(d.date))))
-      .map((d) => d.date);
-  }, [playDateEntries, game?.play_days]);
-
-  const playDateNotes = useMemo(
-    () =>
-      new Map(
-        playDateEntries
-          .filter((d) => d.note)
-          .map((d) => [d.date, d.note!])
-      ),
-    [playDateEntries]
-  );
-
-  const { start: windowStart, end: windowEnd } = useMemo(
-    () =>
-      game
-        ? getSchedulingWindow(game)
-        : { start: startOfDay(new Date()), end: endOfMonth(addMonths(new Date(), 2)) },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally depends on specific fields, not the full game object, to prevent re-render loops
-    [game?.scheduling_window_months, game?.campaign_start_date, game?.campaign_end_date]
-  );
-
-  const specialPlayDatesSet = useMemo(
-    () => new Set(extraDateStrings),
-    [extraDateStrings]
-  );
-
-  const completionByUserId = useMemo(() => {
-    const map = new Map<string, { answered: number; total: number }>();
-    if (!game) return map;
-    const playDates = getPlayDatesInWindow({
-      playDays: game.play_days,
-      schedulingWindowMonths: game.scheduling_window_months,
-      extraPlayDates: extraDateStrings,
-      windowStart,
-      windowEnd,
-    });
-    const total = playDates.length;
-    const playDateSet = new Set(playDates);
-    const allPlayers = [game.gm, ...game.members];
-    for (const p of allPlayers) {
-      const answered = allAvailability.filter(
-        (a) => a.user_id === p.id && playDateSet.has(a.date)
-      ).length;
-      map.set(p.id, { answered, total });
-    }
-    return map;
-  }, [game, allAvailability, extraDateStrings, windowStart, windowEnd]);
+  const {
+    extraDateStrings,
+    playDateNotes,
+    specialPlayDatesSet,
+    windowStart,
+    windowEnd,
+    completionByUserId,
+    suggestions,
+  } = useGameDerivedState(game, allAvailability, gamePlayDates);
 
   const [subscribeUrl, setSubscribeUrl] = useState('');
   useEffect(() => {
     if (typeof window !== 'undefined' && game?.invite_code) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- window.location is only known client-side
       setSubscribeUrl(`webcal://${window.location.host}/api/games/calendar/${game.invite_code}`);
     }
   }, [game?.invite_code]);
@@ -162,40 +96,6 @@ export default function GameDetailPage() {
       router.push("/dashboard");
     }
   }, [loading, game, profile?.id, router]);
-
-  // Calculate suggestions when availability changes
-  useEffect(() => {
-    if (!game) return;
-
-    const allPlayers = [game.gm, ...game.members];
-    const today = startOfDay(new Date());
-
-    // Get play dates within the scheduling window
-    const playDates = isBefore(windowEnd, windowStart)
-      ? []
-      : eachDayOfInterval({ start: windowStart, end: windowEnd })
-          .filter((date) => {
-            const dateStr = format(date, "yyyy-MM-dd");
-            return game.play_days.includes(getDay(date)) || extraDateStrings.includes(dateStr);
-          })
-          .filter(
-            (date) =>
-              isAfter(date, today) ||
-              format(date, "yyyy-MM-dd") === format(today, "yyyy-MM-dd")
-          );
-
-    // Use the shared utility function to calculate suggestions
-    const suggestionList = calculateDateSuggestions({
-      playDates,
-      players: allPlayers,
-      availability: allAvailability,
-      getDayOfWeek: getDay,
-      formatDate: (date) => format(date, "yyyy-MM-dd"),
-      minPlayersNeeded: game.min_players_needed || 0,
-    });
-
-    setSuggestions(suggestionList);
-  }, [game, allAvailability, extraDateStrings, windowStart, windowEnd]);
 
   const toast = useToast();
 

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -49,6 +49,8 @@ interface AvailabilityCalendarProps {
   playDateNotes?: Map<string, string>;
   onUpdatePlayDateNote?: (date: string, note: string | null) => void;
   hasCampaignDates?: boolean;
+  /** Disables all interaction (day clicks, long-press editing, bulk actions). Used by the admin peek view. */
+  readOnly?: boolean;
 }
 
 export function AvailabilityCalendar({
@@ -68,6 +70,7 @@ export function AvailabilityCalendar({
   playDateNotes = new Map(),
   onUpdatePlayDateNote,
   hasCampaignDates = false,
+  readOnly = false,
 }: AvailabilityCalendarProps) {
   const today = startOfDay(new Date());
   const maxDate = windowEnd;
@@ -126,6 +129,7 @@ export function AvailabilityCalendar({
   );
 
   const handleDayClick = (date: Date) => {
+    if (readOnly) return;
     const dateStr = format(date, "yyyy-MM-dd");
     const dayOfWeek = getDay(date);
     const isExtraPlayDate = extraPlayDates.includes(dateStr);
@@ -148,6 +152,7 @@ export function AvailabilityCalendar({
   };
 
   const handleEditComment = (dateStr: string) => {
+    if (readOnly) return;
     setCommentingDate(dateStr);
     setCommentText(availability[dateStr]?.comment || "");
     // Load time fields, converting HH:MM:SS to HH:MM for input
@@ -279,6 +284,7 @@ export function AvailabilityCalendar({
   return (
     <div className="space-y-4">
       {/* Bulk actions */}
+      {!readOnly && (
       <div className="bg-secondary rounded-lg p-3">
         <div className="space-y-2 lg:space-y-0 lg:flex lg:flex-wrap lg:items-center lg:gap-2 text-sm">
           {/* Mark all section — stacked on mobile, inline on desktop */}
@@ -359,6 +365,7 @@ export function AvailabilityCalendar({
           )}
         </div>
       </div>
+      )}
 
       {/* Multi-month calendar grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -384,6 +391,7 @@ export function AvailabilityCalendar({
             windowStart={windowStart}
             windowEnd={windowEnd}
             onOutOfRangeTap={showOutOfRangeToast}
+            readOnly={readOnly}
           />
         ))}
       </div>
@@ -553,6 +561,7 @@ interface MonthCalendarProps {
   windowStart: Date;
   windowEnd: Date;
   onOutOfRangeTap?: (message: string) => void;
+  readOnly?: boolean;
 }
 
 function MonthCalendar({
@@ -575,6 +584,7 @@ function MonthCalendar({
   windowStart,
   windowEnd,
   onOutOfRangeTap,
+  readOnly = false,
 }: MonthCalendarProps) {
   const days = eachDayOfInterval({
     start: startOfMonth(month),
@@ -928,8 +938,8 @@ function MonthCalendar({
                   )}
                 </span>
               )}
-              {/* Bottom-right edit icon — opens editor popover */}
-              {isPlayDay && !isPast && (hasAvailability || isGmOrCoGm) && (
+              {/* Bottom-right edit icon — opens editor popover (read-only: only show existing notes) */}
+              {isPlayDay && !isPast && (hasComment || (!readOnly && (hasAvailability || isGmOrCoGm))) && (
                 <span
                   className={`absolute bottom-0.5 right-1 leading-none cursor-pointer hover:scale-125 transition-all ${
                     hasComment
@@ -945,7 +955,13 @@ function MonthCalendar({
                     }
                     onEditComment(dateStr);
                   }}
-                  title={hasComment ? `Edit note: ${avail!.comment}` : "Add note"}
+                  title={
+                    hasComment
+                      ? readOnly
+                        ? `Note: ${avail!.comment}`
+                        : `Edit note: ${avail!.comment}`
+                      : "Add note"
+                  }
                 >
                   {hasComment ? <MessageSquare className="size-2.5" /> : <Pencil className="size-2.5" />}
                 </span>

--- a/src/components/games/availability/AvailabilityHeader.tsx
+++ b/src/components/games/availability/AvailabilityHeader.tsx
@@ -4,21 +4,27 @@ interface AvailabilityHeaderProps {
   monthRange: string;
   answered: number;
   total: number;
+  /** Hides the interaction hint and uses a neutral title (admin peek view). */
+  readOnly?: boolean;
 }
 
-export function AvailabilityHeader({ monthRange, answered, total }: AvailabilityHeaderProps) {
+export function AvailabilityHeader({ monthRange, answered, total, readOnly = false }: AvailabilityHeaderProps) {
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div>
-        <h2 className="text-2xl font-semibold text-foreground">Mark your availability</h2>
+        <h2 className="text-2xl font-semibold text-foreground">
+          {readOnly ? 'Availability' : 'Mark your availability'}
+        </h2>
         <p className="mt-1 text-sm text-muted-foreground">
           {monthRange} · <span className="font-mono">{answered}/{total}</span>{' '}
           {total === 1 ? 'date' : 'dates'} answered
         </p>
-        <p className="mt-1 text-[11px] italic text-muted-foreground">
-          Click to cycle available → unavailable → maybe. Hover (or long-press on mobile) for
-          notes and time constraints.
-        </p>
+        {!readOnly && (
+          <p className="mt-1 text-[11px] italic text-muted-foreground">
+            Click to cycle available → unavailable → maybe. Hover (or long-press on mobile) for
+            notes and time constraints.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -37,6 +37,9 @@ export interface AvailabilityTabContentProps {
 
   // Empty-state banners
   adHocOnly: boolean;
+
+  /** Renders the calendar non-interactive (admin peek view). */
+  readOnly?: boolean;
 }
 
 export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
@@ -45,13 +48,13 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
     playDays, availability, onToggle, confirmedSessions, extraPlayDates,
     isGmOrCoGm, onToggleExtraDate, weekStartDay, use24h, otherGames,
     onCopyFromGame, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
-    adHocOnly,
+    adHocOnly, readOnly = false,
   } = props;
 
   const monthRange = `${format(windowStart, 'MMM')} – ${format(windowEnd, 'MMM yyyy')}`;
   const myProgress = completionByUserId.get(currentUserId) ?? { answered: 0, total: 0 };
-  const showEmptyAdHocPlayer = adHocOnly && extraPlayDates.length === 0 && !isGmOrCoGm;
-  const showEmptyAdHocGm = adHocOnly && extraPlayDates.length === 0 && isGmOrCoGm;
+  const showEmptyAdHocPlayer = adHocOnly && extraPlayDates.length === 0 && !isGmOrCoGm && !readOnly;
+  const showEmptyAdHocGm = adHocOnly && extraPlayDates.length === 0 && isGmOrCoGm && !readOnly;
 
   return (
     <div className="space-y-5" data-testid="availability-tab-content">
@@ -59,6 +62,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         monthRange={monthRange}
         answered={myProgress.answered}
         total={myProgress.total}
+        readOnly={readOnly}
       />
 
       {showEmptyAdHocPlayer && (
@@ -95,6 +99,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         playDateNotes={playDateNotes}
         onUpdatePlayDateNote={onUpdatePlayDateNote}
         hasCampaignDates={hasCampaignDates}
+        readOnly={readOnly}
       />
     </div>
   );

--- a/src/hooks/useGameDerivedState.ts
+++ b/src/hooks/useGameDerivedState.ts
@@ -1,0 +1,140 @@
+import { useMemo } from 'react';
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  format,
+  getDay,
+  isAfter,
+  isBefore,
+  parseISO,
+  startOfDay,
+} from 'date-fns';
+import type { Availability, DateSuggestion, GameWithMembers } from '@/types';
+import { getPlayDatesInWindow } from '@/lib/availability';
+import { calculateDateSuggestions } from '@/lib/suggestions';
+import { getSchedulingWindow } from '@/lib/scheduling';
+
+export interface GameDerivedState {
+  playDateEntries: { date: string; note: string | null }[];
+  /** Dates that are true extra dates (not regular play days with notes) */
+  extraDateStrings: string[];
+  playDateNotes: Map<string, string>;
+  specialPlayDatesSet: Set<string>;
+  windowStart: Date;
+  windowEnd: Date;
+  completionByUserId: Map<string, { answered: number; total: number }>;
+  suggestions: DateSuggestion[];
+}
+
+/**
+ * Pure derived state for a game's scheduling views: play-date entries, the
+ * scheduling window, per-player completion, and ranked date suggestions.
+ * Shared by the game detail page and the admin read-only peek page so the
+ * computation exists in one place.
+ */
+export function useGameDerivedState(
+  game: GameWithMembers | null,
+  allAvailability: Availability[],
+  gamePlayDates: Array<{ date: string; note: string | null }>
+): GameDerivedState {
+  const playDateEntries = useMemo(() => {
+    return gamePlayDates
+      .map((r) => ({ date: r.date, note: r.note }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [gamePlayDates]);
+
+  const extraDateStrings = useMemo(() => {
+    const regularDays = new Set(game?.play_days ?? []);
+    return playDateEntries
+      .filter((d) => !regularDays.has(getDay(parseISO(d.date))))
+      .map((d) => d.date);
+  }, [playDateEntries, game?.play_days]);
+
+  const playDateNotes = useMemo(
+    () =>
+      new Map(
+        playDateEntries
+          .filter((d) => d.note)
+          .map((d) => [d.date, d.note!])
+      ),
+    [playDateEntries]
+  );
+
+  const { start: windowStart, end: windowEnd } = useMemo(
+    () =>
+      game
+        ? getSchedulingWindow(game)
+        : { start: startOfDay(new Date()), end: endOfMonth(addMonths(new Date(), 2)) },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally depends on specific fields, not the full game object, to prevent re-render loops
+    [game?.scheduling_window_months, game?.campaign_start_date, game?.campaign_end_date]
+  );
+
+  const specialPlayDatesSet = useMemo(
+    () => new Set(extraDateStrings),
+    [extraDateStrings]
+  );
+
+  const completionByUserId = useMemo(() => {
+    const map = new Map<string, { answered: number; total: number }>();
+    if (!game) return map;
+    const playDates = getPlayDatesInWindow({
+      playDays: game.play_days,
+      schedulingWindowMonths: game.scheduling_window_months,
+      extraPlayDates: extraDateStrings,
+      windowStart,
+      windowEnd,
+    });
+    const total = playDates.length;
+    const playDateSet = new Set(playDates);
+    const allPlayers = [game.gm, ...game.members];
+    for (const p of allPlayers) {
+      const answered = allAvailability.filter(
+        (a) => a.user_id === p.id && playDateSet.has(a.date)
+      ).length;
+      map.set(p.id, { answered, total });
+    }
+    return map;
+  }, [game, allAvailability, extraDateStrings, windowStart, windowEnd]);
+
+  const suggestions = useMemo(() => {
+    if (!game) return [];
+
+    const allPlayers = [game.gm, ...game.members];
+    const today = startOfDay(new Date());
+
+    // Get play dates within the scheduling window
+    const playDates = isBefore(windowEnd, windowStart)
+      ? []
+      : eachDayOfInterval({ start: windowStart, end: windowEnd })
+          .filter((date) => {
+            const dateStr = format(date, 'yyyy-MM-dd');
+            return game.play_days.includes(getDay(date)) || extraDateStrings.includes(dateStr);
+          })
+          .filter(
+            (date) =>
+              isAfter(date, today) ||
+              format(date, 'yyyy-MM-dd') === format(today, 'yyyy-MM-dd')
+          );
+
+    return calculateDateSuggestions({
+      playDates,
+      players: allPlayers,
+      availability: allAvailability,
+      getDayOfWeek: getDay,
+      formatDate: (date) => format(date, 'yyyy-MM-dd'),
+      minPlayersNeeded: game.min_players_needed || 0,
+    });
+  }, [game, allAvailability, extraDateStrings, windowStart, windowEnd]);
+
+  return {
+    playDateEntries,
+    extraDateStrings,
+    playDateNotes,
+    specialPlayDatesSet,
+    windowStart,
+    windowEnd,
+    completionByUserId,
+    suggestions,
+  };
+}

--- a/src/lib/topUsers.test.ts
+++ b/src/lib/topUsers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { computeTopUsers, type TopUserProfile } from "./topUsers";
+
+function user(id: string, name = `User ${id}`): TopUserProfile {
+  return { id, name, email: `${id}@test.local`, avatar_url: null };
+}
+
+describe("computeTopUsers", () => {
+  const today = "2026-06-11";
+
+  it("returns empty lists when there is no data", () => {
+    const result = computeTopUsers(
+      { users: [], games: [], memberships: [], sessions: [], availability: [] },
+      { today }
+    );
+    expect(result.topGms).toEqual([]);
+    expect(result.topPlayers).toEqual([]);
+  });
+
+  it("aggregates GM metrics across owned games", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("gm1"), user("p1"), user("p2")],
+        games: [
+          { id: "g1", gm_id: "gm1" },
+          { id: "g2", gm_id: "gm1" },
+        ],
+        memberships: [
+          { game_id: "g1", user_id: "p1" },
+          { game_id: "g1", user_id: "p2" },
+          { game_id: "g2", user_id: "p1" }, // p1 in both games → counted once
+        ],
+        sessions: [
+          { game_id: "g1", date: "2026-01-10" }, // past
+          { game_id: "g1", date: "2026-07-01" }, // upcoming
+          { game_id: "g2", date: "2026-06-11" }, // today counts as upcoming
+        ],
+        availability: [],
+      },
+      { today }
+    );
+
+    expect(result.topGms).toHaveLength(1);
+    expect(result.topGms[0]).toMatchObject({
+      gamesOwned: 2,
+      sessionsBooked: 3,
+      upcomingSessions: 2,
+      playersHosted: 2,
+    });
+    expect(result.topGms[0].user.id).toBe("gm1");
+  });
+
+  it("aggregates player metrics from memberships, sessions, and availability", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("gm1"), user("p1")],
+        games: [{ id: "g1", gm_id: "gm1" }],
+        memberships: [{ game_id: "g1", user_id: "p1" }],
+        sessions: [
+          { game_id: "g1", date: "2026-01-10" },
+          { game_id: "g1", date: "2026-07-01" },
+        ],
+        availability: [{ user_id: "p1" }, { user_id: "p1" }, { user_id: "gm1" }],
+      },
+      { today }
+    );
+
+    expect(result.topPlayers).toHaveLength(1);
+    expect(result.topPlayers[0]).toMatchObject({
+      gamesJoined: 1,
+      sessionsScheduled: 2,
+      datesMarked: 2,
+    });
+    expect(result.topPlayers[0].user.id).toBe("p1");
+  });
+
+  it("excludes users with no owned games from GMs and no memberships from players", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("gm1"), user("p1"), user("bystander")],
+        games: [{ id: "g1", gm_id: "gm1" }],
+        memberships: [{ game_id: "g1", user_id: "p1" }],
+        sessions: [],
+        availability: [{ user_id: "bystander" }],
+      },
+      { today }
+    );
+
+    expect(result.topGms.map((e) => e.user.id)).toEqual(["gm1"]);
+    expect(result.topPlayers.map((e) => e.user.id)).toEqual(["p1"]);
+  });
+
+  it("ranks GMs by sessions booked, then games owned, then name", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("a", "Alice"), user("b", "Bob"), user("c", "Carol")],
+        games: [
+          { id: "g1", gm_id: "a" },
+          { id: "g2", gm_id: "b" },
+          { id: "g3", gm_id: "b" },
+          { id: "g4", gm_id: "c" },
+        ],
+        memberships: [],
+        sessions: [
+          { game_id: "g1", date: "2026-01-01" },
+          { game_id: "g2", date: "2026-01-01" },
+          { game_id: "g4", date: "2026-01-01" },
+        ],
+        availability: [],
+      },
+      { today }
+    );
+
+    // All have 1 session; Bob owns 2 games; Alice beats Carol alphabetically
+    expect(result.topGms.map((e) => e.user.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("ranks players by sessions scheduled, then games joined", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("gm"), user("p1"), user("p2")],
+        games: [
+          { id: "g1", gm_id: "gm" },
+          { id: "g2", gm_id: "gm" },
+        ],
+        memberships: [
+          { game_id: "g1", user_id: "p1" },
+          { game_id: "g1", user_id: "p2" },
+          { game_id: "g2", user_id: "p2" },
+        ],
+        sessions: [{ game_id: "g1", date: "2026-01-01" }],
+        availability: [],
+      },
+      { today }
+    );
+
+    // Both have 1 session via g1, but p2 joined 2 games
+    expect(result.topPlayers.map((e) => e.user.id)).toEqual(["p2", "p1"]);
+  });
+
+  it("caps each list at the limit", () => {
+    const users = Array.from({ length: 15 }, (_, i) => user(`u${i}`));
+    const games = users.map((u, i) => ({ id: `g${i}`, gm_id: u.id }));
+    const result = computeTopUsers(
+      { users, games, memberships: [], sessions: [], availability: [] },
+      { today, limit: 10 }
+    );
+    expect(result.topGms).toHaveLength(10);
+  });
+
+  it("ignores rows referencing unknown users or games", () => {
+    const result = computeTopUsers(
+      {
+        users: [user("gm1")],
+        games: [
+          { id: "g1", gm_id: "gm1" },
+          { id: "g2", gm_id: "ghost-gm" },
+        ],
+        memberships: [
+          { game_id: "g1", user_id: "ghost-player" },
+          { game_id: "ghost-game", user_id: "gm1" },
+        ],
+        sessions: [],
+        availability: [],
+      },
+      { today }
+    );
+
+    expect(result.topGms.map((e) => e.user.id)).toEqual(["gm1"]);
+    // A membership row with an unknown user id still counts toward playersHosted
+    // (the GM hosted that seat), but the unknown user gets no player entry.
+    expect(result.topGms[0].playersHosted).toBe(1);
+    expect(result.topPlayers).toEqual([]);
+  });
+});

--- a/src/lib/topUsers.test.ts
+++ b/src/lib/topUsers.test.ts
@@ -22,8 +22,8 @@ describe("computeTopUsers", () => {
       {
         users: [user("gm1"), user("p1"), user("p2")],
         games: [
-          { id: "g1", gm_id: "gm1" },
-          { id: "g2", gm_id: "gm1" },
+          { id: "g1", gm_id: "gm1", name: "Game g1" },
+          { id: "g2", gm_id: "gm1", name: "Game g2" },
         ],
         memberships: [
           { game_id: "g1", user_id: "p1" },
@@ -48,13 +48,17 @@ describe("computeTopUsers", () => {
       playersHosted: 2,
     });
     expect(result.topGms[0].user.id).toBe("gm1");
+    expect(result.topGms[0].games).toEqual([
+      { id: "g1", name: "Game g1" },
+      { id: "g2", name: "Game g2" },
+    ]);
   });
 
   it("aggregates player metrics from memberships, sessions, and availability", () => {
     const result = computeTopUsers(
       {
         users: [user("gm1"), user("p1")],
-        games: [{ id: "g1", gm_id: "gm1" }],
+        games: [{ id: "g1", gm_id: "gm1", name: "Game g1" }],
         memberships: [{ game_id: "g1", user_id: "p1" }],
         sessions: [
           { game_id: "g1", date: "2026-01-10" },
@@ -72,13 +76,14 @@ describe("computeTopUsers", () => {
       datesMarked: 2,
     });
     expect(result.topPlayers[0].user.id).toBe("p1");
+    expect(result.topPlayers[0].games).toEqual([{ id: "g1", name: "Game g1" }]);
   });
 
   it("excludes users with no owned games from GMs and no memberships from players", () => {
     const result = computeTopUsers(
       {
         users: [user("gm1"), user("p1"), user("bystander")],
-        games: [{ id: "g1", gm_id: "gm1" }],
+        games: [{ id: "g1", gm_id: "gm1", name: "Game g1" }],
         memberships: [{ game_id: "g1", user_id: "p1" }],
         sessions: [],
         availability: [{ user_id: "bystander" }],
@@ -95,10 +100,10 @@ describe("computeTopUsers", () => {
       {
         users: [user("a", "Alice"), user("b", "Bob"), user("c", "Carol")],
         games: [
-          { id: "g1", gm_id: "a" },
-          { id: "g2", gm_id: "b" },
-          { id: "g3", gm_id: "b" },
-          { id: "g4", gm_id: "c" },
+          { id: "g1", gm_id: "a", name: "Game g1" },
+          { id: "g2", gm_id: "b", name: "Game g2" },
+          { id: "g3", gm_id: "b", name: "Game g3" },
+          { id: "g4", gm_id: "c", name: "Game g4" },
         ],
         memberships: [],
         sessions: [
@@ -120,8 +125,8 @@ describe("computeTopUsers", () => {
       {
         users: [user("gm"), user("p1"), user("p2")],
         games: [
-          { id: "g1", gm_id: "gm" },
-          { id: "g2", gm_id: "gm" },
+          { id: "g1", gm_id: "gm", name: "Game g1" },
+          { id: "g2", gm_id: "gm", name: "Game g2" },
         ],
         memberships: [
           { game_id: "g1", user_id: "p1" },
@@ -140,7 +145,7 @@ describe("computeTopUsers", () => {
 
   it("caps each list at the limit", () => {
     const users = Array.from({ length: 15 }, (_, i) => user(`u${i}`));
-    const games = users.map((u, i) => ({ id: `g${i}`, gm_id: u.id }));
+    const games = users.map((u, i) => ({ id: `g${i}`, gm_id: u.id, name: `Game g${i}` }));
     const result = computeTopUsers(
       { users, games, memberships: [], sessions: [], availability: [] },
       { today, limit: 10 }
@@ -153,8 +158,8 @@ describe("computeTopUsers", () => {
       {
         users: [user("gm1")],
         games: [
-          { id: "g1", gm_id: "gm1" },
-          { id: "g2", gm_id: "ghost-gm" },
+          { id: "g1", gm_id: "gm1", name: "Game g1" },
+          { id: "g2", gm_id: "ghost-gm", name: "Game g2" },
         ],
         memberships: [
           { game_id: "g1", user_id: "ghost-player" },

--- a/src/lib/topUsers.ts
+++ b/src/lib/topUsers.ts
@@ -1,0 +1,136 @@
+// Leaderboard aggregation for the admin "Top Users" tab.
+// Pure functions over raw table rows so the ranking logic is unit-testable
+// independently of Supabase.
+
+export interface TopUserProfile {
+  id: string;
+  name: string;
+  email: string;
+  avatar_url: string | null;
+}
+
+export interface TopGmEntry {
+  user: TopUserProfile;
+  gamesOwned: number;
+  sessionsBooked: number;
+  upcomingSessions: number;
+  playersHosted: number;
+}
+
+export interface TopPlayerEntry {
+  user: TopUserProfile;
+  gamesJoined: number;
+  sessionsScheduled: number;
+  datesMarked: number;
+}
+
+export interface TopUsersInput {
+  users: TopUserProfile[];
+  games: Array<{ id: string; gm_id: string }>;
+  memberships: Array<{ game_id: string; user_id: string }>;
+  sessions: Array<{ game_id: string; date: string }>;
+  availability: Array<{ user_id: string }>;
+}
+
+export interface TopUsersResult {
+  topGms: TopGmEntry[];
+  topPlayers: TopPlayerEntry[];
+}
+
+export const TOP_USERS_LIMIT = 10;
+
+export function computeTopUsers(
+  input: TopUsersInput,
+  opts: { limit?: number; today?: string } = {}
+): TopUsersResult {
+  const limit = opts.limit ?? TOP_USERS_LIMIT;
+  const today = opts.today ?? new Date().toISOString().split('T')[0];
+
+  const usersById = new Map(input.users.map((u) => [u.id, u]));
+  const gameOwner = new Map(input.games.map((g) => [g.id, g.gm_id]));
+
+  const sessionsByGame = new Map<string, { total: number; upcoming: number }>();
+  for (const s of input.sessions) {
+    const stats = sessionsByGame.get(s.game_id) ?? { total: 0, upcoming: 0 };
+    stats.total++;
+    if (s.date >= today) stats.upcoming++;
+    sessionsByGame.set(s.game_id, stats);
+  }
+
+  const membersByGame = new Map<string, Set<string>>();
+  for (const m of input.memberships) {
+    if (!membersByGame.has(m.game_id)) membersByGame.set(m.game_id, new Set());
+    membersByGame.get(m.game_id)!.add(m.user_id);
+  }
+
+  // GM aggregates
+  const gmStats = new Map<string, { gamesOwned: number; sessionsBooked: number; upcomingSessions: number; playersHosted: Set<string> }>();
+  for (const game of input.games) {
+    if (!usersById.has(game.gm_id)) continue;
+    if (!gmStats.has(game.gm_id)) {
+      gmStats.set(game.gm_id, { gamesOwned: 0, sessionsBooked: 0, upcomingSessions: 0, playersHosted: new Set() });
+    }
+    const stats = gmStats.get(game.gm_id)!;
+    stats.gamesOwned++;
+    const sessions = sessionsByGame.get(game.id);
+    if (sessions) {
+      stats.sessionsBooked += sessions.total;
+      stats.upcomingSessions += sessions.upcoming;
+    }
+    for (const memberId of membersByGame.get(game.id) ?? []) {
+      stats.playersHosted.add(memberId);
+    }
+  }
+
+  // Player aggregates (membership-based; owning a game doesn't count here)
+  const playerStats = new Map<string, { gamesJoined: number; sessionsScheduled: number }>();
+  for (const m of input.memberships) {
+    if (!usersById.has(m.user_id) || !gameOwner.has(m.game_id)) continue;
+    if (!playerStats.has(m.user_id)) {
+      playerStats.set(m.user_id, { gamesJoined: 0, sessionsScheduled: 0 });
+    }
+    const stats = playerStats.get(m.user_id)!;
+    stats.gamesJoined++;
+    stats.sessionsScheduled += sessionsByGame.get(m.game_id)?.total ?? 0;
+  }
+
+  const datesMarkedByUser = new Map<string, number>();
+  for (const a of input.availability) {
+    datesMarkedByUser.set(a.user_id, (datesMarkedByUser.get(a.user_id) ?? 0) + 1);
+  }
+
+  const topGms: TopGmEntry[] = [...gmStats.entries()]
+    .map(([userId, stats]) => ({
+      user: usersById.get(userId)!,
+      gamesOwned: stats.gamesOwned,
+      sessionsBooked: stats.sessionsBooked,
+      upcomingSessions: stats.upcomingSessions,
+      playersHosted: stats.playersHosted.size,
+    }))
+    .sort(
+      (a, b) =>
+        b.sessionsBooked - a.sessionsBooked ||
+        b.gamesOwned - a.gamesOwned ||
+        b.playersHosted - a.playersHosted ||
+        a.user.name.localeCompare(b.user.name)
+    )
+    .slice(0, limit);
+
+  const topPlayers: TopPlayerEntry[] = [...playerStats.entries()]
+    .map(([userId, stats]) => ({
+      user: usersById.get(userId)!,
+      gamesJoined: stats.gamesJoined,
+      sessionsScheduled: stats.sessionsScheduled,
+      datesMarked: datesMarkedByUser.get(userId) ?? 0,
+    }))
+    .sort(
+      (a, b) =>
+        b.sessionsScheduled - a.sessionsScheduled ||
+        b.gamesJoined - a.gamesJoined ||
+        b.datesMarked - a.datesMarked ||
+        a.user.name.localeCompare(b.user.name)
+    )
+    .slice(0, limit);
+
+  return { topGms, topPlayers };
+}

--- a/src/lib/topUsers.ts
+++ b/src/lib/topUsers.ts
@@ -9,12 +9,19 @@ export interface TopUserProfile {
   avatar_url: string | null;
 }
 
+/** A game reference shown under an expanded leaderboard row (links to the admin peek view). */
+export interface TopUserGameRef {
+  id: string;
+  name: string;
+}
+
 export interface TopGmEntry {
   user: TopUserProfile;
   gamesOwned: number;
   sessionsBooked: number;
   upcomingSessions: number;
   playersHosted: number;
+  games: TopUserGameRef[];
 }
 
 export interface TopPlayerEntry {
@@ -22,11 +29,12 @@ export interface TopPlayerEntry {
   gamesJoined: number;
   sessionsScheduled: number;
   datesMarked: number;
+  games: TopUserGameRef[];
 }
 
 export interface TopUsersInput {
   users: TopUserProfile[];
-  games: Array<{ id: string; gm_id: string }>;
+  games: Array<{ id: string; gm_id: string; name: string }>;
   memberships: Array<{ game_id: string; user_id: string }>;
   sessions: Array<{ game_id: string; date: string }>;
   availability: Array<{ user_id: string }>;
@@ -47,7 +55,7 @@ export function computeTopUsers(
   const today = opts.today ?? new Date().toISOString().split('T')[0];
 
   const usersById = new Map(input.users.map((u) => [u.id, u]));
-  const gameOwner = new Map(input.games.map((g) => [g.id, g.gm_id]));
+  const gamesById = new Map(input.games.map((g) => [g.id, g]));
 
   const sessionsByGame = new Map<string, { total: number; upcoming: number }>();
   for (const s of input.sessions) {
@@ -64,14 +72,15 @@ export function computeTopUsers(
   }
 
   // GM aggregates
-  const gmStats = new Map<string, { gamesOwned: number; sessionsBooked: number; upcomingSessions: number; playersHosted: Set<string> }>();
+  const gmStats = new Map<string, { gamesOwned: number; sessionsBooked: number; upcomingSessions: number; playersHosted: Set<string>; games: TopUserGameRef[] }>();
   for (const game of input.games) {
     if (!usersById.has(game.gm_id)) continue;
     if (!gmStats.has(game.gm_id)) {
-      gmStats.set(game.gm_id, { gamesOwned: 0, sessionsBooked: 0, upcomingSessions: 0, playersHosted: new Set() });
+      gmStats.set(game.gm_id, { gamesOwned: 0, sessionsBooked: 0, upcomingSessions: 0, playersHosted: new Set(), games: [] });
     }
     const stats = gmStats.get(game.gm_id)!;
     stats.gamesOwned++;
+    stats.games.push({ id: game.id, name: game.name });
     const sessions = sessionsByGame.get(game.id);
     if (sessions) {
       stats.sessionsBooked += sessions.total;
@@ -83,16 +92,20 @@ export function computeTopUsers(
   }
 
   // Player aggregates (membership-based; owning a game doesn't count here)
-  const playerStats = new Map<string, { gamesJoined: number; sessionsScheduled: number }>();
+  const playerStats = new Map<string, { gamesJoined: number; sessionsScheduled: number; games: TopUserGameRef[] }>();
   for (const m of input.memberships) {
-    if (!usersById.has(m.user_id) || !gameOwner.has(m.game_id)) continue;
+    const game = gamesById.get(m.game_id);
+    if (!usersById.has(m.user_id) || !game) continue;
     if (!playerStats.has(m.user_id)) {
-      playerStats.set(m.user_id, { gamesJoined: 0, sessionsScheduled: 0 });
+      playerStats.set(m.user_id, { gamesJoined: 0, sessionsScheduled: 0, games: [] });
     }
     const stats = playerStats.get(m.user_id)!;
     stats.gamesJoined++;
+    stats.games.push({ id: game.id, name: game.name });
     stats.sessionsScheduled += sessionsByGame.get(m.game_id)?.total ?? 0;
   }
+
+  const byName = (a: TopUserGameRef, b: TopUserGameRef) => a.name.localeCompare(b.name);
 
   const datesMarkedByUser = new Map<string, number>();
   for (const a of input.availability) {
@@ -106,6 +119,7 @@ export function computeTopUsers(
       sessionsBooked: stats.sessionsBooked,
       upcomingSessions: stats.upcomingSessions,
       playersHosted: stats.playersHosted.size,
+      games: [...stats.games].sort(byName),
     }))
     .sort(
       (a, b) =>
@@ -122,6 +136,7 @@ export function computeTopUsers(
       gamesJoined: stats.gamesJoined,
       sessionsScheduled: stats.sessionsScheduled,
       datesMarked: datesMarkedByUser.get(userId) ?? 0,
+      games: [...stats.games].sort(byName),
     }))
     .sort(
       (a, b) =>


### PR DESCRIPTION
## Summary

Two new admin dashboard features, plus a follow-up that ties them together:

### Top Users tab
- New leaderboards for **Top GMs** (games owned, sessions booked, upcoming sessions, distinct players hosted) and **Top Players** (games joined, sessions scheduled in their games, availability dates marked)
- Ranking logic lives in a pure, unit-tested aggregation (`src/lib/topUsers.ts`) behind a new `/api/admin/top-users` route using the existing `requireAdmin()` + `paginate()` pattern
- Each row expands on click to list that user's games, linking to the peek view below

### Read-only game peek (`/admin/games/[id]`)
- Lets an admin inspect any game — including ones they are not a member of — with zero risk of mutating it:
  - Data comes from a GET-only snapshot API that reuses the existing data-layer fetchers with the service-role client (RLS hides non-member games from the browser client)
  - Reuses the existing Overview / Availability / Schedule tab components with `isGm=false` and all mutation callbacks stubbed; the page imports no mutation hooks at all
  - New `readOnly` mode on `AvailabilityCalendar` (no day-click cycling, no long-press editor, no bulk actions, no add-note affordance) plus a per-player "Viewing availability for" selector
- Game names in the admin Games tab link to the peek view
- Shared derived-state logic (scheduling window, completion, suggestions) extracted from `GameDetailPage` into `useGameDerivedState`, now used by both pages

## Test plan
- [x] 8 new unit tests for `computeTopUsers` (metrics, ranking, tie-breaks, caps, ghost rows, per-user game lists) — 495 total passing
- [x] New e2e specs: peek as non-member admin (read-only banner, no GM controls, no bulk actions, no schedule actions), non-admin 403 + redirect, missing-game 404 state, Top Users leaderboards incl. expand-row → game link → peek navigation — 11 admin e2e passing
- [x] Full availability/scheduling/games e2e suites (166 tests) pass against the `GameDetailPage` refactor
- [x] `npm run lint` and `npm run build` clean
- [x] UI manually validated via dev-login at desktop and 375px mobile widths