### PR TITLE
Cross-game scheduling awareness: other-game badge + copy-conflict prompt

### DIFF
--- a/e2e/tests/availability/cross-game-scheduling.spec.ts
+++ b/e2e/tests/availability/cross-game-scheduling.spec.ts
@@ -1,0 +1,140 @@
+// e2e/tests/availability/cross-game-scheduling.spec.ts
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  createTestSession,
+  setAvailability,
+  getPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Cross-game scheduling awareness', () => {
+  test('shows a badge on a date scheduled in another game', async ({ page, request }) => {
+    const user = await createTestUser(request, {
+      email: `xgame-badge-${Date.now()}@e2e.local`,
+      name: 'XGame Badge',
+      is_gm: true,
+    });
+
+    const gameA = await createTestGame({
+      gm_id: user.id, name: 'Game A Badge', play_days: [5], scheduling_window_months: 2,
+    });
+    const gameB = await createTestGame({
+      gm_id: user.id, name: 'Game B Badge', play_days: [5], scheduling_window_months: 2,
+    });
+
+    const fridays = getPlayDates([5], 4);
+    // Confirm a session in Game B on the first upcoming Friday.
+    await createTestSession({
+      game_id: gameB.id, date: fridays[0], confirmed_by: user.id,
+      start_time: '19:00', end_time: '22:00',
+    });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto(`/games/${gameA.id}`);
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // The shared Friday in Game A carries the other-game badge.
+    const conflictCell = page.locator(`button[data-date="${fridays[0]}"]`);
+    await expect(conflictCell).toHaveAttribute('data-other-game', 'true', {
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+    await expect(conflictCell.locator('[data-testid="other-game-indicator"]')).toBeVisible();
+
+    // A non-scheduled Friday has no badge.
+    const cleanCell = page.locator(`button[data-date="${fridays[1]}"]`);
+    await expect(cleanCell).not.toHaveAttribute('data-other-game', 'true');
+  });
+
+  test('copy prompts on conflicts and applies the chosen status', async ({ page, request }) => {
+    const user = await createTestUser(request, {
+      email: `xgame-copy-${Date.now()}@e2e.local`,
+      name: 'XGame Copy',
+      is_gm: true,
+    });
+
+    const source = await createTestGame({
+      gm_id: user.id, name: 'Source XG', play_days: [5], scheduling_window_months: 2,
+    });
+    const dest = await createTestGame({
+      gm_id: user.id, name: 'Dest XG', play_days: [5], scheduling_window_months: 2,
+    });
+
+    const fridays = getPlayDates([5], 4);
+    // In the source: marked available on two Fridays...
+    await setAvailability(user.id, source.id, [
+      { date: fridays[0], status: 'available' as const },
+      { date: fridays[1], status: 'available' as const },
+    ]);
+    // ...and the source has a confirmed session on the first Friday (the conflict).
+    await createTestSession({
+      game_id: source.id, date: fridays[0], confirmed_by: user.id,
+      start_time: '19:00', end_time: '22:00',
+    });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto(`/games/${dest.id}`);
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    await page.locator('[data-testid="copy-game-select"]').selectOption({ label: 'Source XG' });
+    await page.locator('[data-testid="copy-game-button"]').click();
+
+    // The conflict modal appears; default is Unavailable. Confirm.
+    const modal = page.locator('[data-testid="copy-conflict-modal"]');
+    await expect(modal).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+    await page.locator('[data-testid="copy-conflict-confirm"]').click();
+
+    // The conflicting Friday is marked unavailable (override), not available.
+    const conflictCell = page.locator(`button[data-date="${fridays[0]}"]`);
+    await expect(conflictCell).toHaveAttribute('data-status', 'unavailable', {
+      timeout: TEST_TIMEOUTS.DEFAULT,
+    });
+    // The non-conflict Friday copies through as available.
+    const copiedCell = page.locator(`button[data-date="${fridays[1]}"]`);
+    await expect(copiedCell).toHaveAttribute('data-status', 'available');
+  });
+
+  test('copy without conflicts does not show the modal', async ({ page, request }) => {
+    const user = await createTestUser(request, {
+      email: `xgame-noconflict-${Date.now()}@e2e.local`,
+      name: 'XGame NoConflict',
+      is_gm: true,
+    });
+
+    const source = await createTestGame({
+      gm_id: user.id, name: 'Source NC', play_days: [5], scheduling_window_months: 2,
+    });
+    const dest = await createTestGame({
+      gm_id: user.id, name: 'Dest NC', play_days: [5], scheduling_window_months: 2,
+    });
+
+    const fridays = getPlayDates([5], 4);
+    await setAvailability(user.id, source.id, [
+      { date: fridays[0], status: 'available' as const },
+    ]);
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto(`/games/${dest.id}`);
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    await page.locator('[data-testid="copy-game-select"]').selectOption({ label: 'Source NC' });
+    await page.locator('[data-testid="copy-game-button"]').click();
+
+    // No modal — copy runs immediately.
+    await expect(page.locator('[data-testid="copy-conflict-modal"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="copy-result-message"]')).toContainText(
+      /copied \d+ date/i,
+      { timeout: TEST_TIMEOUTS.DEFAULT },
+    );
+  });
+});

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -245,6 +245,7 @@ export default function AdminGamePeekPage() {
             weekStartDay={weekStartDay}
             use24h={use24h}
             otherGames={[]}
+            otherGameSessionsByDate={new Map()}
             onCopyFromGame={async () => ({ copied: 0, overridden: 0 })}
             playDateNotes={playDateNotes}
             onUpdatePlayDateNote={() => {}}

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -245,7 +245,7 @@ export default function AdminGamePeekPage() {
             weekStartDay={weekStartDay}
             use24h={use24h}
             otherGames={[]}
-            onCopyFromGame={async () => 0}
+            onCopyFromGame={async () => ({ copied: 0, overridden: 0 })}
             playDateNotes={playDateNotes}
             onUpdatePlayDateNote={() => {}}
             hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useAvailability } from "@/hooks/useAvailability";
 import { useSessions } from "@/hooks/useSessions";
 import { usePlayDates } from "@/hooks/usePlayDates";
 import { useGameDerivedState } from "@/hooks/useGameDerivedState";
+import { useOtherGameSessions } from "@/hooks/useOtherGameSessions";
 
 type Tab = "overview" | "availability" | "schedule";
 
@@ -101,6 +102,8 @@ export default function GameDetailPage() {
     completionByUserId,
     suggestions,
   } = useGameDerivedState(game, allAvailability, gamePlayDates);
+
+  const { otherGameSessionsByDate } = useOtherGameSessions(otherGames, userId);
 
   const [subscribeUrl, setSubscribeUrl] = useState('');
   useEffect(() => {
@@ -325,6 +328,7 @@ export default function GameDetailPage() {
           weekStartDay={weekStartDay}
           use24h={use24h}
           otherGames={otherGames}
+          otherGameSessionsByDate={otherGameSessionsByDate}
           onCopyFromGame={copyFromGame}
           onApplyDefaults={() => applyDefaults(extraDateStrings)}
           playDateNotes={playDateNotes}

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -153,8 +153,10 @@ export default function GameDetailPage() {
   const toggleExtraDate = (date: string) =>
     toggleExtraDateRaw(date, extraDateStrings.includes(date));
 
-  const copyFromGame = (sourceGameId: string) =>
-    copyFromGameRaw(sourceGameId, extraDateStrings);
+  const copyFromGame = (
+    sourceGameId: string,
+    conflict: import('@/lib/copyAvailability').CopyConflict | null,
+  ) => copyFromGameRaw(sourceGameId, extraDateStrings, conflict);
 
   const confirmSession = (
     date: string,

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -644,6 +644,11 @@ function MonthCalendar({
           const avail = availability[dateStr];
           const otherSessions = otherGameSessionsByDate.get(dateStr);
           const showOtherGameBadge = isPlayDay && !isPast && !!otherSessions?.length;
+          // Ad-hoc games (no regular play days) keep the GM add/remove icon in the
+          // top-left, so the other-game badge sits top-right there to avoid overlap.
+          // (The extra-date triangle, the only top-right element, renders only when
+          // playDays.length > 0, so the corner is free for ad-hoc games.)
+          const otherGameBadgeAtTopRight = playDays.length === 0;
 
           // Can GM add this as a extra play date? Only non-play days that aren't past
           const canAddAsExtra =
@@ -842,8 +847,10 @@ function MonthCalendar({
               {/* Another game is scheduled this night (informational) */}
               {showOtherGameBadge && (
                 <span
-                  className={`absolute top-0.5 left-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none ${
-                    canRemoveExtra ? "group-hover:opacity-0" : ""
+                  className={`absolute top-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none ${
+                    otherGameBadgeAtTopRight
+                      ? "right-0.5"
+                      : `left-0.5 ${canRemoveExtra ? "group-hover:opacity-0" : ""}`
                   }`}
                   data-testid="other-game-indicator"
                   title={otherSessions!

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -644,11 +644,6 @@ function MonthCalendar({
           const avail = availability[dateStr];
           const otherSessions = otherGameSessionsByDate.get(dateStr);
           const showOtherGameBadge = isPlayDay && !isPast && !!otherSessions?.length;
-          // Ad-hoc games (no regular play days) keep the GM add/remove icon in the
-          // top-left, so the other-game badge sits top-right there to avoid overlap.
-          // (The extra-date triangle, the only top-right element, renders only when
-          // playDays.length > 0, so the corner is free for ad-hoc games.)
-          const otherGameBadgeAtTopRight = playDays.length === 0;
 
           // Can GM add this as a extra play date? Only non-play days that aren't past
           const canAddAsExtra =
@@ -844,14 +839,13 @@ function MonthCalendar({
                   </svg>
                 </span>
               )}
-              {/* Another game is scheduled this night (informational) */}
+              {/* Another game is scheduled this night (informational).
+                  Always top-right; the GM add/remove icons own the top-left, and
+                  the extra-date triangle (also top-right) is suppressed below when
+                  this badge shows, so nothing overlaps. */}
               {showOtherGameBadge && (
                 <span
-                  className={`absolute top-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none ${
-                    otherGameBadgeAtTopRight
-                      ? "right-0.5"
-                      : `left-0.5 ${canRemoveExtra ? "group-hover:opacity-0" : ""}`
-                  }`}
+                  className="absolute top-0.5 right-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none"
                   data-testid="other-game-indicator"
                   title={otherSessions!
                     .map((os) => `Scheduled: ${os.gameName}`)
@@ -861,8 +855,9 @@ function MonthCalendar({
                 </span>
               )}
               {format(date, "d")}
-              {/* Extra date indicator - corner triangle (hidden for ad-hoc games) */}
-              {isExtraPlayDate && !isPast && playDays.length > 0 && (
+              {/* Extra date indicator - corner triangle (hidden for ad-hoc games,
+                  and yielded to the other-game badge when both want the top-right) */}
+              {isExtraPlayDate && !isPast && playDays.length > 0 && !showOtherGameBadge && (
                 <span className="absolute top-0 right-0 size-0 border-t-10 border-t-primary border-l-10 border-l-transparent" />
               )}
               {/* GM: Add extra play date icon on non-play days */}

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -25,6 +25,7 @@ import {
 import { formatTimeShort } from "@/lib/formatting";
 import { getTimeOptions } from "@/lib/timeOptions";
 import type { OtherGameSessionInfo } from "@/lib/otherGameSessions";
+import { CopyFromGamePanel } from "@/components/games/availability/CopyFromGamePanel";
 
 export type { AvailabilityEntry };
 
@@ -94,11 +95,6 @@ export function AvailabilityCalendar({
   const [bulkStatus, setBulkStatus] = useState<AvailabilityStatus>("available");
   // Action menu for GM long-press on extra play dates
   const [actionMenuDate, setActionMenuDate] = useState<string | null>(null);
-  // Copy from game state
-  const [copySourceGameId, setCopySourceGameId] = useState<string>("");
-  const [isCopying, setIsCopying] = useState(false);
-  const [copyResultMessage, setCopyResultMessage] = useState<string | null>(null);
-
   // Out-of-range toast state (mobile feedback)
   const [outOfRangeToast, setOutOfRangeToast] = useState<string | null>(null);
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -270,28 +266,6 @@ export function AvailabilityCalendar({
     bulkSetDays(bulkDayFilter, bulkStatus);
   };
 
-  const handleCopyFromGame = async () => {
-    if (!copySourceGameId || !onCopyFromGame) return;
-    setIsCopying(true);
-    setCopyResultMessage(null);
-    try {
-      const { copied } = await onCopyFromGame(copySourceGameId, null);
-      const gameName =
-        otherGames?.find((g) => g.id === copySourceGameId)?.name ?? "game";
-      setCopyResultMessage(
-        copied > 0
-          ? `Copied ${copied} date${copied !== 1 ? "s" : ""} from ${gameName}`
-          : "No new dates to copy"
-      );
-      setTimeout(() => setCopyResultMessage(null), 3000);
-    } catch {
-      setCopyResultMessage("Failed to copy availability");
-      setTimeout(() => setCopyResultMessage(null), 3000);
-    } finally {
-      setIsCopying(false);
-    }
-  };
-
   return (
     <div className="space-y-4">
       {/* Bulk actions */}
@@ -336,36 +310,15 @@ export function AvailabilityCalendar({
 
         {/* Copy from — its own panel */}
         {otherGames && otherGames.length > 0 && onCopyFromGame && (
-          <div className="bg-secondary rounded-lg p-3 flex flex-wrap items-center gap-2">
-            <span className="text-muted-foreground">Copy from</span>
-            <select
-              value={copySourceGameId}
-              onChange={(e) => setCopySourceGameId(e.target.value)}
-              className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm max-w-50"
-              data-testid="copy-game-select"
-            >
-              <option value="">Select a game</option>
-              {otherGames.map((g) => (
-                <option key={g.id} value={g.id}>
-                  {g.name}
-                </option>
-              ))}
-            </select>
-            <Button
-              size="sm"
-              onClick={handleCopyFromGame}
-              disabled={!copySourceGameId || isCopying}
-              className="h-8"
-              data-testid="copy-game-button"
-            >
-              {isCopying ? "Copying..." : "Copy"}
-            </Button>
-            {copyResultMessage && (
-              <span className="text-xs text-muted-foreground" data-testid="copy-result-message">
-                {copyResultMessage}
-              </span>
-            )}
-          </div>
+          <CopyFromGamePanel
+            otherGames={otherGames}
+            otherGameSessionsByDate={otherGameSessionsByDate}
+            availability={availability}
+            playDays={playDays}
+            extraPlayDates={extraPlayDates}
+            windowEnd={windowEnd}
+            onCopyFromGame={onCopyFromGame}
+          />
         )}
       </div>
       )}

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -14,7 +14,7 @@ import {
   startOfDay,
   parseISO,
 } from "date-fns";
-import { Clock, FileText, MessageSquare, Pencil, Plus, X } from "lucide-react";
+import { CalendarDays, Clock, FileText, MessageSquare, Pencil, Plus, X } from "lucide-react";
 import { Button, EyebrowLabel } from "@/components/ui";
 import type { GameSession, AvailabilityStatus } from "@/types";
 import { DAY_LABELS, TEXT_LIMITS } from "@/lib/constants";
@@ -453,6 +453,12 @@ export function AvailabilityCalendar({
           </div>
           <span>Scheduled</span>
         </div>
+        <div className="flex items-center gap-1.5">
+          <div className="flex size-3.5 items-center justify-center rounded-sm bg-accent text-accent-foreground">
+            <CalendarDays className="size-2.5" />
+          </div>
+          <span>Scheduled in another game</span>
+        </div>
         {hasCampaignDates && (
           <div className="flex items-center gap-1.5">
             <div className="size-3.5 rounded-sm cal-out-of-range" />
@@ -683,6 +689,8 @@ function MonthCalendar({
           const isPast = isBefore(date, today);
           const isConfirmed = confirmedDates.has(dateStr);
           const avail = availability[dateStr];
+          const otherSessions = otherGameSessionsByDate.get(dateStr);
+          const showOtherGameBadge = isPlayDay && !isPast && !!otherSessions?.length;
 
           // Can GM add this as a extra play date? Only non-play days that aren't past
           const canAddAsExtra =
@@ -800,6 +808,15 @@ function MonthCalendar({
           if (hasComment) {
             tooltipParts.push(`Note: ${avail!.comment}`);
           }
+          if (otherSessions?.length) {
+            for (const os of otherSessions) {
+              const oStart = formatTimeShort(os.startTime, use24h);
+              const oEnd = formatTimeShort(os.endTime, use24h);
+              const when =
+                oStart && oEnd ? ` ${oStart}–${oEnd}` : oStart ? ` from ${oStart}` : "";
+              tooltipParts.push(`Scheduled: ${os.gameName}${when}`);
+            }
+          }
           const gmNote = playDateNotes?.get(dateStr);
           if (gmNote) {
             tooltipParts.push(`GM note: ${gmNote}`);
@@ -847,6 +864,7 @@ function MonthCalendar({
               data-status={dataStatus}
               data-availability={isConfirmed && !isPast ? (avail?.status ?? "unset") : undefined}
               data-extra={isExtraPlayDate ? "true" : undefined}
+              data-other-game={showOtherGameBadge ? "true" : undefined}
               title={cellTooltip}
             >
               {/* Scheduled game star decoration */}
@@ -866,6 +884,20 @@ function MonthCalendar({
                       d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
                     />
                   </svg>
+                </span>
+              )}
+              {/* Another game is scheduled this night (informational) */}
+              {showOtherGameBadge && (
+                <span
+                  className={`absolute top-0.5 left-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none ${
+                    canRemoveExtra ? "group-hover:opacity-0" : ""
+                  }`}
+                  data-testid="other-game-indicator"
+                  title={otherSessions!
+                    .map((os) => `Scheduled: ${os.gameName}`)
+                    .join("\n")}
+                >
+                  <CalendarDays className="size-2.5" />
                 </span>
               )}
               {format(date, "d")}

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/availabilityStatus";
 import { formatTimeShort } from "@/lib/formatting";
 import { getTimeOptions } from "@/lib/timeOptions";
+import type { OtherGameSessionInfo } from "@/lib/otherGameSessions";
 
 export type { AvailabilityEntry };
 
@@ -52,6 +53,7 @@ interface AvailabilityCalendarProps {
   ) => Promise<{ copied: number; overridden: number }>;
   playDateNotes?: Map<string, string>;
   onUpdatePlayDateNote?: (date: string, note: string | null) => void;
+  otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   hasCampaignDates?: boolean;
   /** Optional content rendered as the first section of the bulk-actions bar
    *  (e.g. "Apply my default availability"), so related fill shortcuts share one element. */
@@ -74,6 +76,7 @@ export function AvailabilityCalendar({
   use24h = false,
   otherGames,
   onCopyFromGame,
+  otherGameSessionsByDate = new Map(),
   playDateNotes = new Map(),
   onUpdatePlayDateNote,
   hasCampaignDates = false,
@@ -391,6 +394,7 @@ export function AvailabilityCalendar({
             windowStart={windowStart}
             windowEnd={windowEnd}
             onOutOfRangeTap={showOutOfRangeToast}
+            otherGameSessionsByDate={otherGameSessionsByDate}
             readOnly={readOnly}
           />
         ))}
@@ -561,6 +565,7 @@ interface MonthCalendarProps {
   windowStart: Date;
   windowEnd: Date;
   onOutOfRangeTap?: (message: string) => void;
+  otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   readOnly?: boolean;
 }
 
@@ -584,6 +589,7 @@ function MonthCalendar({
   windowStart,
   windowEnd,
   onOutOfRangeTap,
+  otherGameSessionsByDate = new Map(),
   readOnly = false,
 }: MonthCalendarProps) {
   const days = eachDayOfInterval({

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -46,7 +46,10 @@ interface AvailabilityCalendarProps {
   weekStartDay?: 0 | 1;
   use24h?: boolean;
   otherGames?: { id: string; name: string }[];
-  onCopyFromGame?: (sourceGameId: string) => Promise<number>;
+  onCopyFromGame?: (
+    sourceGameId: string,
+    conflict: import('@/lib/copyAvailability').CopyConflict | null,
+  ) => Promise<{ copied: number; overridden: number }>;
   playDateNotes?: Map<string, string>;
   onUpdatePlayDateNote?: (date: string, note: string | null) => void;
   hasCampaignDates?: boolean;
@@ -269,12 +272,12 @@ export function AvailabilityCalendar({
     setIsCopying(true);
     setCopyResultMessage(null);
     try {
-      const count = await onCopyFromGame(copySourceGameId);
+      const { copied } = await onCopyFromGame(copySourceGameId, null);
       const gameName =
         otherGames?.find((g) => g.id === copySourceGameId)?.name ?? "game";
       setCopyResultMessage(
-        count > 0
-          ? `Copied ${count} date${count !== 1 ? "s" : ""} from ${gameName}`
+        copied > 0
+          ? `Copied ${copied} date${copied !== 1 ? "s" : ""} from ${gameName}`
           : "No new dates to copy"
       );
       setTimeout(() => setCopyResultMessage(null), 3000);

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -7,6 +7,7 @@ import { AvailabilityCalendar } from '@/components/calendar/AvailabilityCalendar
 import { AvailabilityHeader } from './AvailabilityHeader';
 import { ApplyDefaultsButton } from './ApplyDefaultsButton';
 import type { ApplyDefaultsResult } from '@/hooks/useAvailability';
+import type { OtherGameSessionInfo } from '@/lib/otherGameSessions';
 
 export interface AvailabilityTabContentProps {
   // Header
@@ -32,6 +33,7 @@ export interface AvailabilityTabContentProps {
   weekStartDay: 0 | 1;
   use24h: boolean;
   otherGames: { id: string; name: string }[];
+  otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   onCopyFromGame: (
     sourceGameId: string,
     conflict: import('@/lib/copyAvailability').CopyConflict | null,
@@ -54,7 +56,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
     playDays, availability, onToggle, confirmedSessions, extraPlayDates,
     isGmOrCoGm, onToggleExtraDate, weekStartDay, use24h, otherGames,
     onCopyFromGame, onApplyDefaults, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
-    adHocOnly, readOnly = false,
+    adHocOnly, readOnly = false, otherGameSessionsByDate = new Map(),
   } = props;
 
   const monthRange = `${format(windowStart, 'MMM')} – ${format(windowEnd, 'MMM yyyy')}`;
@@ -101,6 +103,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         weekStartDay={weekStartDay}
         use24h={use24h}
         otherGames={otherGames}
+        otherGameSessionsByDate={otherGameSessionsByDate}
         onCopyFromGame={onCopyFromGame}
         bulkActionsLead={
           onApplyDefaults ? <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} /> : undefined

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -32,7 +32,10 @@ export interface AvailabilityTabContentProps {
   weekStartDay: 0 | 1;
   use24h: boolean;
   otherGames: { id: string; name: string }[];
-  onCopyFromGame: (sourceGameId: string) => Promise<number>;
+  onCopyFromGame: (
+    sourceGameId: string,
+    conflict: import('@/lib/copyAvailability').CopyConflict | null,
+  ) => Promise<{ copied: number; overridden: number }>;
   onApplyDefaults?: () => Promise<ApplyDefaultsResult>;
   playDateNotes: Map<string, string>;
   onUpdatePlayDateNote: (date: string, note: string | null) => void;

--- a/src/components/games/availability/CopyConflictModal.tsx
+++ b/src/components/games/availability/CopyConflictModal.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import { Modal, Button, EyebrowLabel } from '@/components/ui';
+import type { AvailabilityStatus } from '@/types';
+
+interface CopyConflictModalProps {
+  sourceGameName: string;
+  conflictDates: string[];
+  onConfirm: (status: AvailabilityStatus) => void;
+  onCancel: () => void;
+}
+
+const OPTIONS: { value: AvailabilityStatus; label: string; swatch: string }[] = [
+  { value: 'unavailable', label: 'Unavailable', swatch: 'bg-cal-unavailable-bg' },
+  { value: 'maybe', label: 'Maybe', swatch: 'bg-cal-maybe-bg' },
+  { value: 'available', label: 'Available', swatch: 'bg-cal-available-bg' },
+];
+
+export function CopyConflictModal({
+  sourceGameName,
+  conflictDates,
+  onConfirm,
+  onCancel,
+}: CopyConflictModalProps) {
+  const [status, setStatus] = useState<AvailabilityStatus>('unavailable');
+  const n = conflictDates.length;
+
+  return (
+    <Modal
+      open
+      onClose={onCancel}
+      eyebrow={<EyebrowLabel variant="muted">Copy from {sourceGameName}</EyebrowLabel>}
+      title={`${n} scheduled session${n !== 1 ? 's' : ''} in this range`}
+      data-testid="copy-conflict-modal"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={() => onConfirm(status)} data-testid="copy-conflict-confirm">
+            Copy
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3 text-sm">
+        <div className="rounded-lg border border-primary/30 bg-primary/10 p-3 text-primary">
+          <strong>{sourceGameName}</strong> has {n} scheduled session{n !== 1 ? 's' : ''} in
+          this date range — you&apos;re already scheduled to play those nights. How should they
+          show up in this game?
+        </div>
+
+        <div className="flex flex-wrap gap-1.5" data-testid="copy-conflict-dates">
+          {conflictDates.map((d) => (
+            <span
+              key={d}
+              className="rounded-md border border-border bg-secondary px-2 py-0.5 font-mono text-xs text-foreground"
+            >
+              {format(parseISO(d), 'EEE MMM d')}
+            </span>
+          ))}
+        </div>
+
+        <fieldset>
+          <legend className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Mark those nights as
+          </legend>
+          <div className="flex flex-col gap-2">
+            {OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setStatus(opt.value)}
+                data-testid={`copy-conflict-status-${opt.value}`}
+                aria-pressed={status === opt.value}
+                className={`flex items-center gap-2.5 rounded-lg border p-2.5 text-left transition-colors ${
+                  status === opt.value
+                    ? 'border-primary bg-primary/10'
+                    : 'border-border bg-card hover:bg-secondary'
+                }`}
+              >
+                <span
+                  className={`size-4 flex-none rounded-full border-2 ${
+                    status === opt.value ? 'border-primary bg-primary' : 'border-muted-foreground'
+                  }`}
+                />
+                <span className={`size-3.5 flex-none rounded-sm ${opt.swatch}`} />
+                <span className="font-medium text-foreground">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <p className="text-xs text-muted-foreground">
+          Your other availability from {sourceGameName} will still be copied to open dates.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/games/availability/CopyFromGamePanel.tsx
+++ b/src/components/games/availability/CopyFromGamePanel.tsx
@@ -90,7 +90,7 @@ export function CopyFromGamePanel({
       getDayOfWeek: getDay,
       isBefore,
       isAfter,
-      parseDate: (s) => parseISO(s),
+      parseDate: parseISO,
     });
 
     if (conflictDates.length > 0) {
@@ -111,7 +111,10 @@ export function CopyFromGamePanel({
       <span className="text-muted-foreground">Copy from</span>
       <select
         value={sourceGameId}
-        onChange={(e) => setSourceGameId(e.target.value)}
+        onChange={(e) => {
+          setSourceGameId(e.target.value);
+          setResultMessage(null);
+        }}
         className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm max-w-50"
         data-testid="copy-game-select"
       >

--- a/src/components/games/availability/CopyFromGamePanel.tsx
+++ b/src/components/games/availability/CopyFromGamePanel.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { getDay, isBefore, isAfter, parseISO, startOfDay } from 'date-fns';
+import { Button } from '@/components/ui';
+import type { AvailabilityEntry } from '@/lib/availabilityStatus';
+import type { AvailabilityStatus } from '@/types';
+import {
+  filterSessionConflictsForCopy,
+  type CopyConflict,
+} from '@/lib/copyAvailability';
+import type { OtherGameSessionInfo } from '@/lib/otherGameSessions';
+import { CopyConflictModal } from './CopyConflictModal';
+
+interface CopyFromGamePanelProps {
+  otherGames: { id: string; name: string }[];
+  otherGameSessionsByDate: Map<string, OtherGameSessionInfo[]>;
+  availability: Record<string, AvailabilityEntry>;
+  playDays: number[];
+  extraPlayDates: string[];
+  windowEnd: Date;
+  onCopyFromGame: (
+    sourceGameId: string,
+    conflict: CopyConflict | null,
+  ) => Promise<{ copied: number; overridden: number }>;
+}
+
+export function CopyFromGamePanel({
+  otherGames,
+  otherGameSessionsByDate,
+  availability,
+  playDays,
+  extraPlayDates,
+  windowEnd,
+  onCopyFromGame,
+}: CopyFromGamePanelProps) {
+  const [sourceGameId, setSourceGameId] = useState('');
+  const [isCopying, setIsCopying] = useState(false);
+  const [resultMessage, setResultMessage] = useState<string | null>(null);
+  const [pendingConflict, setPendingConflict] = useState<{
+    sourceGameName: string;
+    conflictDates: string[];
+  } | null>(null);
+
+  const sourceGameName = otherGames.find((g) => g.id === sourceGameId)?.name ?? 'game';
+
+  // The source game's confirmed-session dates currently held in memory.
+  const candidateDates = () => {
+    const dates: string[] = [];
+    for (const [date, infos] of otherGameSessionsByDate) {
+      if (infos.some((i) => i.gameId === sourceGameId)) dates.push(date);
+    }
+    return dates;
+  };
+
+  const runCopy = async (conflict: CopyConflict | null) => {
+    setIsCopying(true);
+    setResultMessage(null);
+    try {
+      const { copied, overridden } = await onCopyFromGame(sourceGameId, conflict);
+      if (copied === 0 && overridden === 0) {
+        setResultMessage('No new dates to copy');
+      } else {
+        const base = `Copied ${copied} date${copied !== 1 ? 's' : ''} from ${sourceGameName}`;
+        const status = conflict?.status;
+        setResultMessage(
+          overridden > 0 && status
+            ? `${base} · ${overridden} marked ${status}`
+            : base,
+        );
+      }
+      setTimeout(() => setResultMessage(null), 4000);
+    } catch {
+      setResultMessage('Failed to copy availability');
+      setTimeout(() => setResultMessage(null), 4000);
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  const handleCopyClick = () => {
+    if (!sourceGameId) return;
+    const conflictDates = filterSessionConflictsForCopy({
+      conflictCandidateDates: candidateDates(),
+      destinationAvailability: availability,
+      destinationPlayDays: playDays,
+      destinationExtraPlayDates: extraPlayDates,
+      today: startOfDay(new Date()),
+      windowEndDate: windowEnd,
+      getDayOfWeek: getDay,
+      isBefore,
+      isAfter,
+      parseDate: (s) => parseISO(s),
+    });
+
+    if (conflictDates.length > 0) {
+      setPendingConflict({ sourceGameName, conflictDates });
+    } else {
+      runCopy(null);
+    }
+  };
+
+  const handleConfirmConflict = (status: AvailabilityStatus) => {
+    const dates = pendingConflict?.conflictDates ?? [];
+    setPendingConflict(null);
+    runCopy({ dates, status });
+  };
+
+  return (
+    <div className="bg-secondary rounded-lg p-3 flex flex-wrap items-center gap-2">
+      <span className="text-muted-foreground">Copy from</span>
+      <select
+        value={sourceGameId}
+        onChange={(e) => setSourceGameId(e.target.value)}
+        className="h-8 px-2 rounded-md border border-border bg-card text-card-foreground text-sm max-w-50"
+        data-testid="copy-game-select"
+      >
+        <option value="">Select a game</option>
+        {otherGames.map((g) => (
+          <option key={g.id} value={g.id}>
+            {g.name}
+          </option>
+        ))}
+      </select>
+      <Button
+        size="sm"
+        onClick={handleCopyClick}
+        disabled={!sourceGameId || isCopying}
+        className="h-8"
+        data-testid="copy-game-button"
+      >
+        {isCopying ? 'Copying...' : 'Copy'}
+      </Button>
+      {resultMessage && (
+        <span className="text-xs text-muted-foreground" data-testid="copy-result-message">
+          {resultMessage}
+        </span>
+      )}
+
+      {pendingConflict && (
+        <CopyConflictModal
+          sourceGameName={pendingConflict.sourceGameName}
+          conflictDates={pendingConflict.conflictDates}
+          onConfirm={handleConfirmConflict}
+          onCancel={() => setPendingConflict(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -22,7 +22,7 @@ import {
   batchUpsertAvailability,
   fetchUserDefaults,
 } from '@/lib/data';
-import { filterAvailabilityForCopy } from '@/lib/copyAvailability';
+import { filterAvailabilityForCopy, applyCopyConflicts, type CopyConflict } from '@/lib/copyAvailability';
 import { computeDefaultEntries, type WeekdayDefault } from '@/lib/defaultAvailability';
 import { getSchedulingWindow } from '@/lib/scheduling';
 
@@ -46,7 +46,11 @@ export interface UseAvailabilityReturn {
     availableAfter: string | null,
     availableUntil: string | null,
   ) => Promise<void>;
-  copyFromGame: (sourceGameId: string, extraDateStrings: string[]) => Promise<number>;
+  copyFromGame: (
+    sourceGameId: string,
+    extraDateStrings: string[],
+    conflict: CopyConflict | null,
+  ) => Promise<{ copied: number; overridden: number }>;
   applyDefaults: (extraDateStrings: string[]) => Promise<ApplyDefaultsResult>;
   removePlayerData: (playerId: string) => void;
   refresh: () => Promise<void>;
@@ -163,14 +167,17 @@ export function useAvailability(
   );
 
   const copyFromGame = useCallback(
-    async (sourceGameId: string, extraDateStrings: string[]): Promise<number> => {
-      if (!userId || !gameId || !game) return 0;
+    async (
+      sourceGameId: string,
+      extraDateStrings: string[],
+      conflict: CopyConflict | null,
+    ): Promise<{ copied: number; overridden: number }> => {
+      if (!userId || !gameId || !game) return { copied: 0, overridden: 0 };
 
       const { data: sourceAvail } = await fetchUserAvailability(supabase, sourceGameId, userId);
-      if (!sourceAvail || sourceAvail.length === 0) return 0;
 
       const sourceMap: Record<string, AvailabilityEntry> = {};
-      sourceAvail.forEach((a) => {
+      (sourceAvail ?? []).forEach((a) => {
         sourceMap[a.date] = {
           status: a.status,
           comment: a.comment,
@@ -182,7 +189,7 @@ export function useAvailability(
       const today = startOfDay(new Date());
       const { end: windowEnd } = getSchedulingWindow(game, today);
 
-      const toCopy = filterAvailabilityForCopy({
+      const copied = filterAvailabilityForCopy({
         sourceAvailability: sourceMap,
         destinationAvailability: availability,
         destinationPlayDays: game.play_days,
@@ -195,15 +202,19 @@ export function useAvailability(
         parseDate: (s) => parseISO(s),
       });
 
-      if (toCopy.length === 0) return 0;
+      const finalEntries = conflict
+        ? applyCopyConflicts(copied, conflict.dates, conflict.status)
+        : copied;
+
+      if (finalEntries.length === 0) return { copied: 0, overridden: 0 };
 
       setAvailability((prev) => {
         const next = { ...prev };
-        for (const { date, entry } of toCopy) next[date] = entry;
+        for (const { date, entry } of finalEntries) next[date] = entry;
         return next;
       });
 
-      const rows = toCopy.map(({ date, entry }) => ({
+      const rows = finalEntries.map(({ date, entry }) => ({
         user_id: userId,
         game_id: gameId,
         date,
@@ -218,7 +229,7 @@ export function useAvailability(
       if (error) {
         setAvailability((prev) => {
           const next = { ...prev };
-          for (const { date } of toCopy) delete next[date];
+          for (const { date } of finalEntries) delete next[date];
           return next;
         });
         throw error;
@@ -227,7 +238,7 @@ export function useAvailability(
       const now = new Date().toISOString();
       setAllAvailability((prev) => [
         ...prev,
-        ...toCopy.map(({ date, entry }) => ({
+        ...finalEntries.map(({ date, entry }) => ({
           id: 'temp',
           user_id: userId,
           game_id: gameId,
@@ -241,7 +252,8 @@ export function useAvailability(
         })),
       ]);
 
-      return toCopy.length;
+      const overridden = conflict ? conflict.dates.length : 0;
+      return { copied: finalEntries.length - overridden, overridden };
     },
     [userId, gameId, game, availability],
   );

--- a/src/hooks/useOtherGameSessions.ts
+++ b/src/hooks/useOtherGameSessions.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { fetchUpcomingSessionsForGames } from '@/lib/data';
+import { getTodayLocalDate } from '@/lib/upcomingSessions';
+import {
+  buildOtherGameSessionMap,
+  type OtherGameSessionInfo,
+} from '@/lib/otherGameSessions';
+
+const supabase = createClient();
+
+export interface UseOtherGameSessionsReturn {
+  otherGameSessionsByDate: Map<string, OtherGameSessionInfo[]>;
+}
+
+/**
+ * Fetch confirmed sessions for the user's OTHER games (RLS lets any participant
+ * read a game's sessions) and index them by date, so the availability calendar
+ * can flag nights the player is already scheduled elsewhere.
+ *
+ * The serialized key of `otherGames` is the effect dependency, so the fetch only
+ * re-runs when the set of other games actually changes (not on every render).
+ */
+export function useOtherGameSessions(
+  otherGames: { id: string; name: string }[],
+  userId: string,
+): UseOtherGameSessionsReturn {
+  const [otherGameSessionsByDate, setOtherGameSessionsByDate] = useState<
+    Map<string, OtherGameSessionInfo[]>
+  >(new Map());
+
+  const gamesKey = otherGames.map((g) => `${g.id}:${g.name}`).join('|');
+
+  useEffect(() => {
+    if (!userId || otherGames.length === 0) {
+      setOtherGameSessionsByDate(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const ids = otherGames.map((g) => g.id);
+      const nameById = new Map(otherGames.map((g) => [g.id, g.name]));
+      const { data } = await fetchUpcomingSessionsForGames(
+        supabase,
+        ids,
+        getTodayLocalDate(),
+      );
+      if (cancelled) return;
+      setOtherGameSessionsByDate(
+        buildOtherGameSessionMap(data ?? [], nameById, getTodayLocalDate()),
+      );
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- gamesKey encodes otherGames; supabase is stable
+  }, [gamesKey, userId]);
+
+  return { otherGameSessionsByDate };
+}

--- a/src/lib/copyAvailability.test.ts
+++ b/src/lib/copyAvailability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterAvailabilityForCopy } from "./copyAvailability";
+import { filterAvailabilityForCopy, filterSessionConflictsForCopy } from "./copyAvailability";
 import { AvailabilityEntry } from "@/lib/availabilityStatus";
 
 // Helper functions matching date-fns behavior
@@ -229,5 +229,51 @@ describe("filterAvailabilityForCopy", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].date).toBe("2025-01-15");
+  });
+});
+
+describe("filterSessionConflictsForCopy", () => {
+  const today = new Date("2025-01-15T12:00:00"); // Wed
+  const windowEndDate = new Date("2025-03-31T12:00:00");
+  const base = { today, windowEndDate, getDayOfWeek, isBefore, isAfter, parseDate };
+
+  it("keeps only blank, in-window, future destination play-days/extra-dates", () => {
+    const result = filterSessionConflictsForCopy({
+      ...base,
+      conflictCandidateDates: [
+        "2025-01-17", // Fri, play day, blank → keep
+        "2025-01-24", // Fri, but already set in dest → drop
+        "2025-01-21", // Tue, not a play day/extra → drop
+        "2025-01-10", // past → drop
+        "2025-04-04", // beyond window → drop
+        "2025-01-20", // Mon, extra play date → keep
+      ],
+      destinationAvailability: { "2025-01-24": makeEntry("available") },
+      destinationPlayDays: [5],
+      destinationExtraPlayDates: ["2025-01-20"],
+    });
+    expect(result).toEqual(["2025-01-17", "2025-01-20"]);
+  });
+
+  it("dedupes and sorts", () => {
+    const result = filterSessionConflictsForCopy({
+      ...base,
+      conflictCandidateDates: ["2025-01-31", "2025-01-17", "2025-01-17"],
+      destinationAvailability: {},
+      destinationPlayDays: [5],
+      destinationExtraPlayDates: [],
+    });
+    expect(result).toEqual(["2025-01-17", "2025-01-31"]);
+  });
+
+  it("returns empty for no candidates", () => {
+    const result = filterSessionConflictsForCopy({
+      ...base,
+      conflictCandidateDates: [],
+      destinationAvailability: {},
+      destinationPlayDays: [5],
+      destinationExtraPlayDates: [],
+    });
+    expect(result).toEqual([]);
   });
 });

--- a/src/lib/copyAvailability.test.ts
+++ b/src/lib/copyAvailability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterAvailabilityForCopy, filterSessionConflictsForCopy } from "./copyAvailability";
+import { filterAvailabilityForCopy, filterSessionConflictsForCopy, applyCopyConflicts } from "./copyAvailability";
 import { AvailabilityEntry } from "@/lib/availabilityStatus";
 
 // Helper functions matching date-fns behavior
@@ -275,5 +275,32 @@ describe("filterSessionConflictsForCopy", () => {
       destinationExtraPlayDates: [],
     });
     expect(result).toEqual([]);
+  });
+});
+
+describe("applyCopyConflicts", () => {
+  it("overrides copied entries on conflict dates and adds missing conflict dates", () => {
+    const toCopy = [
+      { date: "2025-01-17", entry: makeEntry("available", "from B", "18:00", "22:00") },
+      { date: "2025-01-24", entry: makeEntry("maybe") },
+    ];
+    // 2025-01-17 is a conflict (override + strip note/time); 2025-01-31 is a
+    // conflict with no copied entry (added fresh); 2025-01-24 is untouched.
+    const result = applyCopyConflicts(toCopy, ["2025-01-17", "2025-01-31"], "unavailable");
+
+    expect(result).toEqual([
+      { date: "2025-01-17", entry: { status: "unavailable", comment: null, available_after: null, available_until: null } },
+      { date: "2025-01-24", entry: makeEntry("maybe") },
+      { date: "2025-01-31", entry: { status: "unavailable", comment: null, available_after: null, available_until: null } },
+    ]);
+  });
+
+  it("with no conflict dates returns the copied entries sorted", () => {
+    const toCopy = [
+      { date: "2025-01-24", entry: makeEntry("available") },
+      { date: "2025-01-17", entry: makeEntry("available") },
+    ];
+    const result = applyCopyConflicts(toCopy, [], "unavailable");
+    expect(result.map((r) => r.date)).toEqual(["2025-01-17", "2025-01-24"]);
   });
 });

--- a/src/lib/copyAvailability.ts
+++ b/src/lib/copyAvailability.ts
@@ -1,4 +1,5 @@
 import { AvailabilityEntry } from "@/lib/availabilityStatus";
+import type { AvailabilityStatus } from "@/types";
 
 interface FilterAvailabilityForCopyParams {
   sourceAvailability: Record<string, AvailabilityEntry>;
@@ -67,5 +68,69 @@ export function filterAvailabilityForCopy({
   // Sort by date for deterministic order
   result.sort((a, b) => a.date.localeCompare(b.date));
 
+  return result;
+}
+
+export interface CopyConflict {
+  dates: string[];
+  status: AvailabilityStatus;
+}
+
+interface FilterSessionConflictsParams {
+  /** Candidate dates (the source game's confirmed-session dates). */
+  conflictCandidateDates: string[];
+  destinationAvailability: Record<string, AvailabilityEntry>;
+  destinationPlayDays: number[];
+  destinationExtraPlayDates: string[];
+  today: Date;
+  windowEndDate: Date;
+  getDayOfWeek: (date: Date) => number;
+  isBefore: (date: Date, dateToCompare: Date) => boolean;
+  isAfter: (date: Date, dateToCompare: Date) => boolean;
+  parseDate: (dateStr: string) => Date;
+}
+
+/**
+ * From a set of candidate dates (a source game's confirmed sessions), keep those
+ * that are valid copy targets in the destination — i.e. the same rules
+ * `filterAvailabilityForCopy` applies: blank in destination, a destination
+ * play-day or extra play-date, not past, and within the scheduling window.
+ *
+ * @returns sorted, de-duplicated date strings
+ */
+export function filterSessionConflictsForCopy({
+  conflictCandidateDates,
+  destinationAvailability,
+  destinationPlayDays,
+  destinationExtraPlayDates,
+  today,
+  windowEndDate,
+  getDayOfWeek,
+  isBefore,
+  isAfter,
+  parseDate,
+}: FilterSessionConflictsParams): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const dateStr of conflictCandidateDates) {
+    if (seen.has(dateStr)) continue;
+    seen.add(dateStr);
+
+    if (destinationAvailability[dateStr]) continue; // never overwrite
+
+    const date = parseDate(dateStr);
+    if (isBefore(date, today)) continue;
+    if (isAfter(date, windowEndDate)) continue;
+
+    const dayOfWeek = getDayOfWeek(date);
+    const isPlayDay = destinationPlayDays.includes(dayOfWeek);
+    const isExtra = destinationExtraPlayDates.includes(dateStr);
+    if (!isPlayDay && !isExtra) continue;
+
+    result.push(dateStr);
+  }
+
+  result.sort((a, b) => a.localeCompare(b));
   return result;
 }

--- a/src/lib/copyAvailability.ts
+++ b/src/lib/copyAvailability.ts
@@ -134,3 +134,24 @@ export function filterSessionConflictsForCopy({
   result.sort((a, b) => a.localeCompare(b));
   return result;
 }
+
+/**
+ * Merge availability copy entries with session-conflict overrides.
+ *
+ * Conflict dates are written status-only (no comment/time) using `conflictStatus`,
+ * replacing any copied entry on the same date and adding entries for conflict
+ * dates that had no copied availability. Result is sorted by date.
+ */
+export function applyCopyConflicts(
+  toCopy: CopyEntry[],
+  conflictDates: string[],
+  conflictStatus: AvailabilityStatus,
+): CopyEntry[] {
+  const conflictSet = new Set(conflictDates);
+  const base = toCopy.filter((e) => !conflictSet.has(e.date));
+  const overrides: CopyEntry[] = conflictDates.map((date) => ({
+    date,
+    entry: { status: conflictStatus, comment: null, available_after: null, available_until: null },
+  }));
+  return [...base, ...overrides].sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/src/lib/otherGameSessions.test.ts
+++ b/src/lib/otherGameSessions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildOtherGameSessionMap } from "./otherGameSessions";
+import type { GameSession } from "@/types";
+
+const makeSession = (over: Partial<GameSession>): GameSession => ({
+  id: "s",
+  game_id: "g",
+  date: "2026-07-04",
+  start_time: "19:00:00",
+  end_time: "22:00:00",
+  status: "confirmed",
+  confirmed_by: "u1",
+  location: null,
+  notes: null,
+  created_at: "2026-06-01T00:00:00Z",
+  ...over,
+});
+
+const names = new Map([
+  ["gB", "Curse of Strahd"],
+  ["gC", "Dragon Heist"],
+]);
+
+describe("buildOtherGameSessionMap", () => {
+  it("keeps only confirmed sessions on/after fromDate, keyed by date", () => {
+    const sessions = [
+      makeSession({ id: "1", game_id: "gB", date: "2026-07-04" }),
+      makeSession({ id: "2", game_id: "gB", date: "2026-05-01" }), // past → drop
+      makeSession({ id: "3", game_id: "gC", date: "2026-08-01", status: "cancelled" as GameSession["status"] }), // not confirmed → drop
+    ];
+    const map = buildOtherGameSessionMap(sessions, names, "2026-06-26");
+    expect([...map.keys()]).toEqual(["2026-07-04"]);
+    expect(map.get("2026-07-04")).toEqual([
+      { gameId: "gB", gameName: "Curse of Strahd", startTime: "19:00:00", endTime: "22:00:00" },
+    ]);
+  });
+
+  it("groups multiple games on the same date, sorted by game name", () => {
+    const sessions = [
+      makeSession({ id: "1", game_id: "gC", date: "2026-07-04" }),
+      makeSession({ id: "2", game_id: "gB", date: "2026-07-04" }),
+    ];
+    const map = buildOtherGameSessionMap(sessions, names, "2026-06-26");
+    expect(map.get("2026-07-04")!.map((i) => i.gameName)).toEqual([
+      "Curse of Strahd",
+      "Dragon Heist",
+    ]);
+  });
+
+  it("falls back to 'Another game' when the name is unknown", () => {
+    const sessions = [makeSession({ id: "1", game_id: "gX", date: "2026-07-04" })];
+    const map = buildOtherGameSessionMap(sessions, names, "2026-06-26");
+    expect(map.get("2026-07-04")![0].gameName).toBe("Another game");
+  });
+
+  it("includes the fromDate itself (boundary is inclusive)", () => {
+    const sessions = [makeSession({ id: "1", game_id: "gB", date: "2026-06-26" })];
+    const map = buildOtherGameSessionMap(sessions, names, "2026-06-26");
+    expect(map.has("2026-06-26")).toBe(true);
+  });
+});

--- a/src/lib/otherGameSessions.ts
+++ b/src/lib/otherGameSessions.ts
@@ -1,0 +1,43 @@
+import type { GameSession } from "@/types";
+
+export interface OtherGameSessionInfo {
+  gameId: string;
+  gameName: string;
+  startTime: string | null;
+  endTime: string | null;
+}
+
+/**
+ * Group another-game confirmed sessions by date for overlay on a game's calendar.
+ *
+ * Dates are compared as plain `yyyy-MM-dd` strings (how sessions are stored), so
+ * no timezone conversion is needed. Only `confirmed` sessions on or after
+ * `fromDate` are kept. Each date's infos are sorted by game name for stable order.
+ */
+export function buildOtherGameSessionMap(
+  sessions: GameSession[],
+  gameNameById: Map<string, string>,
+  fromDate: string,
+): Map<string, OtherGameSessionInfo[]> {
+  const map = new Map<string, OtherGameSessionInfo[]>();
+
+  for (const s of sessions) {
+    if (s.status !== "confirmed") continue;
+    if (s.date < fromDate) continue;
+
+    const info: OtherGameSessionInfo = {
+      gameId: s.game_id,
+      gameName: gameNameById.get(s.game_id) ?? "Another game",
+      startTime: s.start_time,
+      endTime: s.end_time,
+    };
+    const existing = map.get(s.date);
+    if (existing) existing.push(info);
+    else map.set(s.date, [info]);
+  }
+
+  for (const infos of map.values()) {
+    infos.sort((a, b) => a.gameName.localeCompare(b.gameName));
+  }
+  return map;
+}


### PR DESCRIPTION
## Cross-game scheduling awareness

When a player belongs to multiple games, they previously had no visibility into nights they were already committed to in other games while entering availability. This adds that awareness in two places — both rooted in one idea: *"you're already scheduled with another game that night."*

### 1. "Scheduled in another game" badge
The availability calendar now shows a small accent-colored calendar badge (top-right of a day cell) when the player has a **confirmed session in another game** that night — only on this game's own play-days/extra-dates, future dates only. Hovering shows which game(s) and the time. A new legend entry explains it.

- Reuses the existing RLS-safe `fetchUpcomingSessionsForGames` (a participant can already read a game's sessions).
- New pure helper `buildOtherGameSessionMap` + `useOtherGameSessions` hook.
- The badge sits top-right consistently; on the rare cell that is both a GM extra date and an other-game night, the decorative extra-date triangle yields the corner to the badge so nothing overlaps.

### 2. Copy-from-game conflict prompt
When copying availability from a source game that has confirmed sessions landing on open dates in the destination game, a prompt now appears first (otherwise copy runs unchanged). It asks one global choice — **Unavailable (default) / Maybe / Available** — and applies it to those conflict nights, **overriding** the copied status (you were almost certainly marked *available* in the source — the wrong thing to import). All other availability still copies as before. Override is status-only (no note that would leak the other game's name to this game's GM).

- New pure helpers `filterSessionConflictsForCopy` + `applyCopyConflicts`.
- Copy UI extracted into a focused `CopyFromGamePanel` (+ `CopyConflictModal`), shrinking the oversized `AvailabilityCalendar.tsx`.

### Testing
- Unit tests for all new helpers (`otherGameSessions`, copy-conflict detection + merge). Full suite: 526 passing.
- New e2e (`e2e/tests/availability/cross-game-scheduling.spec.ts`): badge appears on a scheduled-elsewhere date and not on a clean one; copy prompts on conflict and the chosen status overrides the copied one while other dates still copy; no-conflict copy shows no modal. Existing copy-from-game e2e still green.
- Semantic theme classes throughout (no hardcoded colors); mobile + desktop checked.

### Notes
Built test-first, task-by-task, with per-task and whole-branch review.
