### PR TITLE
Add availability onboarding nudge for new game participants

### DIFF
--- a/e2e/tests/availability/onboarding-nudge.spec.ts
+++ b/e2e/tests/availability/onboarding-nudge.spec.ts
@@ -44,4 +44,25 @@ test.describe('Availability onboarding nudge', () => {
     await page.goto(`/games/${game.id}`);
     await expect(page.getByRole('button', { name: /add availability/i })).toBeHidden();
   });
+
+  test('shows for the GM when they have no availability', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-nudge-gm-${Date.now()}@e2e.local`,
+      name: 'Nudge GM Self',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Nudge GM Campaign',
+      play_days: [5, 6],
+    });
+
+    // GM has no availability yet -> banner should show for them too.
+    await loginTestUser(page, gm);
+    await page.goto(`/games/${game.id}`);
+
+    const cta = page.getByRole('button', { name: /add availability/i });
+    await expect(cta).toBeVisible();
+  });
 });

--- a/e2e/tests/availability/onboarding-nudge.spec.ts
+++ b/e2e/tests/availability/onboarding-nudge.spec.ts
@@ -27,15 +27,23 @@ test.describe('Availability onboarding nudge', () => {
     });
     await addPlayerToGame(game.id, player.id);
 
-    // Player has no availability yet -> banner should show.
+    // Player has no availability yet -> banner and pulsing dot should show.
     await loginTestUser(page, player);
     await page.goto(`/games/${game.id}`);
 
     const cta = page.getByRole('button', { name: /add availability/i });
     await expect(cta).toBeVisible();
 
-    // Clicking the CTA switches to the Availability tab; the banner disappears.
+    // Pulsing dot on the Availability tab button is visible while nudge is active.
+    await expect(page.getByTestId('availability-nudge-dot')).toBeVisible();
+
+    // Clicking the CTA switches to the Availability tab.
     await cta.click();
+
+    // Positive assertion: the Availability tab content container is now visible.
+    await expect(page.getByTestId('availability-tab-content')).toBeVisible();
+
+    // Banner is gone once the Availability tab is active.
     await expect(cta).toBeHidden();
 
     // After the player has availability, the banner stays gone on reload (overview tab).
@@ -43,6 +51,9 @@ test.describe('Availability onboarding nudge', () => {
     await setAvailability(player.id, game.id, [{ date: playDates[0], is_available: true }]);
     await page.goto(`/games/${game.id}`);
     await expect(page.getByRole('button', { name: /add availability/i })).toBeHidden();
+
+    // Pulsing dot is also gone after availability is marked.
+    await expect(page.getByTestId('availability-nudge-dot')).toBeHidden();
   });
 
   test('shows for the GM when they have no availability', async ({ page, request }) => {

--- a/e2e/tests/availability/onboarding-nudge.spec.ts
+++ b/e2e/tests/availability/onboarding-nudge.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  addPlayerToGame,
+  setAvailability,
+  getPlayDates,
+} from '../../helpers/seed';
+
+test.describe('Availability onboarding nudge', () => {
+  test('shows for a member with no availability and resolves after marking', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-nudge-${Date.now()}@e2e.local`,
+      name: 'Nudge GM',
+      is_gm: true,
+    });
+    const player = await createTestUser(request, {
+      email: `player-nudge-${Date.now()}@e2e.local`,
+      name: 'Nudge Player',
+      is_gm: false,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Nudge Campaign',
+      play_days: [5, 6],
+    });
+    await addPlayerToGame(game.id, player.id);
+
+    // Player has no availability yet -> banner should show.
+    await loginTestUser(page, player);
+    await page.goto(`/games/${game.id}`);
+
+    const cta = page.getByRole('button', { name: /add availability/i });
+    await expect(cta).toBeVisible();
+
+    // Clicking the CTA switches to the Availability tab; the banner disappears.
+    await cta.click();
+    await expect(cta).toBeHidden();
+
+    // After the player has availability, the banner stays gone on reload (overview tab).
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(player.id, game.id, [{ date: playDates[0], is_available: true }]);
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /add availability/i })).toBeHidden();
+  });
+});

--- a/e2e/tests/availability/onboarding-nudge.spec.ts
+++ b/e2e/tests/availability/onboarding-nudge.spec.ts
@@ -31,7 +31,7 @@ test.describe('Availability onboarding nudge', () => {
     await loginTestUser(page, player);
     await page.goto(`/games/${game.id}`);
 
-    const cta = page.getByRole('button', { name: /add availability/i });
+    const cta = page.getByRole('button', { name: /mark your dates/i });
     await expect(cta).toBeVisible();
 
     // Pulsing dot on the Availability tab button is visible while nudge is active.
@@ -50,7 +50,7 @@ test.describe('Availability onboarding nudge', () => {
     const playDates = getPlayDates([5, 6], 4);
     await setAvailability(player.id, game.id, [{ date: playDates[0], is_available: true }]);
     await page.goto(`/games/${game.id}`);
-    await expect(page.getByRole('button', { name: /add availability/i })).toBeHidden();
+    await expect(page.getByRole('button', { name: /mark your dates/i })).toBeHidden();
 
     // Pulsing dot is also gone after availability is marked.
     await expect(page.getByTestId('availability-nudge-dot')).toBeHidden();
@@ -73,7 +73,7 @@ test.describe('Availability onboarding nudge', () => {
     await loginTestUser(page, gm);
     await page.goto(`/games/${game.id}`);
 
-    const cta = page.getByRole('button', { name: /add availability/i });
+    const cta = page.getByRole('button', { name: /mark your dates/i });
     await expect(cta).toBeVisible();
   });
 });

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -253,6 +253,7 @@ export default function GameDetailPage() {
                 {tab === "availability" && showAvailabilityNudge && (
                   <span
                     aria-hidden
+                    data-testid="availability-nudge-dot"
                     className="absolute -right-2.5 -top-1 size-1.5 rounded-full bg-primary motion-safe:animate-ping"
                   />
                 )}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -233,7 +233,7 @@ export default function GameDetailPage() {
         <OnboardingBanner
           title="You're in the party! 🎉"
           description="Add your availability so the GM can find a night that works for everyone."
-          ctaLabel="Add availability"
+          ctaLabel="Mark your dates"
           onCta={() => setActiveTab("availability")}
         />
       )}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -4,7 +4,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRouter, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
-import { Button, LoadingSpinner, Modal, useToast } from "@/components/ui";
+import { Button, LoadingSpinner, Modal, OnboardingBanner, useToast } from "@/components/ui";
+import { shouldShowAvailabilityNudge } from "@/lib/onboarding";
 import { OverviewTabContent } from "@/components/games/overview/OverviewTabContent";
 import { User } from "@/types";
 import { AvailabilityTabContent } from "@/components/games/availability/AvailabilityTabContent";
@@ -69,6 +70,13 @@ export default function GameDetailPage() {
     game?.members.some((m) => m.id === profile?.id && m.is_co_gm) ?? false;
   const canDoGmActions = !!(isGm || isCoGm);
   const isMember = game?.members.some((m) => m.id === profile?.id);
+
+  const hasAnyAvailability = Object.keys(availability).length > 0;
+  const showAvailabilityNudge = shouldShowAvailabilityNudge({
+    hasAnyAvailability,
+    activeTab,
+    isParticipant: !!isMember,
+  });
 
   const {
     extraDateStrings,
@@ -218,6 +226,15 @@ export default function GameDetailPage() {
         )}
       </div>
 
+      {showAvailabilityNudge && (
+        <OnboardingBanner
+          title="You're in the party! 🎉"
+          description="Add your availability so the GM can find a night that works for everyone."
+          ctaLabel="Add availability"
+          onCta={() => setActiveTab("availability")}
+        />
+      )}
+
       {/* Tabs */}
       <div className="border-b border-border mb-6">
         <nav className="-mb-px flex gap-4 sm:gap-6">
@@ -231,7 +248,15 @@ export default function GameDetailPage() {
                   : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
               }`}
             >
-              {tab}
+              <span className="relative inline-flex items-center">
+                {tab}
+                {tab === "availability" && showAvailabilityNudge && (
+                  <span
+                    aria-hidden
+                    className="absolute -right-2.5 -top-1 size-1.5 rounded-full bg-primary motion-safe:animate-ping"
+                  />
+                )}
+              </span>
             </button>
           ))}
         </nav>

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -72,10 +72,13 @@ export default function GameDetailPage() {
   const isMember = game?.members.some((m) => m.id === profile?.id);
 
   const hasAnyAvailability = Object.keys(availability).length > 0;
+  // The host GM owns the game via gm_id and is intentionally not a
+  // game_memberships row (see schema.sql), so isMember is false for them.
+  // They still mark availability, so treat them as a participant too.
   const showAvailabilityNudge = shouldShowAvailabilityNudge({
     hasAnyAvailability,
     activeTab,
-    isParticipant: !!isMember,
+    isParticipant: !!isMember || isGm,
   });
 
   const {

--- a/src/components/ui/OnboardingBanner.test.tsx
+++ b/src/components/ui/OnboardingBanner.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OnboardingBanner } from "./OnboardingBanner";
+import { describe, it, expect, vi } from "vitest";
+
+describe("OnboardingBanner", () => {
+  it("renders title, description, and cta label", () => {
+    render(
+      <OnboardingBanner
+        title="You're in the party!"
+        description="Add your availability."
+        ctaLabel="Add availability"
+        onCta={() => {}}
+      />
+    );
+    expect(screen.getByText("You're in the party!")).toBeInTheDocument();
+    expect(screen.getByText("Add your availability.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add availability/i })).toBeInTheDocument();
+  });
+
+  it("calls onCta when the button is clicked", () => {
+    const onCta = vi.fn();
+    render(
+      <OnboardingBanner
+        title="t"
+        description="d"
+        ctaLabel="Add availability"
+        onCta={onCta}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /add availability/i }));
+    expect(onCta).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/OnboardingBanner.tsx
+++ b/src/components/ui/OnboardingBanner.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ReactNode } from 'react';
+import Image from 'next/image';
+
+export interface OnboardingBannerProps {
+  /** Leading visual; defaults to the app logo. */
+  icon?: ReactNode;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  onCta: () => void;
+}
+
+export function OnboardingBanner({
+  icon,
+  title,
+  description,
+  ctaLabel,
+  onCta,
+}: OnboardingBannerProps) {
+  return (
+    <div className="mb-6 flex flex-col gap-4 rounded-xl bg-primary px-5 py-4 text-primary-foreground shadow-lg sm:flex-row sm:items-center">
+      <div className="flex items-center justify-center rounded-lg bg-primary-foreground/15 p-2 shrink-0 self-start sm:self-center">
+        {icon ?? (
+          <Image src="/logo.png" alt="Can We Play?" width={40} height={40} />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-bold leading-tight">{title}</p>
+        <p className="text-sm opacity-90 mt-0.5">{description}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onCta}
+        className="shrink-0 inline-flex items-center justify-center gap-2 rounded-lg bg-primary-foreground px-4 py-2.5 text-sm font-bold text-primary transition-transform hover:scale-[1.03] w-full sm:w-auto"
+      >
+        {ctaLabel}
+        <span aria-hidden className="motion-safe:animate-pulse">→</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,4 +11,5 @@ export { StatePill, type PillState } from './StatePill';
 export { RankCircle } from './RankCircle';
 export { EyebrowLabel } from './EyebrowLabel';
 export { Modal } from './Modal';
+export { OnboardingBanner, type OnboardingBannerProps } from './OnboardingBanner';
 export { ToastProvider, useToast } from './Toast';

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowAvailabilityNudge } from "./onboarding";
+
+describe("shouldShowAvailabilityNudge", () => {
+  const base = {
+    hasAnyAvailability: false,
+    activeTab: "overview" as const,
+    isParticipant: true,
+  };
+
+  it("shows for a participant with no availability on the overview tab", () => {
+    expect(shouldShowAvailabilityNudge(base)).toBe(true);
+  });
+
+  it("shows for a participant with no availability on the schedule tab", () => {
+    expect(shouldShowAvailabilityNudge({ ...base, activeTab: "schedule" })).toBe(true);
+  });
+
+  it("hides when the participant already has availability", () => {
+    expect(shouldShowAvailabilityNudge({ ...base, hasAnyAvailability: true })).toBe(false);
+  });
+
+  it("hides while on the availability tab even with no availability", () => {
+    expect(shouldShowAvailabilityNudge({ ...base, activeTab: "availability" })).toBe(false);
+  });
+
+  it("hides for a non-participant", () => {
+    expect(shouldShowAvailabilityNudge({ ...base, isParticipant: false })).toBe(false);
+  });
+});

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,15 @@
+export type GameTab = "overview" | "availability" | "schedule";
+
+/**
+ * Whether to show the "add your availability" onboarding nudge.
+ * Shown to a game participant who has not yet marked any availability,
+ * except while they are already on the Availability tab.
+ */
+export function shouldShowAvailabilityNudge(args: {
+  hasAnyAvailability: boolean;
+  activeTab: GameTab;
+  isParticipant: boolean;
+}): boolean {
+  const { hasAnyAvailability, activeTab, isParticipant } = args;
+  return isParticipant && !hasAnyAvailability && activeTab !== "availability";
+}


### PR DESCRIPTION
## What & why

After joining a game, players landed on the Overview tab with no signal about the one action that makes the app useful: marking their availability. This adds a bold, self-resolving onboarding nudge that directs any game participant with **no availability** to the Availability tab.

## Behavior

- **Data-driven trigger:** shows to any participant — players *and* the host GM — who has zero availability for the game. Persists across visits/refreshes and **auto-resolves** the moment they mark their first availability.
- **No dismiss button:** the only way to clear it is to add availability (the app is useless without it).
- **Tab-aware:** hidden while already on the Availability tab. The CTA switches the active tab to Availability.
- **Affordance:** a pulsing dot on the Availability tab button while the nudge is active.

## Visual

A bold filled banner (`bg-primary` / `text-primary-foreground`) with the app logo, headline + subtext, and a high-contrast animated CTA. Semantic theme classes only (works across all 5 themes + dark mode); responsive (row on desktop, stacked full-width CTA on mobile).

## Implementation

- `src/lib/onboarding.ts` — pure `shouldShowAvailabilityNudge()` helper (unit-tested).
- `src/components/ui/OnboardingBanner.tsx` — reusable presentational banner (component-tested), built to generalize for future onboarding nudges.
- `src/app/games/[id]/page.tsx` — derives visibility from already-loaded availability data; no schema/redirect/query-param changes.

## Notable

The host GM is intentionally **not** a `game_memberships` row (they own the game via `gm_id`), so `isMember` excludes them. The participant check is `!!isMember || isGm` so the GM sees the nudge too — a bug the GM-persona E2E case caught.

## Testing

- Unit: `shouldShowAvailabilityNudge` (5 cases) + `OnboardingBanner` render/click.
- E2E (`e2e/tests/availability/onboarding-nudge.spec.ts`): player sees banner + dot → CTA switches to Availability tab content → banner/dot gone after marking availability; plus a GM-persona case. **2/2 passing locally.**
- Full unit suite 502/502, lint clean, build compiles.