### PR TITLE
Default availability: a reusable weekly pattern you can apply to any game

### DIFF
--- a/e2e/helpers/db-assertions.ts
+++ b/e2e/helpers/db-assertions.ts
@@ -88,3 +88,19 @@ export async function availabilityRowsInGame(gameId: string, userId: string): Pr
     .eq('user_id', userId);
   return count ?? 0;
 }
+
+export async function availabilityStatusForDate(
+  gameId: string,
+  userId: string,
+  date: string
+): Promise<string | null> {
+  const admin = getAdminClient();
+  const { data } = await admin
+    .from('availability')
+    .select('status')
+    .eq('game_id', gameId)
+    .eq('user_id', userId)
+    .eq('date', date)
+    .maybeSingle();
+  return data?.status ?? null;
+}

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -392,6 +392,7 @@ export function resetDatabaseSchema(): void {
 
   // SQL to drop all app tables and types (in dependency order)
   const dropSql = `
+    DROP TABLE IF EXISTS user_availability_defaults CASCADE;
     DROP TABLE IF EXISTS game_play_dates CASCADE;
     DROP TABLE IF EXISTS sessions CASCADE;
     DROP TABLE IF EXISTS availability CASCADE;

--- a/e2e/tests/availability/bulk-actions.spec.ts
+++ b/e2e/tests/availability/bulk-actions.spec.ts
@@ -40,7 +40,7 @@ test.describe('Bulk Availability Actions', () => {
     await dayDropdown.selectOption('5'); // Friday = 5
 
     // Click Apply button
-    const applyButton = page.getByRole('button', { name: /apply/i });
+    const applyButton = page.getByRole('button', { name: 'Apply', exact: true });
     await applyButton.click();
 
     // Get upcoming Fridays to verify
@@ -99,7 +99,7 @@ test.describe('Bulk Availability Actions', () => {
     await statusDropdown.selectOption('unavailable');
 
     // Click Apply button
-    const applyButton = page.getByRole('button', { name: /apply/i });
+    const applyButton = page.getByRole('button', { name: 'Apply', exact: true });
     await applyButton.click();
 
     // Get upcoming Saturdays to verify
@@ -153,7 +153,7 @@ test.describe('Bulk Availability Actions', () => {
     const dayDropdown = page.getByLabel('Day of week');
     await dayDropdown.selectOption('5'); // Friday = 5
     // Status is already "available" by default
-    const applyButton = page.getByRole('button', { name: /apply/i });
+    const applyButton = page.getByRole('button', { name: 'Apply', exact: true });
     await applyButton.click();
 
     // Get first Friday to check
@@ -222,7 +222,7 @@ test.describe('Bulk Availability Actions', () => {
     const dayDropdown = page.getByLabel('Day of week');
     await dayDropdown.selectOption('remaining');
     // Status is already "available" by default
-    const applyButton = page.getByRole('button', { name: /apply/i });
+    const applyButton = page.getByRole('button', { name: 'Apply', exact: true });
     await applyButton.click();
 
     // The first Friday should still be unavailable - not overwritten
@@ -281,7 +281,7 @@ test.describe('Bulk Availability Actions', () => {
     const statusDropdown = page.getByLabel('Availability status');
     await statusDropdown.selectOption('maybe');
 
-    const applyButton = page.getByRole('button', { name: /apply/i });
+    const applyButton = page.getByRole('button', { name: 'Apply', exact: true });
     await applyButton.click();
 
     // Verify Fridays are marked as maybe

--- a/e2e/tests/settings/default-availability.spec.ts
+++ b/e2e/tests/settings/default-availability.spec.ts
@@ -4,20 +4,19 @@ import { createTestGame, getPlayDates, setAvailability } from '../../helpers/see
 import { availabilityRowsInGame, availabilityStatusForDate } from '../../helpers/db-assertions';
 import { TEST_TIMEOUTS } from '../../constants';
 
-/**
- * Click a weekday default status and wait for the auto-save to settle.
- *
- * The editor saves asynchronously on click; navigating or reloading before the
- * POST completes cancels the request and the default never persists. We assert
- * the optimistic UI update, then wait for the transient "Saving…" indicator to
- * clear, guaranteeing the row is written before the next step.
- */
-async function setDefaultAndWait(page: Page, day: string, value: string) {
+/** Select a weekday default status (local state only; persisted on Save). */
+async function setDefault(page: Page, day: string, value: string) {
   const button = page.locator(`[data-testid="status-${day}-${value}"]:visible`);
   await button.click();
   await expect(button).toHaveAttribute('aria-checked', 'true', { timeout: TEST_TIMEOUTS.DEFAULT });
-  // The save indicator reads "Saving…" while in flight; wait for it to clear.
-  await expect(page.getByText(/saving…/i)).toHaveCount(0, { timeout: TEST_TIMEOUTS.DEFAULT });
+}
+
+/** Click the editor's Save button and wait for the success confirmation. */
+async function saveDefaults(page: Page) {
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+  await expect(page.getByText('Default availability saved!')).toBeVisible({
+    timeout: TEST_TIMEOUTS.DEFAULT,
+  });
 }
 
 test.describe('Default availability', () => {
@@ -30,11 +29,12 @@ test.describe('Default availability', () => {
 
     const game = await createTestGame({ gm_id: user.id, name: 'Defaults Game', play_days: [3, 5] });
 
-    // Configure defaults in the editor.
+    // Configure defaults in the editor, then save.
     await page.goto('/settings/default-availability');
     await expect(page.getByRole('heading', { name: /default availability/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
-    await setDefaultAndWait(page, 'friday', 'available');
-    await setDefaultAndWait(page, 'wednesday', 'unavailable');
+    await setDefault(page, 'friday', 'available');
+    await setDefault(page, 'wednesday', 'unavailable');
+    await saveDefaults(page);
 
     // Reload and confirm persistence.
     await page.reload();
@@ -71,10 +71,11 @@ test.describe('Default availability', () => {
     await setAvailability(user.id, game.id, [{ date: manualDate, status: 'maybe' }]);
     const rowsBefore = await availabilityRowsInGame(game.id, user.id);
 
-    // Default: Friday = Available.
+    // Default: Friday = Available, then save.
     await page.goto('/settings/default-availability');
     await expect(page.getByRole('heading', { name: /default availability/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
-    await setDefaultAndWait(page, 'friday', 'available');
+    await setDefault(page, 'friday', 'available');
+    await saveDefaults(page);
 
     // Apply.
     await page.goto(`/games/${game.id}`);
@@ -88,5 +89,33 @@ test.describe('Default availability', () => {
     expect(await availabilityStatusForDate(game.id, user.id, manualDate)).toBe('maybe');
     // And new future Fridays were filled, so the row count grew.
     expect(await availabilityRowsInGame(game.id, user.id)).toBeGreaterThan(rowsBefore);
+  });
+
+  test('editor back link returns to the game when opened from a game', async ({ page }) => {
+    const user = await loginTestUser(page, {
+      email: `default-back-${Date.now()}@e2e.local`,
+      name: 'Back Link User',
+      is_gm: true,
+    });
+    const game = await createTestGame({ gm_id: user.id, name: 'Back Link Game', play_days: [5] });
+
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /^availability$/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /^availability$/i }).click();
+
+    // Open the editor via the "Edit defaults" link on the Availability tab.
+    await page.getByRole('link', { name: /edit defaults/i }).click();
+    await expect(page).toHaveURL(/\/settings\/default-availability\?returnTo=/, { timeout: TEST_TIMEOUTS.DEFAULT });
+
+    // The back link returns to the game's Availability tab (not Settings, and
+    // not the Overview tab).
+    const backLink = page.getByRole('link', { name: /back to game/i });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute('href', `/games/${game.id}?tab=availability`);
+    await backLink.click();
+    // Landing back on the Availability tab: the apply button only renders there.
+    await expect(page.getByRole('button', { name: /apply my default availability/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
   });
 });

--- a/e2e/tests/settings/default-availability.spec.ts
+++ b/e2e/tests/settings/default-availability.spec.ts
@@ -66,7 +66,7 @@ test.describe('Default availability', () => {
     const game = await createTestGame({ gm_id: user.id, name: 'Non Destructive Game', play_days: [5] });
 
     // Pre-set one Friday to 'maybe' via seed.
-    const fridays = getPlayDates([5], 1);
+    const fridays = getPlayDates([5], 2);
     const manualDate = fridays[0];
     await setAvailability(user.id, game.id, [{ date: manualDate, status: 'maybe' }]);
     const rowsBefore = await availabilityRowsInGame(game.id, user.id);

--- a/e2e/tests/settings/default-availability.spec.ts
+++ b/e2e/tests/settings/default-availability.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loginTestUser } from '../../helpers/test-auth';
+import { createTestGame, getPlayDates, setAvailability } from '../../helpers/seed';
+import { availabilityRowsInGame, availabilityStatusForDate } from '../../helpers/db-assertions';
+import { TEST_TIMEOUTS } from '../../constants';
+
+/**
+ * Click a weekday default status and wait for the auto-save to settle.
+ *
+ * The editor saves asynchronously on click; navigating or reloading before the
+ * POST completes cancels the request and the default never persists. We assert
+ * the optimistic UI update, then wait for the transient "Saving…" indicator to
+ * clear, guaranteeing the row is written before the next step.
+ */
+async function setDefaultAndWait(page: Page, day: string, value: string) {
+  const button = page.locator(`[data-testid="status-${day}-${value}"]:visible`);
+  await button.click();
+  await expect(button).toHaveAttribute('aria-checked', 'true', { timeout: TEST_TIMEOUTS.DEFAULT });
+  // The save indicator reads "Saving…" while in flight; wait for it to clear.
+  await expect(page.getByText(/saving…/i)).toHaveCount(0, { timeout: TEST_TIMEOUTS.DEFAULT });
+}
+
+test.describe('Default availability', () => {
+  test('set defaults in settings, then apply them to a game', async ({ page }) => {
+    const user = await loginTestUser(page, {
+      email: `default-avail-${Date.now()}@e2e.local`,
+      name: 'Default Avail User',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({ gm_id: user.id, name: 'Defaults Game', play_days: [3, 5] });
+
+    // Configure defaults in the editor.
+    await page.goto('/settings/default-availability');
+    await expect(page.getByRole('heading', { name: /default availability/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await setDefaultAndWait(page, 'friday', 'available');
+    await setDefaultAndWait(page, 'wednesday', 'unavailable');
+
+    // Reload and confirm persistence.
+    await page.reload();
+    await expect(page.locator('[data-testid="status-friday-available"]:visible')).toHaveAttribute('aria-checked', 'true', { timeout: TEST_TIMEOUTS.DEFAULT });
+
+    // Apply to the game.
+    await page.goto(`/games/${game.id}`);
+    // The game page renders tabs as plain buttons (not role="tab"); match the
+    // tab by its exact accessible name so we don't also hit the "Apply my
+    // default availability" button.
+    await expect(page.getByRole('button', { name: /^availability$/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /^availability$/i }).click();
+
+    await page.getByRole('button', { name: /apply my default availability/i }).click();
+    await expect(page.getByText(/filled in \d+ dates?/i)).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+    expect(await availabilityRowsInGame(game.id, user.id)).toBeGreaterThan(0);
+
+    // Re-applying fills nothing.
+    await page.getByRole('button', { name: /apply my default availability/i }).click();
+    await expect(page.getByText(/already applied/i)).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+  });
+
+  test('apply is non-destructive — a pre-set date is not overwritten', async ({ page }) => {
+    const user = await loginTestUser(page, {
+      email: `default-nd-${Date.now()}@e2e.local`,
+      name: 'Non Destructive User',
+      is_gm: true,
+    });
+    const game = await createTestGame({ gm_id: user.id, name: 'Non Destructive Game', play_days: [5] });
+
+    // Pre-set one Friday to 'maybe' via seed.
+    const fridays = getPlayDates([5], 1);
+    const manualDate = fridays[0];
+    await setAvailability(user.id, game.id, [{ date: manualDate, status: 'maybe' }]);
+    const rowsBefore = await availabilityRowsInGame(game.id, user.id);
+
+    // Default: Friday = Available.
+    await page.goto('/settings/default-availability');
+    await expect(page.getByRole('heading', { name: /default availability/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await setDefaultAndWait(page, 'friday', 'available');
+
+    // Apply.
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /^availability$/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /^availability$/i }).click();
+    await page.getByRole('button', { name: /apply my default availability/i }).click();
+    await expect(page.getByText(/filled in \d+ dates?/i)).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+
+    // The pre-set date must survive unchanged (non-destructive): still 'maybe',
+    // not overwritten by the Friday=Available default.
+    expect(await availabilityStatusForDate(game.id, user.id, manualDate)).toBe('maybe');
+    // And new future Fridays were filled, so the row count grew.
+    expect(await availabilityRowsInGame(game.id, user.id)).toBeGreaterThan(rowsBefore);
+  });
+});

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -246,6 +246,7 @@ export default function AdminGamePeekPage() {
             use24h={use24h}
             otherGames={[]}
             onCopyFromGame={async () => 0}
+            onApplyDefaults={async () => ({ hadDefaults: false, filled: 0 })}
             playDateNotes={playDateNotes}
             onUpdatePlayDateNote={() => {}}
             hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -246,7 +246,6 @@ export default function AdminGamePeekPage() {
             use24h={use24h}
             otherGames={[]}
             onCopyFromGame={async () => 0}
-            onApplyDefaults={async () => ({ hadDefaults: false, filled: 0 })}
             playDateNotes={playDateNotes}
             onUpdatePlayDateNote={() => {}}
             hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -64,6 +64,17 @@ export default function GameDetailPage() {
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
 
+  // Honor a `?tab=` hint so deep links land on the right tab — e.g. returning
+  // from the default-availability editor sends you back to the Availability tab
+  // you came from, not Overview. The loading spinner masks this initial set.
+  useEffect(() => {
+    const tab = new URLSearchParams(window.location.search).get("tab");
+    if (tab === "availability" || tab === "schedule") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time deep-link tab hint
+      setActiveTab(tab);
+    }
+  }, []);
+
   const isGm = game?.gm_id === profile?.id;
   const isCoGm =
     game?.members.some((m) => m.id === profile?.id && m.is_co_gm) ?? false;

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -33,7 +33,7 @@ export default function GameDetailPage() {
 
   const ready = !!game;
   const availabilityHook = useAvailability(gameId, userId, game);
-  const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, removePlayerData } = availabilityHook;
+  const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, applyDefaults, removePlayerData } = availabilityHook;
 
   const sessionsHook = useSessions(gameId, ready);
   const { sessions, confirmSession: confirmSessionRaw, updateSession, cancelSession } = sessionsHook;
@@ -284,6 +284,7 @@ export default function GameDetailPage() {
           use24h={use24h}
           otherGames={otherGames}
           onCopyFromGame={copyFromGame}
+          onApplyDefaults={() => applyDefaults(extraDateStrings)}
           playDateNotes={playDateNotes}
           onUpdatePlayDateNote={updatePlayDateNote}
           hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}

--- a/src/app/settings/default-availability/page.tsx
+++ b/src/app/settings/default-availability/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuthRedirect } from '@/hooks/useAuthRedirect';
+import { DefaultAvailabilityEditor } from '@/components/settings/DefaultAvailabilityEditor';
+
+export default function DefaultAvailabilityPage() {
+  useAuthRedirect();
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <Link href="/settings" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back to Settings
+        </Link>
+      </div>
+
+      <h1 className="mb-2 text-2xl font-bold text-foreground">Default availability</h1>
+      <p className="mb-8 text-muted-foreground">
+        Set your usual weekly availability. You can apply it to pre-fill any game&apos;s calendar
+        from that game&apos;s <span className="font-medium text-foreground">Availability</span> tab.
+        Applying never overwrites dates you&apos;ve already set.
+      </p>
+
+      <DefaultAvailabilityEditor />
+    </div>
+  );
+}

--- a/src/app/settings/default-availability/page.tsx
+++ b/src/app/settings/default-availability/page.tsx
@@ -1,17 +1,25 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
+import { safeCallbackUrl } from '@/lib/url';
 import { DefaultAvailabilityEditor } from '@/components/settings/DefaultAvailabilityEditor';
 
-export default function DefaultAvailabilityPage() {
+function DefaultAvailabilityContent() {
   useAuthRedirect();
+  const searchParams = useSearchParams();
+  // Return to wherever the user came from (e.g. a game's Availability tab),
+  // falling back to Settings. safeCallbackUrl guards against open redirects.
+  const backHref = safeCallbackUrl(searchParams.get('returnTo'), '/settings');
+  const backLabel = backHref.startsWith('/games/') ? 'Back to game' : 'Back to Settings';
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Link href="/settings" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Back to Settings
+        <Link href={backHref} className="text-sm text-muted-foreground hover:text-foreground">
+          ← {backLabel}
         </Link>
       </div>
 
@@ -24,5 +32,13 @@ export default function DefaultAvailabilityPage() {
 
       <DefaultAvailabilityEditor />
     </div>
+  );
+}
+
+export default function DefaultAvailabilityPage() {
+  return (
+    <Suspense>
+      <DefaultAvailabilityContent />
+    </Suspense>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -232,6 +232,22 @@ export default function SettingsPage() {
           </Button>
         </div>
 
+        {/* ── Default availability ─────────────────────────────────────── */}
+        <Panel as="section" padded="md">
+          <EyebrowLabel className="mb-4 block">Default availability</EyebrowLabel>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="sm:max-w-md">
+              <p className="text-sm font-medium text-foreground">Your usual weekly availability</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Define a recurring pattern once, then apply it to fill in any game&apos;s calendar.
+              </p>
+            </div>
+            <Link href="/settings/default-availability" className="shrink-0">
+              <Button variant="secondary">Set default availability</Button>
+            </Link>
+          </div>
+        </Panel>
+
         {/* ── Danger Zone ──────────────────────────────────────────────── */}
         <section className="mt-2 rounded-xl border border-destructive/40 bg-card p-4 sm:p-6">
           <EyebrowLabel variant="danger" className="mb-4 block">Danger Zone</EyebrowLabel>

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useRef, useCallback, useEffect } from "react";
+import { useMemo, useState, useRef, useCallback, useEffect, type ReactNode } from "react";
 import {
   format,
   startOfMonth,
@@ -50,6 +50,9 @@ interface AvailabilityCalendarProps {
   playDateNotes?: Map<string, string>;
   onUpdatePlayDateNote?: (date: string, note: string | null) => void;
   hasCampaignDates?: boolean;
+  /** Optional content rendered as the first section of the bulk-actions bar
+   *  (e.g. "Apply my default availability"), so related fill shortcuts share one element. */
+  bulkActionsLead?: ReactNode;
   /** Disables all interaction (day clicks, long-press editing, bulk actions). Used by the admin peek view. */
   readOnly?: boolean;
 }
@@ -71,6 +74,7 @@ export function AvailabilityCalendar({
   playDateNotes = new Map(),
   onUpdatePlayDateNote,
   hasCampaignDates = false,
+  bulkActionsLead,
   readOnly = false,
 }: AvailabilityCalendarProps) {
   const today = startOfDay(new Date());
@@ -288,6 +292,14 @@ export function AvailabilityCalendar({
       {!readOnly && (
       <div className="bg-secondary rounded-lg p-3">
         <div className="space-y-2 lg:space-y-0 lg:flex lg:flex-wrap lg:items-center lg:gap-2 text-sm">
+          {/* Lead slot — e.g. "Apply my default availability" — sits alongside the bulk tools */}
+          {bulkActionsLead && (
+            <>
+              {bulkActionsLead}
+              <span className="hidden lg:inline text-muted-foreground/50">|</span>
+              <div className="border-t border-muted-foreground/25 lg:hidden" />
+            </>
+          )}
           {/* Mark all section — stacked on mobile, inline on desktop */}
           <div className="lg:contents">
             <p className="text-xs text-muted-foreground mb-1 lg:hidden">Mark all</p>

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -23,6 +23,7 @@ import {
   AvailabilityEntry,
 } from "@/lib/availabilityStatus";
 import { formatTimeShort } from "@/lib/formatting";
+import { getTimeOptions } from "@/lib/timeOptions";
 
 export type { AvailabilityEntry };
 
@@ -972,26 +973,6 @@ function MonthCalendar({
       </div>
     </div>
   );
-}
-
-// Time options for availability selects (30-minute increments)
-function getTimeOptions(use24h: boolean): { value: string; label: string }[] {
-  const options: { value: string; label: string }[] = [];
-  for (let h = 0; h < 24; h++) {
-    for (const m of [0, 30]) {
-      const value = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
-      let label: string;
-      if (use24h) {
-        label = `${h}:${String(m).padStart(2, "0")}`;
-      } else {
-        const h12 = h % 12 || 12;
-        const ampm = h >= 12 ? "PM" : "AM";
-        label = m === 0 ? `${h12}:00 ${ampm}` : `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
-      }
-      options.push({ value, label });
-    }
-  }
-  return options;
 }
 
 // Extracted component to avoid IIFE in JSX (Turbopack compatibility)

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -290,93 +290,77 @@ export function AvailabilityCalendar({
     <div className="space-y-4">
       {/* Bulk actions */}
       {!readOnly && (
-      <div className="bg-secondary rounded-lg p-3">
-        <div className="space-y-2 lg:space-y-0 lg:flex lg:flex-wrap lg:items-center lg:gap-2 text-sm">
-          {/* Lead slot — e.g. "Apply my default availability" — sits alongside the bulk tools */}
-          {bulkActionsLead && (
-            <>
-              {bulkActionsLead}
-              <span className="hidden lg:inline text-muted-foreground/50">|</span>
-              <div className="border-t border-muted-foreground/25 lg:hidden" />
-            </>
-          )}
-          {/* Mark all section — stacked on mobile, inline on desktop */}
-          <div className="lg:contents">
-            <p className="text-xs text-muted-foreground mb-1 lg:hidden">Mark all</p>
-            <span className="text-muted-foreground hidden lg:inline">Mark all</span>
-            <div className="flex flex-wrap items-center gap-2 lg:contents">
-              <select
-                value={bulkDayFilter}
-                onChange={(e) => setBulkDayFilter(e.target.value)}
-                className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm"
-                aria-label="Day of week"
-              >
-                <option value="remaining">remaining days</option>
-                {playDays.map((day) => (
-                  <option key={day} value={day}>
-                    {DAY_LABELS.full[day]}s
-                  </option>
-                ))}
-              </select>
-              <span className="text-muted-foreground hidden sm:inline">as</span>
-              <select
-                value={bulkStatus}
-                onChange={(e) =>
-                  setBulkStatus(e.target.value as AvailabilityStatus)
-                }
-                className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm"
-                aria-label="Availability status"
-              >
-                <option value="available">available</option>
-                <option value="unavailable">unavailable</option>
-                <option value="maybe">maybe</option>
-              </select>
-              <Button size="sm" onClick={handleBulkSubmit} className="h-8">
-                Apply
-              </Button>
-            </div>
-          </div>
-          {otherGames && otherGames.length > 0 && onCopyFromGame && (
-            <>
-              <span className="hidden lg:inline text-muted-foreground/50">|</span>
-              <div className="border-t border-muted-foreground/25 lg:hidden" />
-              {/* Copy from section — stacked on mobile, inline on desktop */}
-              <div className="lg:contents">
-                <p className="text-xs text-muted-foreground mb-1 lg:hidden">Copy from</p>
-                <span className="text-muted-foreground hidden lg:inline">Copy from</span>
-                <div className="flex items-center gap-2 lg:contents">
-                  <select
-                    value={copySourceGameId}
-                    onChange={(e) => setCopySourceGameId(e.target.value)}
-                    className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm max-w-50"
-                    data-testid="copy-game-select"
-                  >
-                    <option value="">Select a game</option>
-                    {otherGames.map((g) => (
-                      <option key={g.id} value={g.id}>
-                        {g.name}
-                      </option>
-                    ))}
-                  </select>
-                  <Button
-                    size="sm"
-                    onClick={handleCopyFromGame}
-                    disabled={!copySourceGameId || isCopying}
-                    className="h-8"
-                    data-testid="copy-game-button"
-                  >
-                    {isCopying ? "Copying..." : "Copy"}
-                  </Button>
-                  {copyResultMessage && (
-                    <span className="text-xs text-muted-foreground" data-testid="copy-result-message">
-                      {copyResultMessage}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </>
-          )}
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start text-sm">
+        {/* Apply my default availability — its own panel */}
+        {bulkActionsLead && (
+          <div className="bg-secondary rounded-lg p-3">{bulkActionsLead}</div>
+        )}
+
+        {/* Mark all — its own panel */}
+        <div className="bg-secondary rounded-lg p-3 flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground">Mark all</span>
+          <select
+            value={bulkDayFilter}
+            onChange={(e) => setBulkDayFilter(e.target.value)}
+            className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm"
+            aria-label="Day of week"
+          >
+            <option value="remaining">remaining days</option>
+            {playDays.map((day) => (
+              <option key={day} value={day}>
+                {DAY_LABELS.full[day]}s
+              </option>
+            ))}
+          </select>
+          <span className="text-muted-foreground">as</span>
+          <select
+            value={bulkStatus}
+            onChange={(e) => setBulkStatus(e.target.value as AvailabilityStatus)}
+            className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm"
+            aria-label="Availability status"
+          >
+            <option value="available">available</option>
+            <option value="unavailable">unavailable</option>
+            <option value="maybe">maybe</option>
+          </select>
+          <Button size="sm" onClick={handleBulkSubmit} className="h-8">
+            Apply
+          </Button>
         </div>
+
+        {/* Copy from — its own panel */}
+        {otherGames && otherGames.length > 0 && onCopyFromGame && (
+          <div className="bg-secondary rounded-lg p-3 flex flex-wrap items-center gap-2">
+            <span className="text-muted-foreground">Copy from</span>
+            <select
+              value={copySourceGameId}
+              onChange={(e) => setCopySourceGameId(e.target.value)}
+              className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm max-w-50"
+              data-testid="copy-game-select"
+            >
+              <option value="">Select a game</option>
+              {otherGames.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+            <Button
+              size="sm"
+              onClick={handleCopyFromGame}
+              disabled={!copySourceGameId || isCopying}
+              className="h-8"
+              data-testid="copy-game-button"
+            >
+              {isCopying ? "Copying..." : "Copy"}
+            </Button>
+            {copyResultMessage && (
+              <span className="text-xs text-muted-foreground" data-testid="copy-result-message">
+                {copyResultMessage}
+              </span>
+            )}
+          </div>
+        )}
       </div>
       )}
 

--- a/src/components/games/availability/ApplyDefaultsButton.tsx
+++ b/src/components/games/availability/ApplyDefaultsButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui';
+import { useToast } from '@/components/ui/Toast';
+import type { ApplyDefaultsResult } from '@/hooks/useAvailability';
+
+interface ApplyDefaultsButtonProps {
+  onApplyDefaults: () => Promise<ApplyDefaultsResult>;
+}
+
+export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProps) {
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+
+  const handleClick = async () => {
+    setBusy(true);
+    try {
+      const { hadDefaults, filled } = await onApplyDefaults();
+      if (!hadDefaults) {
+        toast.show('Set up your default availability first.');
+        return;
+      }
+      if (filled === 0) {
+        toast.show('Your defaults are already applied — nothing to fill.');
+        return;
+      }
+      toast.show(`Filled in ${filled} ${filled === 1 ? 'date' : 'dates'}.`);
+    } catch {
+      toast.show('Could not apply your defaults. Please try again.', 'danger');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <Button size="sm" variant="secondary" onClick={handleClick} disabled={busy}>
+        {busy ? 'Applying…' : 'Apply my default availability'}
+      </Button>
+      <Link
+        href="/settings/default-availability"
+        className="text-xs text-muted-foreground hover:text-foreground"
+      >
+        Edit defaults
+      </Link>
+    </div>
+  );
+}

--- a/src/components/games/availability/ApplyDefaultsButton.tsx
+++ b/src/components/games/availability/ApplyDefaultsButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui';
 import { useToast } from '@/components/ui/Toast';
 import type { ApplyDefaultsResult } from '@/hooks/useAvailability';
@@ -12,7 +13,13 @@ interface ApplyDefaultsButtonProps {
 
 export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProps) {
   const toast = useToast();
+  const pathname = usePathname();
   const [busy, setBusy] = useState(false);
+  // Send the editor's back link here, so "← Back" returns to this game's
+  // Availability tab (this button only renders on that tab).
+  const editHref = `/settings/default-availability?returnTo=${encodeURIComponent(
+    `${pathname}?tab=availability`,
+  )}`;
 
   const handleClick = async () => {
     setBusy(true);
@@ -40,7 +47,7 @@ export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProp
         {busy ? 'Applying…' : 'Apply my default availability'}
       </Button>
       <Link
-        href="/settings/default-availability"
+        href={editHref}
         className="text-xs text-muted-foreground hover:text-foreground"
       >
         Edit defaults

--- a/src/components/games/availability/ApplyDefaultsButton.tsx
+++ b/src/components/games/availability/ApplyDefaultsButton.tsx
@@ -42,8 +42,8 @@ export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProp
   };
 
   return (
-    <div className="flex items-center gap-3">
-      <Button size="sm" variant="secondary" onClick={handleClick} disabled={busy}>
+    <div className="flex items-center gap-2">
+      <Button size="sm" className="h-8" onClick={handleClick} disabled={busy}>
         {busy ? 'Applying…' : 'Apply my default availability'}
       </Button>
       <Link

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -5,6 +5,8 @@ import type { GameSession, AvailabilityStatus } from '@/types';
 import type { AvailabilityEntry } from '@/components/calendar/AvailabilityCalendar';
 import { AvailabilityCalendar } from '@/components/calendar/AvailabilityCalendar';
 import { AvailabilityHeader } from './AvailabilityHeader';
+import { ApplyDefaultsButton } from './ApplyDefaultsButton';
+import type { ApplyDefaultsResult } from '@/hooks/useAvailability';
 
 export interface AvailabilityTabContentProps {
   // Header
@@ -31,6 +33,7 @@ export interface AvailabilityTabContentProps {
   use24h: boolean;
   otherGames: { id: string; name: string }[];
   onCopyFromGame: (sourceGameId: string) => Promise<number>;
+  onApplyDefaults: () => Promise<ApplyDefaultsResult>;
   playDateNotes: Map<string, string>;
   onUpdatePlayDateNote: (date: string, note: string | null) => void;
   hasCampaignDates: boolean;
@@ -47,7 +50,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
     windowStart, windowEnd, currentUserId, completionByUserId,
     playDays, availability, onToggle, confirmedSessions, extraPlayDates,
     isGmOrCoGm, onToggleExtraDate, weekStartDay, use24h, otherGames,
-    onCopyFromGame, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
+    onCopyFromGame, onApplyDefaults, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
     adHocOnly, readOnly = false,
   } = props;
 
@@ -64,6 +67,12 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         total={myProgress.total}
         readOnly={readOnly}
       />
+
+      {!readOnly && (
+        <div className="mt-3">
+          <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} />
+        </div>
+      )}
 
       {showEmptyAdHocPlayer && (
         <div className="rounded-lg border border-primary/30 bg-primary/10 p-3">

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -68,12 +68,6 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         readOnly={readOnly}
       />
 
-      {!readOnly && onApplyDefaults && (
-        <div className="mt-3">
-          <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} />
-        </div>
-      )}
-
       {showEmptyAdHocPlayer && (
         <div className="rounded-lg border border-primary/30 bg-primary/10 p-3">
           <p className="text-sm text-primary">
@@ -105,6 +99,9 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         use24h={use24h}
         otherGames={otherGames}
         onCopyFromGame={onCopyFromGame}
+        bulkActionsLead={
+          onApplyDefaults ? <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} /> : undefined
+        }
         playDateNotes={playDateNotes}
         onUpdatePlayDateNote={onUpdatePlayDateNote}
         hasCampaignDates={hasCampaignDates}

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -33,7 +33,7 @@ export interface AvailabilityTabContentProps {
   use24h: boolean;
   otherGames: { id: string; name: string }[];
   onCopyFromGame: (sourceGameId: string) => Promise<number>;
-  onApplyDefaults: () => Promise<ApplyDefaultsResult>;
+  onApplyDefaults?: () => Promise<ApplyDefaultsResult>;
   playDateNotes: Map<string, string>;
   onUpdatePlayDateNote: (date: string, note: string | null) => void;
   hasCampaignDates: boolean;
@@ -68,7 +68,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         readOnly={readOnly}
       />
 
-      {!readOnly && (
+      {!readOnly && onApplyDefaults && (
         <div className="mt-3">
           <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} />
         </div>

--- a/src/components/settings/DefaultAvailabilityEditor.tsx
+++ b/src/components/settings/DefaultAvailabilityEditor.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import { createClient } from '@/lib/supabase/client';
-import { useToast } from '@/components/ui/Toast';
+import { Button } from '@/components/ui';
 import { DAY_LABELS } from '@/lib/constants';
 import type { WeekdayDefault } from '@/lib/defaultAvailability';
 import { fetchUserDefaults, upsertUserDefault, deleteUserDefault } from '@/lib/data';
@@ -12,15 +12,29 @@ import { DefaultDayRow } from './DefaultDayRow';
 
 const supabase = createClient();
 
+const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
+
 type DefaultsMap = Record<number, WeekdayDefault | undefined>;
+
+function sameDefault(a: WeekdayDefault | undefined, b: WeekdayDefault | undefined): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return (
+    a.status === b.status &&
+    a.comment === b.comment &&
+    a.available_after === b.available_after &&
+    a.available_until === b.available_until
+  );
+}
 
 export function DefaultAvailabilityEditor() {
   const { profile } = useAuth();
   const { weekStartDay, use24h } = useUserPreferences();
-  const toast = useToast();
   const [defaults, setDefaults] = useState<DefaultsMap>({});
+  const [saved, setSaved] = useState<DefaultsMap>({});
   const [loading, setLoading] = useState(true);
-  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
 
   const userId = profile?.id;
 
@@ -40,6 +54,7 @@ export function DefaultAvailabilityEditor() {
         };
       });
       setDefaults(map);
+      setSaved(map);
       setLoading(false);
     })();
     return () => {
@@ -47,30 +62,44 @@ export function DefaultAvailabilityEditor() {
     };
   }, [userId]);
 
-  const handleChange = async (dayOfWeek: number, next: WeekdayDefault | undefined) => {
-    if (!userId) return;
-    const prev = defaults[dayOfWeek];
+  // Edits only update local state; changes are persisted on Save.
+  const handleChange = (dayOfWeek: number, next: WeekdayDefault | undefined) => {
     setDefaults((d) => ({ ...d, [dayOfWeek]: next }));
-    setSaveState('saving');
+    setMessage('');
+  };
 
-    const { error } = next
-      ? await upsertUserDefault(supabase, {
-          user_id: userId,
-          day_of_week: dayOfWeek,
-          status: next.status,
-          comment: next.comment,
-          available_after: next.available_after,
-          available_until: next.available_until,
-        })
-      : await deleteUserDefault(supabase, userId, dayOfWeek);
+  const handleSave = async () => {
+    if (!userId) return;
+    setSaving(true);
+    setMessage('');
 
-    if (error) {
-      setDefaults((d) => ({ ...d, [dayOfWeek]: prev })); // rollback
-      setSaveState('error');
-      toast.show('Could not save your default. Please try again.', 'danger');
-      return;
+    let failed = false;
+    for (const dow of WEEKDAYS) {
+      if (sameDefault(defaults[dow], saved[dow])) continue;
+      const next = defaults[dow];
+      const { error } = next
+        ? await upsertUserDefault(supabase, {
+            user_id: userId,
+            day_of_week: dow,
+            status: next.status,
+            comment: next.comment,
+            available_after: next.available_after,
+            available_until: next.available_until,
+          })
+        : await deleteUserDefault(supabase, userId, dow);
+      if (error) {
+        failed = true;
+        break;
+      }
     }
-    setSaveState('saved');
+
+    if (failed) {
+      setMessage('Error saving default availability. Please try again.');
+    } else {
+      setSaved(defaults);
+      setMessage('Default availability saved!');
+    }
+    setSaving(false);
   };
 
   // Order the week per the user's preference (Sunday- or Monday-first).
@@ -93,13 +122,16 @@ export function DefaultAvailabilityEditor() {
           />
         ))}
       </div>
-      <p className="mt-3 text-xs text-muted-foreground" aria-live="polite">
-        {saveState === 'saving'
-          ? 'Saving…'
-          : saveState === 'error'
-            ? 'Last change failed to save.'
-            : 'Changes are saved automatically.'}
-      </p>
+      <div className="mt-4 flex items-center gap-3">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Changes'}
+        </Button>
+        {message && (
+          <p className={`text-sm ${message.includes('Error') ? 'text-danger' : 'text-success'}`}>
+            {message}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/settings/DefaultAvailabilityEditor.tsx
+++ b/src/components/settings/DefaultAvailabilityEditor.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUserPreferences } from '@/hooks/useUserPreferences';
+import { createClient } from '@/lib/supabase/client';
+import { useToast } from '@/components/ui/Toast';
+import { DAY_LABELS } from '@/lib/constants';
+import type { WeekdayDefault } from '@/lib/defaultAvailability';
+import { fetchUserDefaults, upsertUserDefault, deleteUserDefault } from '@/lib/data';
+import { DefaultDayRow } from './DefaultDayRow';
+
+const supabase = createClient();
+
+type DefaultsMap = Record<number, WeekdayDefault | undefined>;
+
+export function DefaultAvailabilityEditor() {
+  const { profile } = useAuth();
+  const { weekStartDay, use24h } = useUserPreferences();
+  const toast = useToast();
+  const [defaults, setDefaults] = useState<DefaultsMap>({});
+  const [loading, setLoading] = useState(true);
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  const userId = profile?.id;
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await fetchUserDefaults(supabase, userId);
+      if (cancelled) return;
+      const map: DefaultsMap = {};
+      data?.forEach((d) => {
+        map[d.day_of_week] = {
+          status: d.status,
+          comment: d.comment,
+          available_after: d.available_after,
+          available_until: d.available_until,
+        };
+      });
+      setDefaults(map);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const handleChange = async (dayOfWeek: number, next: WeekdayDefault | undefined) => {
+    if (!userId) return;
+    const prev = defaults[dayOfWeek];
+    setDefaults((d) => ({ ...d, [dayOfWeek]: next }));
+    setSaveState('saving');
+
+    const { error } = next
+      ? await upsertUserDefault(supabase, {
+          user_id: userId,
+          day_of_week: dayOfWeek,
+          status: next.status,
+          comment: next.comment,
+          available_after: next.available_after,
+          available_until: next.available_until,
+        })
+      : await deleteUserDefault(supabase, userId, dayOfWeek);
+
+    if (error) {
+      setDefaults((d) => ({ ...d, [dayOfWeek]: prev })); // rollback
+      setSaveState('error');
+      toast.show('Could not save your default. Please try again.', 'danger');
+      return;
+    }
+    setSaveState('saved');
+  };
+
+  // Order the week per the user's preference (Sunday- or Monday-first).
+  const order = weekStartDay === 1 ? [1, 2, 3, 4, 5, 6, 0] : [0, 1, 2, 3, 4, 5, 6];
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  return (
+    <div>
+      <div className="rounded-xl border border-border bg-card px-4 sm:px-6">
+        {order.map((dow) => (
+          <DefaultDayRow
+            key={dow}
+            dayLabel={DAY_LABELS.full[dow]}
+            value={defaults[dow]}
+            use24h={use24h}
+            onChange={(next) => handleChange(dow, next)}
+          />
+        ))}
+      </div>
+      <p className="mt-3 text-xs text-muted-foreground" aria-live="polite">
+        {saveState === 'saving'
+          ? 'Saving…'
+          : saveState === 'error'
+            ? 'Last change failed to save.'
+            : 'Changes are saved automatically.'}
+      </p>
+    </div>
+  );
+}

--- a/src/components/settings/DefaultDayRow.tsx
+++ b/src/components/settings/DefaultDayRow.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { WeekdayDefault } from '@/lib/defaultAvailability';
+import { getTimeOptions } from '@/lib/timeOptions';
+import { TEXT_LIMITS } from '@/lib/constants';
+import { StatusSelector, type DefaultStatus } from './StatusSelector';
+
+interface DefaultDayRowProps {
+  dayLabel: string;
+  value: WeekdayDefault | undefined;
+  use24h: boolean;
+  onChange: (next: WeekdayDefault | undefined) => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  available: 'Available',
+  unavailable: 'Unavailable',
+  maybe: 'Maybe',
+};
+
+function summaryText(value: WeekdayDefault | undefined, use24h: boolean): string {
+  if (!value) return 'No default';
+  const opts = getTimeOptions(use24h);
+  const labelFor = (hms: string | null) =>
+    hms ? (opts.find((o) => o.value === hms.slice(0, 5))?.label ?? hms.slice(0, 5)) : null;
+  const parts = [STATUS_LABEL[value.status]];
+  const after = labelFor(value.available_after);
+  const until = labelFor(value.available_until);
+  if (after) parts.push(`after ${after}`);
+  if (until) parts.push(`until ${until}`);
+  return parts.join(' · ');
+}
+
+export function DefaultDayRow({ dayLabel, value, use24h, onChange }: DefaultDayRowProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Sync local note text with external prop changes using the derived-state pattern:
+  // track the last external value in a ref and reset local state inline during render
+  // (avoids setState-in-effect cascading renders).
+  const externalComment = value?.comment ?? '';
+  const prevExternalCommentRef = useRef(externalComment);
+  const [noteText, setNoteText] = useState(externalComment);
+
+  let displayedNote = noteText;
+  if (prevExternalCommentRef.current !== externalComment) {
+    prevExternalCommentRef.current = externalComment;
+    setNoteText(externalComment);
+    displayedNote = externalComment;
+  }
+
+  const status: DefaultStatus = value ? value.status : 'none';
+  const showTimes = status === 'available' || status === 'maybe';
+  const timeOptions = getTimeOptions(use24h);
+
+  const setStatus = (s: DefaultStatus) => {
+    if (s === 'none') {
+      onChange(undefined);
+      return;
+    }
+    onChange({
+      status: s,
+      comment: value?.comment ?? null,
+      available_after: value?.available_after ?? null,
+      available_until: value?.available_until ?? null,
+    });
+  };
+
+  const setTime = (field: 'available_after' | 'available_until', hhmm: string) => {
+    if (!value) return;
+    onChange({ ...value, [field]: hhmm ? `${hhmm}:00` : null });
+  };
+
+  const commitNote = () => {
+    if (!value) return; // notes only attach to a set status
+    const trimmed = displayedNote.trim();
+    const next = trimmed.length ? trimmed : null;
+    if (next !== (value.comment ?? null)) {
+      onChange({ ...value, comment: next });
+    }
+  };
+
+  // Shared controls used by both desktop and mobile-expanded layouts.
+  const controls = (
+    <>
+      <StatusSelector value={status} onChange={setStatus} dayLabel={dayLabel} />
+      {showTimes && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1 block text-xs text-muted-foreground">Available after</label>
+            <select
+              value={value?.available_after ? value.available_after.slice(0, 5) : ''}
+              onChange={(e) => setTime('available_after', e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-label={`${dayLabel} available after`}
+            >
+              <option value="">—</option>
+              {timeOptions.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs text-muted-foreground">Until</label>
+            <select
+              value={value?.available_until ? value.available_until.slice(0, 5) : ''}
+              onChange={(e) => setTime('available_until', e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-label={`${dayLabel} available until`}
+            >
+              <option value="">—</option>
+              {timeOptions.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+      {value && (
+        <input
+          type="text"
+          value={displayedNote}
+          onChange={(e) => setNoteText(e.target.value)}
+          onBlur={commitNote}
+          maxLength={TEXT_LIMITS.AVAILABILITY_COMMENT}
+          placeholder="Add a note (optional)"
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label={`${dayLabel} note`}
+        />
+      )}
+    </>
+  );
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      {/* Desktop: inline row */}
+      <div className="hidden items-start gap-4 py-3 sm:grid sm:grid-cols-[110px_1fr]">
+        <div className="pt-1 text-sm font-semibold text-foreground">{dayLabel}</div>
+        <div className="space-y-3">{controls}</div>
+      </div>
+
+      {/* Mobile: compact summary + tap to expand */}
+      <div className="sm:hidden">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex w-full items-center justify-between gap-3 py-3 text-left"
+          aria-expanded={expanded}
+        >
+          <span className="text-sm font-semibold text-foreground">{dayLabel}</span>
+          <span className="flex items-center gap-2 truncate text-xs text-muted-foreground">
+            <span className="truncate">{summaryText(value, use24h)}</span>
+            <span aria-hidden>{expanded ? '⌄' : '›'}</span>
+          </span>
+        </button>
+        {expanded && <div className="space-y-3 pb-4">{controls}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/DefaultDayRow.tsx
+++ b/src/components/settings/DefaultDayRow.tsx
@@ -87,14 +87,16 @@ export function DefaultDayRow({ dayLabel, value, use24h, onChange }: DefaultDayR
       {showTimes && (
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="mb-1 block text-xs text-muted-foreground">Available after</label>
+            <label className="mb-1 block text-xs text-muted-foreground">
+              Available after <span className="text-muted-foreground/70">(optional)</span>
+            </label>
             <select
               value={value?.available_after ? value.available_after.slice(0, 5) : ''}
               onChange={(e) => setTime('available_after', e.target.value)}
               className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               aria-label={`${dayLabel} available after`}
             >
-              <option value="">—</option>
+              <option value="">Any time</option>
               {timeOptions.map((t) => (
                 <option key={t.value} value={t.value}>
                   {t.label}
@@ -103,14 +105,16 @@ export function DefaultDayRow({ dayLabel, value, use24h, onChange }: DefaultDayR
             </select>
           </div>
           <div>
-            <label className="mb-1 block text-xs text-muted-foreground">Until</label>
+            <label className="mb-1 block text-xs text-muted-foreground">
+              Until <span className="text-muted-foreground/70">(optional)</span>
+            </label>
             <select
               value={value?.available_until ? value.available_until.slice(0, 5) : ''}
               onChange={(e) => setTime('available_until', e.target.value)}
               className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               aria-label={`${dayLabel} available until`}
             >
-              <option value="">—</option>
+              <option value="">Any time</option>
               {timeOptions.map((t) => (
                 <option key={t.value} value={t.value}>
                   {t.label}

--- a/src/components/settings/StatusSelector.tsx
+++ b/src/components/settings/StatusSelector.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import type { AvailabilityStatus } from '@/types';
+
+export type DefaultStatus = AvailabilityStatus | 'none';
+
+const OPTIONS: { value: DefaultStatus; label: string }[] = [
+  { value: 'available', label: 'Available' },
+  { value: 'unavailable', label: 'Unavailable' },
+  { value: 'maybe', label: 'Maybe' },
+  { value: 'none', label: 'No default' },
+];
+
+const SELECTED_STYLE: Record<AvailabilityStatus, CSSProperties> = {
+  available: { backgroundColor: 'var(--cal-available-bg)', color: 'var(--cal-available-text)' },
+  unavailable: { backgroundColor: 'var(--cal-unavailable-bg)', color: 'var(--cal-unavailable-text)' },
+  maybe: { backgroundColor: 'var(--cal-maybe-bg)', color: 'var(--cal-maybe-text)' },
+};
+
+interface StatusSelectorProps {
+  value: DefaultStatus;
+  onChange: (value: DefaultStatus) => void;
+  dayLabel: string;
+}
+
+export function StatusSelector({ value, onChange, dayLabel }: StatusSelectorProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`${dayLabel} default status`}
+      className="inline-flex flex-wrap gap-1 rounded-md border border-border bg-card p-0.5"
+    >
+      {OPTIONS.map((opt) => {
+        const selected = value === opt.value;
+        const colorStyle =
+          selected && opt.value !== 'none' ? SELECTED_STYLE[opt.value] : undefined;
+        const stateClass = selected
+          ? opt.value === 'none'
+            ? 'bg-muted text-foreground'
+            : ''
+          : 'text-muted-foreground hover:text-foreground';
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(opt.value)}
+            style={colorStyle}
+            className={`rounded-sm px-2.5 py-1 text-xs font-medium transition-colors ${stateClass}`}
+            data-testid={`status-${dayLabel.toLowerCase()}-${opt.value}`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -5,6 +5,8 @@ import {
   parseISO,
   isAfter,
   isBefore,
+  eachDayOfInterval,
+  format,
 } from 'date-fns';
 import { createClient } from '@/lib/supabase/client';
 import type {
@@ -18,11 +20,20 @@ import {
   fetchAllAvailability,
   upsertAvailability,
   batchUpsertAvailability,
+  fetchUserDefaults,
 } from '@/lib/data';
 import { filterAvailabilityForCopy } from '@/lib/copyAvailability';
+import { computeDefaultEntries, type WeekdayDefault } from '@/lib/defaultAvailability';
 import { getSchedulingWindow } from '@/lib/scheduling';
 
 const supabase = createClient();
+
+export interface ApplyDefaultsResult {
+  /** False when the user has not configured any default availability yet. */
+  hadDefaults: boolean;
+  /** Number of dates filled (0 when everything eligible was already set). */
+  filled: number;
+}
 
 export interface UseAvailabilityReturn {
   availability: Record<string, AvailabilityEntry>;
@@ -36,6 +47,7 @@ export interface UseAvailabilityReturn {
     availableUntil: string | null,
   ) => Promise<void>;
   copyFromGame: (sourceGameId: string, extraDateStrings: string[]) => Promise<number>;
+  applyDefaults: (extraDateStrings: string[]) => Promise<ApplyDefaultsResult>;
   removePlayerData: (playerId: string) => void;
   refresh: () => Promise<void>;
 }
@@ -234,6 +246,100 @@ export function useAvailability(
     [userId, gameId, game, availability],
   );
 
+  const applyDefaults = useCallback(
+    async (extraDateStrings: string[]): Promise<ApplyDefaultsResult> => {
+      if (!userId || !gameId || !game) return { hadDefaults: false, filled: 0 };
+
+      const { data: defaultRows } = await fetchUserDefaults(supabase, userId);
+      if (!defaultRows || defaultRows.length === 0) {
+        return { hadDefaults: false, filled: 0 };
+      }
+
+      const defaults: Record<number, WeekdayDefault> = {};
+      defaultRows.forEach((d) => {
+        defaults[d.day_of_week] = {
+          status: d.status,
+          comment: d.comment,
+          available_after: d.available_after,
+          available_until: d.available_until,
+        };
+      });
+
+      const today = startOfDay(new Date());
+      const { start, end } = getSchedulingWindow(game, today);
+      // getSchedulingWindow can return start > end (empty window); eachDayOfInterval would throw.
+      const dates = isAfter(start, end) ? [] : eachDayOfInterval({ start, end });
+
+      const entries = computeDefaultEntries({
+        defaults,
+        dates,
+        playDays: game.play_days,
+        extraPlayDates: extraDateStrings,
+        existingAvailability: availability,
+        today,
+        formatDate: (d) => format(d, 'yyyy-MM-dd'),
+        getDayOfWeek: getDay,
+        isBefore,
+      });
+
+      if (entries.length === 0) return { hadDefaults: true, filled: 0 };
+
+      // Optimistic local update.
+      setAvailability((prev) => {
+        const next = { ...prev };
+        for (const e of entries) {
+          next[e.date] = {
+            status: e.status,
+            comment: e.comment,
+            available_after: e.available_after,
+            available_until: e.available_until,
+          };
+        }
+        return next;
+      });
+
+      const rows = entries.map((e) => ({
+        user_id: userId,
+        game_id: gameId,
+        date: e.date,
+        status: e.status,
+        comment: e.comment,
+        available_after: e.available_after,
+        available_until: e.available_until,
+      }));
+
+      const { error } = await batchUpsertAvailability(supabase, rows);
+      if (error) {
+        setAvailability((prev) => {
+          const next = { ...prev };
+          for (const e of entries) delete next[e.date];
+          return next;
+        });
+        throw error;
+      }
+
+      const now = new Date().toISOString();
+      setAllAvailability((prev) => [
+        ...prev,
+        ...entries.map((e) => ({
+          id: 'temp',
+          user_id: userId,
+          game_id: gameId,
+          date: e.date,
+          status: e.status,
+          comment: e.comment,
+          available_after: e.available_after,
+          available_until: e.available_until,
+          created_at: now,
+          updated_at: now,
+        })),
+      ]);
+
+      return { hadDefaults: true, filled: entries.length };
+    },
+    [userId, gameId, game, availability],
+  );
+
   const removePlayerData = useCallback((playerId: string) => {
     setAllAvailability((prev) => prev.filter((a) => a.user_id !== playerId));
   }, []);
@@ -244,6 +350,7 @@ export function useAvailability(
     loading,
     changeAvailability,
     copyFromGame,
+    applyDefaults,
     removePlayerData,
     refresh,
   };

--- a/src/lib/data/defaultAvailability.ts
+++ b/src/lib/data/defaultAvailability.ts
@@ -1,0 +1,37 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { AvailabilityStatus } from '@/types';
+
+export async function fetchUserDefaults(supabase: SupabaseClient, userId: string) {
+  return supabase
+    .from('user_availability_defaults')
+    .select('*')
+    .eq('user_id', userId);
+}
+
+export async function upsertUserDefault(
+  supabase: SupabaseClient,
+  params: {
+    user_id: string;
+    day_of_week: number;
+    status: AvailabilityStatus;
+    comment: string | null;
+    available_after: string | null;
+    available_until: string | null;
+  }
+) {
+  return supabase
+    .from('user_availability_defaults')
+    .upsert(params, { onConflict: 'user_id,day_of_week' });
+}
+
+export async function deleteUserDefault(
+  supabase: SupabaseClient,
+  userId: string,
+  dayOfWeek: number
+) {
+  return supabase
+    .from('user_availability_defaults')
+    .delete()
+    .eq('user_id', userId)
+    .eq('day_of_week', dayOfWeek);
+}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -4,3 +4,4 @@ export * from './availability';
 export * from './sessions';
 export * from './playDates';
 export * from './users';
+export * from './defaultAvailability';

--- a/src/lib/defaultAvailability.test.ts
+++ b/src/lib/defaultAvailability.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { eachDayOfInterval, getDay, isBefore, format } from "date-fns";
+import { computeDefaultEntries, type WeekdayDefault } from "./defaultAvailability";
+
+const formatDate = (d: Date) => format(d, "yyyy-MM-dd");
+
+// Helpers to build the params with sane defaults for each test.
+function run(overrides: Partial<Parameters<typeof computeDefaultEntries>[0]>) {
+  // Jan 2025: 1st=Wed. Window covers Jan 1–31, 2025.
+  // Use local-time constructors (not ISO strings) to avoid UTC-midnight timezone shift.
+  const windowStart = new Date(2025, 0, 1);
+  const windowEnd = new Date(2025, 0, 31);
+  return computeDefaultEntries({
+    defaults: {},
+    dates: eachDayOfInterval({ start: windowStart, end: windowEnd }),
+    playDays: [3, 5], // Wed, Fri
+    extraPlayDates: [],
+    existingAvailability: {},
+    today: new Date(2025, 0, 1),
+    formatDate,
+    getDayOfWeek: getDay,
+    isBefore,
+    ...overrides,
+  });
+}
+
+const FRI_AVAIL: WeekdayDefault = {
+  status: "available",
+  comment: null,
+  available_after: "19:30:00",
+  available_until: null,
+};
+const WED_UNAVAIL: WeekdayDefault = {
+  status: "unavailable",
+  comment: null,
+  available_after: null,
+  available_until: null,
+};
+
+describe("computeDefaultEntries", () => {
+  it("returns nothing when the user has no defaults", () => {
+    expect(run({ defaults: {} })).toEqual([]);
+  });
+
+  it("fills blank play-day dates whose weekday has a default", () => {
+    const result = run({ defaults: { 5: FRI_AVAIL } });
+    // Fridays in Jan 2025: 3, 10, 17, 24, 31
+    expect(result.map((e) => e.date)).toEqual([
+      "2025-01-03",
+      "2025-01-10",
+      "2025-01-17",
+      "2025-01-24",
+      "2025-01-31",
+    ]);
+    expect(result[0]).toEqual({
+      date: "2025-01-03",
+      status: "available",
+      comment: null,
+      available_after: "19:30:00",
+      available_until: null,
+    });
+  });
+
+  it("skips play-day weekdays that have no default", () => {
+    // Only Wednesday has a default; Fridays (also a play day) must produce no entries.
+    const result = run({ defaults: { 3: WED_UNAVAIL } });
+    const fridaysInJan = ["2025-01-03", "2025-01-10", "2025-01-17", "2025-01-24", "2025-01-31"];
+    expect(result.map((e) => e.date).filter((d) => fridaysInJan.includes(d))).toEqual([]);
+  });
+
+  it("does not touch dates that already have availability (non-destructive)", () => {
+    const result = run({
+      defaults: { 5: FRI_AVAIL },
+      existingAvailability: {
+        "2025-01-10": {
+          status: "maybe",
+          comment: null,
+          available_after: null,
+          available_until: null,
+        },
+      },
+    });
+    expect(result.map((e) => e.date)).not.toContain("2025-01-10");
+  });
+
+  it("skips past dates", () => {
+    const result = run({ defaults: { 5: FRI_AVAIL }, today: new Date(2025, 0, 15) });
+    // Only Fridays on/after Jan 15 remain: 17, 24, 31
+    expect(result.map((e) => e.date)).toEqual(["2025-01-17", "2025-01-24", "2025-01-31"]);
+  });
+
+  it("skips non-play, non-extra weekdays", () => {
+    // Monday has a default but is not a play day and not an extra date -> ignored.
+    const MON_AVAIL = { ...FRI_AVAIL, available_after: null };
+    const result = run({ defaults: { 1: MON_AVAIL } });
+    expect(result).toEqual([]);
+  });
+
+  it("includes extra play dates matched by their weekday default", () => {
+    // 2025-01-04 is a Saturday (not a play day) but is an extra play date.
+    const SAT_AVAIL = { ...FRI_AVAIL, available_after: null };
+    const result = run({
+      defaults: { 6: SAT_AVAIL },
+      extraPlayDates: ["2025-01-04"],
+    });
+    expect(result.map((e) => e.date)).toEqual(["2025-01-04"]);
+  });
+
+  it("copies comment and times through for available/maybe; carries unavailable as-is", () => {
+    const result = run({ defaults: { 3: WED_UNAVAIL, 5: FRI_AVAIL } });
+    const wed = result.find((e) => e.date === "2025-01-01"); // Wed
+    const fri = result.find((e) => e.date === "2025-01-03"); // Fri
+    expect(wed?.status).toBe("unavailable");
+    expect(wed?.available_after).toBeNull();
+    expect(fri?.status).toBe("available");
+    expect(fri?.available_after).toBe("19:30:00");
+  });
+
+  it("works for ad-hoc games (no play days, only extra dates)", () => {
+    const result = run({
+      defaults: { 5: FRI_AVAIL },
+      playDays: [],
+      extraPlayDates: ["2025-01-10"], // a Friday
+    });
+    expect(result.map((e) => e.date)).toEqual(["2025-01-10"]);
+  });
+});

--- a/src/lib/defaultAvailability.ts
+++ b/src/lib/defaultAvailability.ts
@@ -1,0 +1,77 @@
+import type { AvailabilityStatus } from "@/types";
+import type { AvailabilityEntry } from "@/lib/availabilityStatus";
+
+/** A user's standing default for one weekday. Mirrors a per-date entry minus the date. */
+export interface WeekdayDefault {
+  status: AvailabilityStatus;
+  comment: string | null;
+  available_after: string | null; // HH:MM:SS
+  available_until: string | null; // HH:MM:SS
+}
+
+/** A single per-date availability row the apply action will write. */
+export interface DefaultEntryToWrite {
+  date: string; // YYYY-MM-DD
+  status: AvailabilityStatus;
+  comment: string | null;
+  available_after: string | null;
+  available_until: string | null;
+}
+
+interface ComputeDefaultEntriesParams {
+  /** User's weekday defaults keyed by day_of_week (0=Sun…6=Sat). Missing key = no default. */
+  defaults: Record<number, WeekdayDefault>;
+  /** Every calendar date in the scheduling window (e.g. eachDayOfInterval(start, end)). */
+  dates: Date[];
+  playDays: number[];
+  extraPlayDates: string[];
+  existingAvailability: Record<string, AvailabilityEntry>;
+  today: Date;
+  formatDate: (date: Date) => string;
+  getDayOfWeek: (date: Date) => number;
+  isBefore: (date: Date, dateToCompare: Date) => boolean;
+}
+
+/**
+ * Compute the per-date entries to write when applying a user's default availability
+ * to a game. Non-destructive: only blank, future, play/extra dates whose weekday has a
+ * configured default are returned.
+ */
+export function computeDefaultEntries({
+  defaults,
+  dates,
+  playDays,
+  extraPlayDates,
+  existingAvailability,
+  today,
+  formatDate,
+  getDayOfWeek,
+  isBefore,
+}: ComputeDefaultEntriesParams): DefaultEntryToWrite[] {
+  const entries: DefaultEntryToWrite[] = [];
+
+  for (const date of dates) {
+    const dayOfWeek = getDayOfWeek(date);
+    const dateStr = formatDate(date);
+
+    // Must be a play day or an extra play date.
+    if (!playDays.includes(dayOfWeek) && !extraPlayDates.includes(dateStr)) continue;
+    // Skip past dates; today is eligible.
+    if (isBefore(date, today)) continue;
+    // Non-destructive: leave already-set dates alone.
+    if (existingAvailability[dateStr]) continue;
+    // The weekday must have a configured default.
+    const def = defaults[dayOfWeek];
+    if (!def) continue;
+
+    entries.push({
+      date: dateStr,
+      status: def.status,
+      comment: def.comment,
+      available_after: def.available_after,
+      available_until: def.available_until,
+    });
+  }
+
+  return entries;
+}

--- a/src/lib/timeOptions.test.ts
+++ b/src/lib/timeOptions.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { getTimeOptions } from "./timeOptions";
+
+describe("getTimeOptions", () => {
+  it("returns 48 half-hour slots", () => {
+    expect(getTimeOptions(false)).toHaveLength(48);
+  });
+
+  it("uses 24-hour labels when use24h is true", () => {
+    const opts = getTimeOptions(true);
+    expect(opts[0]).toEqual({ value: "00:00", label: "0:00" });
+    expect(opts[39]).toEqual({ value: "19:30", label: "19:30" });
+  });
+
+  it("uses 12-hour AM/PM labels when use24h is false", () => {
+    const opts = getTimeOptions(false);
+    expect(opts[0]).toEqual({ value: "00:00", label: "12:00 AM" });
+    expect(opts[39]).toEqual({ value: "19:30", label: "7:30 PM" });
+  });
+});

--- a/src/lib/timeOptions.ts
+++ b/src/lib/timeOptions.ts
@@ -1,0 +1,19 @@
+/** Time-of-day options in 30-minute increments for availability selects. */
+export function getTimeOptions(use24h: boolean): { value: string; label: string }[] {
+  const options: { value: string; label: string }[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (const m of [0, 30]) {
+      const value = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+      let label: string;
+      if (use24h) {
+        label = `${h}:${String(m).padStart(2, "0")}`;
+      } else {
+        const h12 = h % 12 || 12;
+        const ampm = h >= 12 ? "PM" : "AM";
+        label = m === 0 ? `${h12}:00 ${ampm}` : `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
+      }
+      options.push({ value, label });
+    }
+  }
+  return options;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,18 @@ export interface Availability {
   updated_at: string;
 }
 
+export interface UserAvailabilityDefault {
+  id: string;
+  user_id: string;
+  day_of_week: number; // 0=Sun … 6=Sat
+  status: AvailabilityStatus;
+  comment: string | null;
+  available_after: string | null; // HH:MM:SS
+  available_until: string | null; // HH:MM:SS
+  created_at: string;
+  updated_at: string;
+}
+
 // Note: Sessions are always created as 'confirmed' and cancelled by deletion.
 // The 'suggested' and 'cancelled' values existed historically but were never used.
 export type SessionStatus = 'confirmed';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -79,6 +79,21 @@ CREATE TABLE availability (
   UNIQUE(user_id, game_id, date)
 );
 
+-- User-level default (recurring weekly) availability.
+-- One row per weekday the user has configured; no row = "no default" for that weekday.
+CREATE TABLE user_availability_defaults (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  day_of_week SMALLINT NOT NULL CHECK (day_of_week BETWEEN 0 AND 6), -- 0=Sun … 6=Sat
+  status availability_status NOT NULL,
+  comment TEXT CHECK (comment IS NULL OR char_length(comment) <= 500),
+  available_after TIME,
+  available_until TIME,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, day_of_week)
+);
+
 -- Sessions (Scheduled Game Nights) table
 -- Note: Sessions are always created as 'confirmed' and cancelled by deletion.
 -- The 'suggested' and 'cancelled' values existed historically but were never used.
@@ -391,6 +406,10 @@ CREATE TRIGGER update_availability_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+CREATE TRIGGER update_user_availability_defaults_updated_at
+  BEFORE UPDATE ON user_availability_defaults
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
 -- Create user profile when auth user signs up
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
@@ -479,6 +498,18 @@ CREATE POLICY "GMs can update memberships" ON game_memberships
   WITH CHECK (
     EXISTS (SELECT 1 FROM public.games WHERE id = game_id AND gm_id = (select auth.uid()))
   );
+
+-- User availability defaults policies
+ALTER TABLE user_availability_defaults ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own availability defaults" ON user_availability_defaults
+  FOR SELECT USING ((select auth.uid()) = user_id);
+CREATE POLICY "Users can insert own availability defaults" ON user_availability_defaults
+  FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
+CREATE POLICY "Users can update own availability defaults" ON user_availability_defaults
+  FOR UPDATE USING ((select auth.uid()) = user_id);
+CREATE POLICY "Users can delete own availability defaults" ON user_availability_defaults
+  FOR DELETE USING ((select auth.uid()) = user_id);
 
 -- Availability policies
 CREATE POLICY "Game participants can view availability" ON availability

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -507,7 +507,8 @@ CREATE POLICY "Users can view own availability defaults" ON user_availability_de
 CREATE POLICY "Users can insert own availability defaults" ON user_availability_defaults
   FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
 CREATE POLICY "Users can update own availability defaults" ON user_availability_defaults
-  FOR UPDATE USING ((select auth.uid()) = user_id);
+  FOR UPDATE USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
 CREATE POLICY "Users can delete own availability defaults" ON user_availability_defaults
   FOR DELETE USING ((select auth.uid()) = user_id);
 


### PR DESCRIPTION
## Summary

Adds **default availability** — a personal, reusable weekly availability pattern (issue #47).

- Users set their usual week at `/settings/default-availability`: per weekday, one of *available / unavailable / maybe / no-default*, each with optional **after/until times** and a **note**. Stored in a new user-level `user_availability_defaults` table.
- On any game's **Availability** tab, **"Apply my default availability"** pre-fills the calendar from that pattern in one click — **non-destructively** (only fills blank future play/special dates; never overwrites dates you've already set).
- The editor uses an explicit **Save** button (consistent with Settings), is responsive (desktop table / mobile tap-to-expand), and respects week-start + 12/24h preferences. Its back link returns you to wherever you came from (e.g. the game's Availability tab).
- The Availability tab's bulk tools are now three peer panels: **Apply defaults · Mark all · Copy from**.

Applying just writes ordinary per-date `availability` rows, so per-game tweaks still work afterward.

## Database migration required

A new table + RLS must be applied to production before deploy (run once; schema.sql is the in-repo source of truth, so this standalone migration is intentionally not committed):

```sql
BEGIN;

CREATE TABLE user_availability_defaults (
  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
  day_of_week SMALLINT NOT NULL CHECK (day_of_week BETWEEN 0 AND 6), -- 0=Sun … 6=Sat
  status availability_status NOT NULL,
  comment TEXT CHECK (comment IS NULL OR char_length(comment) <= 500),
  available_after TIME,
  available_until TIME,
  created_at TIMESTAMPTZ DEFAULT NOW(),
  updated_at TIMESTAMPTZ DEFAULT NOW(),
  UNIQUE(user_id, day_of_week)
);

CREATE TRIGGER update_user_availability_defaults_updated_at
  BEFORE UPDATE ON user_availability_defaults
  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

ALTER TABLE user_availability_defaults ENABLE ROW LEVEL SECURITY;

CREATE POLICY "Users can view own availability defaults" ON user_availability_defaults
  FOR SELECT USING ((select auth.uid()) = user_id);
CREATE POLICY "Users can insert own availability defaults" ON user_availability_defaults
  FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
CREATE POLICY "Users can update own availability defaults" ON user_availability_defaults
  FOR UPDATE USING ((select auth.uid()) = user_id)
  WITH CHECK ((select auth.uid()) = user_id);
CREATE POLICY "Users can delete own availability defaults" ON user_availability_defaults
  FOR DELETE USING ((select auth.uid()) = user_id);

COMMIT;
```

## Test plan

- **Unit:** `computeDefaultEntries` (non-destructive fill logic, 9 cases) and `getTimeOptions` (3 cases). `npm run test:run` → all green.
- **E2E:** `e2e/tests/settings/default-availability.spec.ts` — set defaults → apply → persistence; non-destructive (a pre-set date survives); back link returns to the Availability tab. Bulk-actions specs updated for the shared bar and still pass. Full suite green.

## Notes

- RLS: own-rows only for all of SELECT/INSERT/UPDATE/DELETE, with `WITH CHECK` on UPDATE.
- `origin/main` (incl. #119 onboarding nudge) merged in; no conflicts.
