### PR TITLE
Always show "My Games" nav link (fixes #120)

### DIFF
--- a/e2e/tests/dashboard/navbar-my-games.spec.ts
+++ b/e2e/tests/dashboard/navbar-my-games.spec.ts
@@ -70,7 +70,7 @@ test.describe('Navbar My Games link', () => {
     await expect(nav.getByRole('link', { name: 'My Games' })).toBeVisible();
   });
 
-  test('does not show "My Games" in navbar when user has no games', async ({ page, request }) => {
+  test('shows "My Games" in navbar even when user has no games, linking to the create/join page', async ({ page, request }) => {
     const user = await createTestUser(request, {
       email: `user-nogames-${Date.now()}@e2e.local`,
       name: 'No Games User',
@@ -83,14 +83,22 @@ test.describe('Navbar My Games link', () => {
       is_gm: true,
     });
 
-    await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: /your games/i })).toBeVisible({
+    // Start somewhere other than the dashboard.
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({
       timeout: TEST_TIMEOUTS.LONG,
     });
 
-    // "My Games" link should NOT be in the navbar
+    // "My Games" is always present for a logged-in user, regardless of game count.
     const nav = page.locator('nav');
-    await expect(nav.getByRole('link', { name: 'My Games' })).not.toBeVisible();
+    await expect(nav.getByRole('link', { name: 'My Games' })).toBeVisible();
+
+    // Clicking it lands on the helpful create-or-join welcome page.
+    await nav.getByRole('link', { name: 'My Games' }).click();
+    await expect(page.getByRole('heading', { name: 'Create a Game' })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.getByRole('heading', { name: 'Join a Game' })).toBeVisible();
   });
 
   test('"My Games" link navigates to dashboard', async ({ page, request }) => {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,8 +6,6 @@ import Image from 'next/image';
 import { BookOpen, Mail } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Avatar, Button } from '@/components/ui';
-import { createClient } from '@/lib/supabase/client';
-import { fetchUserGameCount } from '@/lib/data';
 
 const FEEDBACK_EMAIL = process.env.NEXT_PUBLIC_FEEDBACK_EMAIL;
 
@@ -60,7 +58,7 @@ function HelpDropdown() {
   );
 }
 
-function MobileMenu({ profile, signOut, hasGames }: { profile: { is_gm?: boolean; is_admin?: boolean; name?: string | null } | null; signOut: () => void; hasGames: boolean }) {
+function MobileMenu({ profile, signOut }: { profile: { is_gm?: boolean; is_admin?: boolean; name?: string | null } | null; signOut: () => void }) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -96,15 +94,13 @@ function MobileMenu({ profile, signOut, hasGames }: { profile: { is_gm?: boolean
       </button>
       {isOpen && (
         <div className="absolute right-0 mt-2 w-48 bg-card border border-border rounded-md shadow-lg z-50 py-1">
-          {hasGames && (
-            <Link
-              href="/"
-              className="block px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
-              onClick={() => setIsOpen(false)}
-            >
-              My Games
-            </Link>
-          )}
+          <Link
+            href="/"
+            className="block px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
+            onClick={() => setIsOpen(false)}
+          >
+            My Games
+          </Link>
           {profile.is_gm && (
             <Link
               href="/games/new"
@@ -147,29 +143,6 @@ function MobileMenu({ profile, signOut, hasGames }: { profile: { is_gm?: boolean
 
 export function Navbar() {
   const { profile, authStatus, signOut } = useAuth();
-  const [hasGames, setHasGames] = useState(false);
-
-  useEffect(() => {
-    if (!profile?.id) {
-      return () => {};
-    }
-
-    let cancelled = false;
-    const supabase = createClient();
-    Promise.all([
-      supabase.from('game_memberships').select('*', { count: 'exact', head: true }).eq('user_id', profile.id),
-      fetchUserGameCount(supabase, profile.id),
-    ]).then(([{ count: memberCount }, { count: gmCount }]) => {
-      if (!cancelled) {
-        setHasGames(((memberCount || 0) + (gmCount || 0)) > 0);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      setHasGames(false);
-    };
-  }, [profile?.id]);
 
   return (
     <nav className="bg-card border-b border-border">
@@ -180,16 +153,14 @@ export function Navbar() {
               <Image src="/logo.png" alt="Can We Play?" width={44} height={44} className="shrink-0" />
               <span className="hidden sm:block font-bold text-xl text-foreground">Can We Play?</span>
             </Link>
-            {(hasGames || profile?.is_gm || profile?.is_admin) && (
+            {profile && (
               <div className="hidden sm:ml-8 sm:flex sm:space-x-4">
-                {hasGames && (
-                  <Link
-                    href="/"
-                    className="text-muted-foreground hover:text-foreground px-3 py-2 text-sm font-medium transition-colors"
-                  >
-                    My Games
-                  </Link>
-                )}
+                <Link
+                  href="/"
+                  className="text-muted-foreground hover:text-foreground px-3 py-2 text-sm font-medium transition-colors"
+                >
+                  My Games
+                </Link>
                 {profile?.is_gm && (
                   <Link
                     href="/games/new"
@@ -233,7 +204,7 @@ export function Navbar() {
                     Sign out
                   </Button>
                 </div>
-                <MobileMenu profile={profile} signOut={signOut} hasGames={hasGames} />
+                <MobileMenu profile={profile} signOut={signOut} />
               </>
             ) : (
               <Link href="/login">


### PR DESCRIPTION
## Problem

Fixes #120 — after creating your first game, the **My Games** nav link doesn't appear until a full page reload.

The link was gated on a `hasGames` flag in `Navbar.tsx`, computed by a game-count query inside a `useEffect` keyed only on `profile.id`. Creating a game is a client-side navigation (`router.push`), so `profile.id` never changes, the count is never re-fetched, and the link stays hidden until the navbar re-mounts on a full reload.

## Fix

Rather than re-running the count on every navigation (extra DB queries, flicker, stale-state edge cases), just **always show the link** for logged-in users. Clicking it with no games lands on `/`, which already renders the create-or-join `WelcomeEmptyState` — a perfectly useful destination.

This deletes the `hasGames` state, its `useEffect`, and the two `COUNT` queries entirely:
- Bug fixed by removing the stale state that caused it
- **Zero** extra DB load (an improvement over the previous behavior)

## Tests

`e2e/tests/dashboard/navbar-my-games.spec.ts`:
- Replaced the now-invalid "does not show when no games" test with one asserting the link **is** shown for a user with no games and leads to the create/join welcome page
- Kept the existing GM-with-games, player-with-games, and navigates-to-dashboard tests

## Verification

- `npm run lint` ✅
- `npm run build` ✅
- Full e2e suite: **289 passed** ✅