### PR TITLE
Mobile layout: make calendar subscription discoverable, surface buried sidebars

### DIFF
--- a/e2e/tests/games/game-detail.spec.ts
+++ b/e2e/tests/games/game-detail.spec.ts
@@ -252,7 +252,12 @@ test.describe('Game Detail Page', () => {
 
     // Should see calendar subscription section in Game Details
     await expect(page.getByText(/calendar subscription/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /copy calendar url/i })).toBeVisible();
+
+    // Subscribe is a webcal:// link with a copy-URL fallback button.
+    const subscribe = page.locator('[data-testid="calendar-subscribe-link"]');
+    await expect(subscribe).toBeVisible();
+    await expect(subscribe).toHaveAttribute('href', /^webcal:\/\//);
+    await expect(page.locator('[data-testid="calendar-subscribe-copy"]')).toBeVisible();
   });
 });
 

--- a/e2e/tests/overview/mobile-discoverability.spec.ts
+++ b/e2e/tests/overview/mobile-discoverability.spec.ts
@@ -27,7 +27,7 @@ test.describe('Overview tab mobile discoverability', () => {
     });
 
     // Game details (with subscribe) is visible inline on mobile.
-    const details = page.locator('[data-testid="mobile-game-details"]');
+    const details = page.locator('[data-testid="game-details"]');
     await expect(details).toBeVisible();
 
     // Subscribe is a webcal:// link.

--- a/e2e/tests/overview/mobile-discoverability.spec.ts
+++ b/e2e/tests/overview/mobile-discoverability.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame } from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Overview tab mobile discoverability', () => {
+  test('game details + subscribe appear above the player list on mobile', async ({ page, request }) => {
+    await page.setViewportSize({ width: 380, height: 800 });
+
+    const gm = await createTestUser(request, {
+      email: `gm-overview-mobile-${Date.now()}@e2e.local`,
+      name: 'Overview Mobile GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Overview Mobile Campaign',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.locator('[data-testid="overview-tab-content"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Game details (with subscribe) is visible inline on mobile.
+    const details = page.locator('[data-testid="mobile-game-details"]');
+    await expect(details).toBeVisible();
+
+    // Subscribe is a webcal:// link.
+    const subscribe = details.locator('[data-testid="calendar-subscribe-link"]').first();
+    await expect(subscribe).toBeVisible();
+    await expect(subscribe).toHaveAttribute('href', /^webcal:\/\//);
+
+    // Details sits ABOVE the (potentially long) player list.
+    const detailsBox = await details.boundingBox();
+    const partyBox = await page.locator('[data-testid="players-list"]').boundingBox();
+    expect(detailsBox).not.toBeNull();
+    expect(partyBox).not.toBeNull();
+    expect(detailsBox!.y).toBeLessThan(partyBox!.y);
+  });
+});

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -206,10 +206,9 @@ test.describe('Schedule Tab Redesign', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────────
-  // Test 4: Mobile viewport collapses sidebar into <details> cards
+  // Test 4: Mobile viewport shows calendar + subscribe inline, above ranked list
   // ────────────────────────────────────────────────────────────────────────────
-  test('mobile viewport shows collapsible calendar and response-status cards', async ({ page, request }) => {
-    // Set mobile viewport BEFORE navigating
+  test('mobile viewport shows the calendar + subscribe inline, above the ranked list', async ({ page, request }) => {
     await page.setViewportSize({ width: 380, height: 800 });
 
     const gm = await createTestUser(request, {
@@ -224,16 +223,10 @@ test.describe('Schedule Tab Redesign', () => {
       play_days: [5, 6],
     });
 
-    // Seed one date so the schedule tab has content to render
     const playDates = getPlayDates([5, 6], 4);
     await setAvailability(gm.id, game.id, [{ date: playDates[0], is_available: true }]);
 
-    await loginTestUser(page, {
-      email: gm.email,
-      name: gm.name,
-      is_gm: true,
-    });
-
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
     await page.goto(`/games/${game.id}`);
 
     await expect(page.getByRole('button', { name: /schedule/i })).toBeVisible({
@@ -245,8 +238,23 @@ test.describe('Schedule Tab Redesign', () => {
       timeout: TEST_TIMEOUTS.LONG,
     });
 
-    // Mobile: sidebar elements are collapsed into <details> cards
-    await expect(page.locator('[data-testid="mobile-calendar-collapsible"]')).toBeVisible();
-    await expect(page.locator('[data-testid="mobile-response-collapsible"]')).toBeVisible();
+    // Calendar + response panels are visible inline — no tap-to-expand gate.
+    const panels = page.locator('[data-testid="mobile-sidebar-panels"]');
+    await expect(panels).toBeVisible();
+
+    // Subscribe is a discoverable webcal:// link, no expansion needed.
+    const subscribe = panels.locator('[data-testid="calendar-subscribe-link"]').first();
+    await expect(subscribe).toBeVisible();
+    await expect(subscribe).toHaveAttribute('href', /^webcal:\/\//);
+
+    // The panels sit ABOVE the long ranked list.
+    const panelsBox = await panels.boundingBox();
+    const rankedBox = await page.locator('[data-testid="ranked-list"]').first().boundingBox();
+    expect(panelsBox).not.toBeNull();
+    expect(rankedBox).not.toBeNull();
+    expect(panelsBox!.y).toBeLessThan(rankedBox!.y);
+
+    // The old collapsible is gone.
+    await expect(page.locator('[data-testid="mobile-calendar-collapsible"]')).toHaveCount(0);
   });
 });

--- a/src/components/games/CalendarSubscribeButton.test.tsx
+++ b/src/components/games/CalendarSubscribeButton.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider } from '@/components/ui';
+import { CalendarSubscribeButton } from './CalendarSubscribeButton';
+
+function renderWithToast(ui: ReactNode) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+describe('CalendarSubscribeButton', () => {
+  it('renders nothing while the webcal URL is not yet known', () => {
+    const { container } = renderWithToast(<CalendarSubscribeButton webcalUrl="" />);
+    expect(container.querySelector('[data-testid="calendar-subscribe"]')).toBeNull();
+  });
+
+  it('renders a labeled webcal:// subscribe link', () => {
+    renderWithToast(
+      <CalendarSubscribeButton webcalUrl="webcal://example.com/api/games/calendar/abc" />
+    );
+    const link = screen.getByTestId('calendar-subscribe-link');
+    expect(link).toHaveAttribute('href', 'webcal://example.com/api/games/calendar/abc');
+    expect(link).toHaveTextContent('Subscribe');
+  });
+
+  it('copies the URL to the clipboard via the fallback button', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    renderWithToast(<CalendarSubscribeButton webcalUrl="webcal://example.com/feed" />);
+    await userEvent.click(screen.getByTestId('calendar-subscribe-copy'));
+    expect(writeText).toHaveBeenCalledWith('webcal://example.com/feed');
+  });
+});

--- a/src/components/games/CalendarSubscribeButton.tsx
+++ b/src/components/games/CalendarSubscribeButton.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Link2, Copy } from 'lucide-react';
+import { useToast } from '@/components/ui';
+
+interface CalendarSubscribeButtonProps {
+  /** Absolute webcal://… subscription URL. Empty string until known client-side. */
+  webcalUrl: string;
+  className?: string;
+}
+
+export function CalendarSubscribeButton({ webcalUrl, className = '' }: CalendarSubscribeButtonProps) {
+  const toast = useToast();
+
+  if (!webcalUrl) return null;
+
+  const copyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(webcalUrl);
+      toast.show('Calendar URL copied to clipboard.');
+    } catch {
+      toast.show('Could not copy. Select the URL manually.', 'danger');
+    }
+  };
+
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`} data-testid="calendar-subscribe">
+      <a
+        href={webcalUrl}
+        data-testid="calendar-subscribe-link"
+        title="Subscribe in your calendar app — auto-syncs confirmed sessions to Google Calendar, Apple Calendar, or Outlook"
+        className="inline-flex items-center justify-center rounded-lg border border-border bg-secondary px-3 py-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+      >
+        <Link2 className="mr-1 size-3" />
+        Subscribe
+      </a>
+      <button
+        type="button"
+        onClick={copyUrl}
+        data-testid="calendar-subscribe-copy"
+        aria-label="Copy calendar subscription URL"
+        title="Copy the webcal:// URL to your clipboard"
+        className="inline-flex items-center justify-center rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <Copy className="size-3.5" />
+      </button>
+    </span>
+  );
+}

--- a/src/components/games/overview/GameDetailsPanel.tsx
+++ b/src/components/games/overview/GameDetailsPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Link2 } from 'lucide-react';
 import { parseISO } from 'date-fns';
-import { Button, EyebrowLabel, Panel, useToast } from '@/components/ui';
+import { EyebrowLabel, Panel } from '@/components/ui';
+import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 import { DAY_LABELS } from '@/lib/constants';
 import { formatTime } from '@/lib/formatting';
 import { formatTimezoneDisplay } from '@/lib/timezone';
@@ -22,7 +22,7 @@ interface GameDetailsPanelProps {
   defaultEndTime: string | null;
   timezone: string | null;
   minPlayersNeeded?: number;
-  inviteCode: string;
+  subscribeUrl: string;
   use24h?: boolean;
   adHocOnly?: boolean;
   campaignStartDate: string | null;
@@ -45,24 +45,12 @@ export function GameDetailsPanel({
   defaultEndTime,
   timezone,
   minPlayersNeeded = 0,
-  inviteCode,
+  subscribeUrl,
   use24h = false,
   adHocOnly = false,
   campaignStartDate,
   campaignEndDate,
 }: GameDetailsPanelProps) {
-  const toast = useToast();
-
-  const copyCalendarUrl = async () => {
-    const webcalUrl = `webcal://${window.location.host}/api/games/calendar/${inviteCode}`;
-    try {
-      await navigator.clipboard.writeText(webcalUrl);
-      toast.show('Calendar URL copied to clipboard.');
-    } catch {
-      toast.show('Could not copy. Select the URL manually.', 'danger');
-    }
-  };
-
   return (
     <Panel>
       <EyebrowLabel>Game details</EyebrowLabel>
@@ -106,12 +94,9 @@ export function GameDetailsPanel({
         <div>
           <EyebrowLabel variant="muted">Calendar subscription</EyebrowLabel>
           <p className="mb-2 mt-1 text-[11px] text-muted-foreground">
-            Add this URL to your calendar app to auto-sync confirmed sessions.
+            Subscribe to auto-sync confirmed sessions to your calendar app.
           </p>
-          <Button onClick={copyCalendarUrl} variant="secondary" size="sm">
-            <Link2 className="size-3 mr-1" />
-            Copy Calendar URL
-          </Button>
+          <CalendarSubscribeButton webcalUrl={subscribeUrl} />
         </div>
       </div>
     </Panel>

--- a/src/components/games/overview/OverviewTabContent.tsx
+++ b/src/components/games/overview/OverviewTabContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { format, parseISO } from 'date-fns';
+import { format, parseISO, startOfDay, isBefore } from 'date-fns';
 import type { User, MemberWithRole, GameSession } from '@/types';
 import { useToast } from '@/components/ui';
 import { generateICS, slugifyGameName, triggerICSDownload } from '@/lib/ics';
@@ -48,6 +48,14 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
   const monthRange = `${format(props.windowStart, 'MMM')} – ${format(props.windowEnd, 'MMM yyyy')}`;
   const scheduledCount = props.confirmedSessions.length;
   const toast = useToast();
+
+  // Mirrors UpcomingSessionsCard's own visibility rule (it returns null when no
+  // upcoming sessions). We need it here so the card's grid cell isn't reserved
+  // when the card renders nothing.
+  const overviewToday = startOfDay(new Date());
+  const hasUpcoming = props.confirmedSessions.some(
+    (s) => !isBefore(parseISO(s.date), overviewToday)
+  );
 
   const handleDownloadIcs = (session: GameSession) => {
     const ics = generateICS([
@@ -104,20 +112,40 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
         scheduledCount={scheduledCount}
       />
 
-      <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
-        <div className="space-y-5 min-w-0">
-          <UpcomingSessionsCard
-            sessions={props.confirmedSessions}
-            use24h={props.use24h}
-            onDownloadIcs={handleDownloadIcs}
-            onDownloadAllIcs={handleDownloadAllIcs}
-          />
-
-          {/* Mobile: game details + subscribe, visible above the long player list */}
-          <div className="lg:hidden" data-testid="mobile-game-details">
-            {detailsPanel}
+      {/*
+        Flat grid so the three panels can be ordered independently per breakpoint.
+        Mobile (single column): upcoming sessions → game details → players, so the
+        info-dense details panel sits above the long player list.
+        Desktop (2 columns): upcoming + players stack in column 1; game details is a
+        sticky panel in column 2. Rendered ONCE — duplicating it broke unscoped
+        getByText() assertions (two DOM matches) and read the content twice to AT.
+      */}
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:items-start">
+        {hasUpcoming && (
+          <div className="min-w-0 lg:col-start-1 lg:row-start-1">
+            <UpcomingSessionsCard
+              sessions={props.confirmedSessions}
+              use24h={props.use24h}
+              onDownloadIcs={handleDownloadIcs}
+              onDownloadAllIcs={handleDownloadAllIcs}
+            />
           </div>
+        )}
 
+        <div
+          data-testid="game-details"
+          className={`lg:col-start-2 lg:row-start-1 lg:sticky lg:top-20 ${
+            hasUpcoming ? 'lg:row-span-2' : ''
+          }`}
+        >
+          {detailsPanel}
+        </div>
+
+        <div
+          className={`min-w-0 lg:col-start-1 ${
+            hasUpcoming ? 'lg:row-start-2' : 'lg:row-start-1'
+          }`}
+        >
           <PartyPanel
             allPlayers={props.allPlayers}
             gmId={props.gmId}
@@ -130,10 +158,6 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
             onRemovePlayer={props.onRemovePlayer}
           />
         </div>
-
-        <aside className="hidden lg:block lg:sticky lg:top-20 lg:self-start">
-          {detailsPanel}
-        </aside>
       </div>
     </div>
   );

--- a/src/components/games/overview/OverviewTabContent.tsx
+++ b/src/components/games/overview/OverviewTabContent.tsx
@@ -109,7 +109,6 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
           <UpcomingSessionsCard
             sessions={props.confirmedSessions}
             use24h={props.use24h}
-            subscribeUrl={props.subscribeUrl}
             onDownloadIcs={handleDownloadIcs}
             onDownloadAllIcs={handleDownloadAllIcs}
           />

--- a/src/components/games/overview/OverviewTabContent.tsx
+++ b/src/components/games/overview/OverviewTabContent.tsx
@@ -80,14 +80,21 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
     triggerICSDownload(ics, `${slug}-sessions.ics`);
   };
 
-  const handleCopySubscribe = async () => {
-    try {
-      await navigator.clipboard.writeText(props.subscribeUrl);
-      toast.show('Subscribe URL copied to clipboard.');
-    } catch {
-      toast.show('Could not copy. Select the URL manually.', 'danger');
-    }
-  };
+  const detailsPanel = (
+    <GameDetailsPanel
+      playDays={props.playDays}
+      schedulingWindowMonths={props.schedulingWindowMonths}
+      defaultStartTime={props.defaultStartTime}
+      defaultEndTime={props.defaultEndTime}
+      timezone={props.timezone}
+      minPlayersNeeded={props.minPlayersNeeded}
+      subscribeUrl={props.subscribeUrl}
+      use24h={props.use24h}
+      adHocOnly={props.adHocOnly}
+      campaignStartDate={props.campaignStartDate}
+      campaignEndDate={props.campaignEndDate}
+    />
+  );
 
   return (
     <div className="space-y-5" data-testid="overview-tab-content">
@@ -105,8 +112,13 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
             subscribeUrl={props.subscribeUrl}
             onDownloadIcs={handleDownloadIcs}
             onDownloadAllIcs={handleDownloadAllIcs}
-            onCopySubscribe={handleCopySubscribe}
           />
+
+          {/* Mobile: game details + subscribe, visible above the long player list */}
+          <div className="lg:hidden" data-testid="mobile-game-details">
+            {detailsPanel}
+          </div>
+
           <PartyPanel
             allPlayers={props.allPlayers}
             gmId={props.gmId}
@@ -120,20 +132,8 @@ export function OverviewTabContent(props: OverviewTabContentProps) {
           />
         </div>
 
-        <aside className="lg:sticky lg:top-20 lg:self-start">
-          <GameDetailsPanel
-            playDays={props.playDays}
-            schedulingWindowMonths={props.schedulingWindowMonths}
-            defaultStartTime={props.defaultStartTime}
-            defaultEndTime={props.defaultEndTime}
-            timezone={props.timezone}
-            minPlayersNeeded={props.minPlayersNeeded}
-            inviteCode={props.inviteCode}
-            use24h={props.use24h}
-            adHocOnly={props.adHocOnly}
-            campaignStartDate={props.campaignStartDate}
-            campaignEndDate={props.campaignEndDate}
-          />
+        <aside className="hidden lg:block lg:sticky lg:top-20 lg:self-start">
+          {detailsPanel}
         </aside>
       </div>
     </div>

--- a/src/components/games/overview/UpcomingSessionsCard.tsx
+++ b/src/components/games/overview/UpcomingSessionsCard.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from 'react';
 import { format, parseISO, startOfDay, isBefore, differenceInCalendarDays } from 'date-fns';
-import { Calendar, Link2, MapPin, Star, StickyNote } from 'lucide-react';
+import { Calendar, MapPin, Star, StickyNote } from 'lucide-react';
 import { Button, EyebrowLabel } from '@/components/ui';
 import type { GameSession } from '@/types';
 import { formatTime } from '@/lib/formatting';
+import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 
 interface UpcomingSessionsCardProps {
   sessions: GameSession[];
@@ -13,7 +14,6 @@ interface UpcomingSessionsCardProps {
   subscribeUrl: string;
   onDownloadIcs: (session: GameSession) => void;
   onDownloadAllIcs: () => void;
-  onCopySubscribe: () => void;
 }
 
 function relativeLabel(daysFromNow: number): string {
@@ -60,7 +60,6 @@ export function UpcomingSessionsCard({
   subscribeUrl,
   onDownloadIcs,
   onDownloadAllIcs,
-  onCopySubscribe,
 }: UpcomingSessionsCardProps) {
   const today = startOfDay(new Date());
   const upcoming = sessions
@@ -89,18 +88,7 @@ export function UpcomingSessionsCard({
               <span className="hidden sm:inline">Add all to calendar</span>
             </Button>
           )}
-          {subscribeUrl && (
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={onCopySubscribe}
-              title="Copy a webcal:// URL that auto-syncs scheduled sessions to Google Calendar, Apple Calendar, or Outlook"
-              aria-label="Copy calendar subscription URL"
-            >
-              <Link2 className="size-3 sm:mr-1" />
-              <span className="hidden sm:inline">Subscribe</span>
-            </Button>
-          )}
+          <CalendarSubscribeButton webcalUrl={subscribeUrl} />
         </div>
       </div>
 

--- a/src/components/games/overview/UpcomingSessionsCard.tsx
+++ b/src/components/games/overview/UpcomingSessionsCard.tsx
@@ -2,16 +2,14 @@
 
 import { useState } from 'react';
 import { format, parseISO, startOfDay, isBefore, differenceInCalendarDays } from 'date-fns';
-import { Calendar, MapPin, Star, StickyNote } from 'lucide-react';
+import { CalendarArrowDown, MapPin, Star, StickyNote } from 'lucide-react';
 import { Button, EyebrowLabel } from '@/components/ui';
 import type { GameSession } from '@/types';
 import { formatTime } from '@/lib/formatting';
-import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 
 interface UpcomingSessionsCardProps {
   sessions: GameSession[];
   use24h: boolean;
-  subscribeUrl: string;
   onDownloadIcs: (session: GameSession) => void;
   onDownloadAllIcs: () => void;
 }
@@ -57,7 +55,6 @@ function ClampedNotes({ text }: { text: string }) {
 export function UpcomingSessionsCard({
   sessions,
   use24h,
-  subscribeUrl,
   onDownloadIcs,
   onDownloadAllIcs,
 }: UpcomingSessionsCardProps) {
@@ -81,14 +78,13 @@ export function UpcomingSessionsCard({
               size="sm"
               variant="ghost"
               onClick={onDownloadAllIcs}
-              title="Download a single calendar file containing all upcoming sessions"
-              aria-label="Add all to calendar"
+              title="Download a single calendar file (.ics) containing all upcoming sessions"
+              aria-label="Download all upcoming sessions as a calendar file"
             >
-              <Calendar className="size-3 sm:mr-1" />
-              <span className="hidden sm:inline">Add all to calendar</span>
+              <CalendarArrowDown className="size-3 mr-1" />
+              Download all
             </Button>
           )}
-          <CalendarSubscribeButton webcalUrl={subscribeUrl} />
         </div>
       </div>
 
@@ -151,7 +147,7 @@ export function UpcomingSessionsCard({
                 aria-label="Add to calendar"
                 className="shrink-0"
               >
-                <Calendar className="size-3 sm:mr-1" />
+                <CalendarArrowDown className="size-3 sm:mr-1" />
                 <span className="hidden sm:inline">Add to calendar</span>
               </Button>
             </li>

--- a/src/components/games/schedule/MiniCalendar.tsx
+++ b/src/components/games/schedule/MiniCalendar.tsx
@@ -18,7 +18,6 @@ interface MiniCalendarProps {
   weekStartDay: number;
   onCellActivate: (date: string) => void;
   subscribeLink?: React.ReactNode;
-  embedded?: boolean;
 }
 
 export function MiniCalendar({
@@ -31,7 +30,6 @@ export function MiniCalendar({
   weekStartDay,
   onCellActivate,
   subscribeLink,
-  embedded = false,
 }: MiniCalendarProps) {
   const months = useMemo(() => {
     const count = differenceInCalendarMonths(windowEnd, windowStart) + 1;
@@ -57,14 +55,10 @@ export function MiniCalendar({
 
   const body = (
     <>
-      {embedded ? (
-        subscribeLink && <div className="flex justify-end mb-3">{subscribeLink}</div>
-      ) : (
-        <div className="flex items-center justify-between mb-3">
-          <EyebrowLabel>Calendar</EyebrowLabel>
-          {subscribeLink}
-        </div>
-      )}
+      <div className="flex items-center justify-between mb-3">
+        <EyebrowLabel>Calendar</EyebrowLabel>
+        {subscribeLink}
+      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {months.map((m) => (
           <CalendarMonth
@@ -91,6 +85,5 @@ export function MiniCalendar({
     </>
   );
 
-  if (embedded) return body;
   return <Panel>{body}</Panel>;
 }

--- a/src/components/games/schedule/ResponseStatus.tsx
+++ b/src/components/games/schedule/ResponseStatus.tsx
@@ -6,7 +6,6 @@ import { Avatar, EyebrowLabel, Panel } from '@/components/ui';
 interface ResponseStatusProps {
   members: MemberWithRole[];
   completionByUserId: Map<string, { answered: number; total: number }>;
-  embedded?: boolean;
 }
 
 function fillClass(pct: number): string {
@@ -15,9 +14,9 @@ function fillClass(pct: number): string {
   return 'bg-danger';
 }
 
-export function ResponseStatus({ members, completionByUserId, embedded = false }: ResponseStatusProps) {
+export function ResponseStatus({ members, completionByUserId }: ResponseStatusProps) {
   const list = (
-    <ul className={embedded ? 'space-y-2' : 'mt-3 space-y-2'}>
+    <ul className="mt-3 space-y-2">
         {members.map((m) => {
           const c = completionByUserId.get(m.id) ?? { answered: 0, total: 0 };
           const pct = c.total > 0 ? Math.round((c.answered / c.total) * 100) : 0;
@@ -39,7 +38,6 @@ export function ResponseStatus({ members, completionByUserId, embedded = false }
     </ul>
   );
 
-  if (embedded) return list;
   return (
     <Panel>
       <EyebrowLabel>Response status</EyebrowLabel>

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -15,8 +15,7 @@ import { CalendarHoverPopover } from './CalendarHoverPopover';
 import { generateICS, slugifyGameName, triggerICSDownload, composeIcsDescription } from '@/lib/ics';
 import { splitUpcomingPast } from '@/lib/scheduleView';
 import { useToast } from '@/components/ui/Toast';
-import { Button, EyebrowLabel, Panel } from '@/components/ui';
-import { Link2 } from 'lucide-react';
+import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 
 export interface ScheduleTabContentProps {
   suggestions: DateSuggestion[];
@@ -166,15 +165,6 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
     triggerICSDownload(ics, `${slugifyGameName(gameName)}-sessions.ics`);
   };
 
-  const handleCopySubscribe = async () => {
-    try {
-      await navigator.clipboard.writeText(subscribeUrl);
-      toast.show('Subscribe URL copied to clipboard.');
-    } catch {
-      toast.show('Could not copy. Select the URL manually.', 'danger');
-    }
-  };
-
   const miniCalendarProps = {
     windowStart,
     windowEnd,
@@ -186,18 +176,12 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
     onCellActivate: handleCellActivate,
   };
 
-  const subscribeLink = subscribeUrl ? (
-    <Button
-      size="sm"
-      variant="ghost"
-      onClick={handleCopySubscribe}
-      data-testid="calendar-subscribe-copy"
-      title="Copy a webcal:// URL that auto-syncs scheduled sessions to Google Calendar, Apple Calendar, or Outlook"
-    >
-      <Link2 className="size-3 mr-1" />
-      Subscribe
-    </Button>
-  ) : null;
+  const subscribeLink = <CalendarSubscribeButton webcalUrl={subscribeUrl} />;
+
+  const calendarPanel = <MiniCalendar {...miniCalendarProps} subscribeLink={subscribeLink} />;
+  const responsePanel = (
+    <ResponseStatus members={members} completionByUserId={completionByUserId} />
+  );
 
   return (
     <HoverSyncProvider>
@@ -225,6 +209,12 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
               onEditDetails={(s) => setEditFor(s)}
             />
 
+            {/* Mobile: calendar + response status, visible above the long ranked list */}
+            <div className="space-y-5 lg:hidden" data-testid="mobile-sidebar-panels">
+              {calendarPanel}
+              {responsePanel}
+            </div>
+
             <RankedList
               suggestions={unscheduledSuggestions}
               isGm={isGm}
@@ -236,36 +226,12 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
               onLockIn={(d) => setScheduleFor(d)}
               autoExpandDate={autoExpandDate}
             />
-
-            {/* Mobile: collapsible cards below the list */}
-            <div className="space-y-3 lg:hidden">
-              <Panel as="details" className="group" data-testid="mobile-calendar-collapsible">
-                <summary className="cursor-pointer list-none flex items-center justify-between">
-                  <EyebrowLabel>Calendar</EyebrowLabel>
-                  <span className="font-mono text-[11px] text-muted-foreground group-open:hidden">tap to expand</span>
-                  <span className="font-mono text-[11px] text-muted-foreground hidden group-open:inline">tap to collapse</span>
-                </summary>
-                <div className="mt-3">
-                  <MiniCalendar {...miniCalendarProps} subscribeLink={subscribeLink} embedded />
-                </div>
-              </Panel>
-              <Panel as="details" className="group" data-testid="mobile-response-collapsible">
-                <summary className="cursor-pointer list-none flex items-center justify-between">
-                  <EyebrowLabel>Response status</EyebrowLabel>
-                  <span className="font-mono text-[11px] text-muted-foreground group-open:hidden">tap to expand</span>
-                  <span className="font-mono text-[11px] text-muted-foreground hidden group-open:inline">tap to collapse</span>
-                </summary>
-                <div className="mt-3">
-                  <ResponseStatus members={members} completionByUserId={completionByUserId} embedded />
-                </div>
-              </Panel>
-            </div>
           </div>
 
-          {/* Desktop sidebar */}
+          {/* Desktop sidebar (unchanged behavior) */}
           <aside className="hidden lg:block space-y-5 lg:sticky lg:top-20 lg:self-start">
-            <MiniCalendar {...miniCalendarProps} subscribeLink={subscribeLink} />
-            <ResponseStatus members={members} completionByUserId={completionByUserId} />
+            {calendarPanel}
+            {responsePanel}
           </aside>
         </div>
 


### PR DESCRIPTION
## Why

A user couldn't find how to subscribe to a game's calendar feed — on mobile every subscribe entry point was either buried at the bottom of the page, collapsed behind a "tap to expand", or stripped to an unlabeled icon. The root cause is a recurring pattern: content that sits in an always-visible sidebar on desktop gets demoted to the bottom (or behind a collapse) on mobile, below long lists that make anything after them effectively invisible.

This is a focused mobile layout pass. Desktop two-column sticky sidebars are unchanged.

## What changed

**Shared subscribe affordance**
- New `CalendarSubscribeButton` — a tappable `webcal://` link (taps open the calendar app's subscribe dialog on iOS/Android) with a copy-URL fallback, always labeled. Renders nothing until the URL is known client-side.
- All subscribe sites route through it, replacing three divergent treatments (a copy-only ghost button, an unlabeled mobile icon, and a "Copy Calendar URL" button that rebuilt its own URL).

**Schedule tab (mobile)**
- Dropped the `<details>` collapse. The mini-calendar (+ Subscribe) and response-status now render inline, **above** the long ranked-date list. Order: confirmed sessions → calendar + subscribe → response status → ranked list.

**Overview tab (mobile)**
- The game-details panel (which holds the subscribe affordance) now renders **above** the long player list instead of dead-last.
- Decluttered the upcoming-sessions card: removed the redundant Subscribe (it lives, labeled with an explainer, in the adjacent game-details panel), relabeled the bulk export as a visible **"Download all"**, and swapped the obtuse calendar glyph for `CalendarArrowDown` on the bulk + per-session download buttons.

## Tests
- Unit: `CalendarSubscribeButton` (empty-URL guard, webcal href, copy fallback).
- E2E (380px viewport): both tabs assert the subscribe control is visible without expanding anything, that it's a `webcal://` link, and that the calendar/details panels sit above the long lists (bounding-box ordering). The old collapsible test was converted.
- Full suite: 498 unit pass; lint + build clean.

## Follow-ups (deferred, non-blocking)
- Dead `embedded` prop now unused in `MiniCalendar` / `ResponseStatus` after removing the collapsibles — cleanup.
- Copy-button touch target (~26px) is under the 44px ideal.