### PR TITLE
Surface cross-game session conflicts in the date popover + guide updates

### DIFF
--- a/e2e/tests/availability/cross-game-scheduling.spec.ts
+++ b/e2e/tests/availability/cross-game-scheduling.spec.ts
@@ -50,6 +50,45 @@ test.describe('Cross-game scheduling awareness', () => {
     await expect(cleanCell).not.toHaveAttribute('data-other-game', 'true');
   });
 
+  test('the date popover surfaces the other-game session (reachable on mobile)', async ({ page, request }) => {
+    const user = await createTestUser(request, {
+      email: `xgame-popover-${Date.now()}@e2e.local`,
+      name: 'XGame Popover',
+      is_gm: true,
+    });
+
+    const gameA = await createTestGame({
+      gm_id: user.id, name: 'Game A Popover', play_days: [5], scheduling_window_months: 2,
+    });
+    const gameB = await createTestGame({
+      gm_id: user.id, name: 'Game B Popover', play_days: [5], scheduling_window_months: 2,
+    });
+
+    const fridays = getPlayDates([5], 4);
+    await createTestSession({
+      game_id: gameB.id, date: fridays[0], confirmed_by: user.id,
+      start_time: '19:00', end_time: '22:00',
+    });
+
+    await loginTestUser(page, { email: user.email, name: user.name, is_gm: true });
+    await page.goto(`/games/${gameA.id}`);
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Open the date's detail popover — the same one a mobile long-press opens.
+    const conflictCell = page.locator(`button[data-date="${fridays[0]}"]`);
+    await conflictCell.hover();
+    await conflictCell.locator('[data-testid="edit-note-icon"]').click();
+
+    // It names the game you're already scheduled with that night, with the time.
+    const otherGame = page.locator('[data-testid="popover-other-game"]');
+    await expect(otherGame).toBeVisible({ timeout: TEST_TIMEOUTS.DEFAULT });
+    await expect(otherGame).toContainText('Game B Popover');
+    await expect(otherGame).toContainText('7pm–10pm');
+  });
+
   test('copy prompts on conflicts and applies the chosen status', async ({ page, request }) => {
     const user = await createTestUser(request, {
       email: `xgame-copy-${Date.now()}@e2e.local`,

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -183,6 +183,12 @@ export default function HelpPage() {
               <p>
                 Dates you haven&apos;t responded to yet show as <strong className="text-foreground">pending</strong>.
               </p>
+              <p>
+                If you&apos;re in more than one game, a badge marks any night where you already
+                have a confirmed session in another game. To see which game, hover the date on
+                desktop or long-press it on mobile; the game and time appear under <strong className="text-foreground">Scheduled
+                elsewhere</strong>.
+              </p>
             </HelpSection>
 
             <HelpSection title="Adding Notes & Time Constraints">
@@ -214,12 +220,36 @@ export default function HelpPage() {
               </p>
             </HelpSection>
 
+            <HelpSection title="Default Availability">
+              <p>
+                Set your usual weekly pattern once instead of filling in every game by hand. In <Link href="/settings/default-availability" className="text-primary hover:underline">Settings &rarr; Default
+                availability</Link>, pick a status for each day of the week &mdash; available,
+                unavailable, maybe, or No default.
+                Available and maybe days can carry the same time constraints and notes as any
+                other date.
+              </p>
+              <p>
+                On any game&apos;s Availability tab, click <strong className="text-foreground">Apply my
+                default availability</strong> to fill that game&apos;s calendar from your pattern.
+                It fills only the dates you haven&apos;t answered yet, leaving anything you&apos;ve
+                already marked untouched, and you can apply it again later (for example, after your
+                GM adds play dates). Use <strong className="text-foreground">Edit defaults</strong> beside
+                the button to change your pattern.
+              </p>
+            </HelpSection>
+
             <HelpSection title="Copy Availability">
               <p>
                 If you&apos;re in multiple games with overlapping dates, use <strong className="text-foreground">Copy
                 from</strong> in the bulk actions bar to pull your availability over from another game.
                 It only fills in dates you haven&apos;t responded to yet, so anything
                 you&apos;ve already set stays untouched.
+              </p>
+              <p>
+                If the game you&apos;re copying from has confirmed sessions on nights you
+                haven&apos;t answered here, you&apos;ll first be asked how to mark those nights
+                &mdash; unavailable, maybe, or available &mdash; so a booked night isn&apos;t copied
+                in as available.
               </p>
             </HelpSection>
 
@@ -245,6 +275,11 @@ export default function HelpPage() {
             <li><strong className="text-foreground">Time format</strong>: 12-hour or 24-hour</li>
             <li><strong className="text-foreground">Color theme</strong>: applies across all your games</li>
           </ul>
+          <p>
+            Settings is also where you set your <strong className="text-foreground">default
+            availability</strong> &mdash; the reusable weekly pattern covered under Default
+            Availability above.
+          </p>
         </HelpSection>
       </div>
     </div>

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -24,7 +24,10 @@ import {
 } from "@/lib/availabilityStatus";
 import { formatTimeShort } from "@/lib/formatting";
 import { getTimeOptions } from "@/lib/timeOptions";
-import type { OtherGameSessionInfo } from "@/lib/otherGameSessions";
+import {
+  formatSessionTimeWindow,
+  type OtherGameSessionInfo,
+} from "@/lib/otherGameSessions";
 import { CopyFromGamePanel } from "@/components/games/availability/CopyFromGamePanel";
 
 export type { AvailabilityEntry };
@@ -449,6 +452,7 @@ export function AvailabilityCalendar({
           onSave={handleSaveComment}
           onCancel={handleCancelComment}
           use24h={use24h}
+          otherGameSessions={otherGameSessionsByDate.get(commentingDate) ?? []}
           gmNote={playDateNotes.get(commentingDate!) ?? null}
           showGmNote={isGmOrCoGm || !!playDateNotes.get(commentingDate!)}
           isGmOrCoGm={isGmOrCoGm}
@@ -763,11 +767,8 @@ function MonthCalendar({
           }
           if (otherSessions?.length) {
             for (const os of otherSessions) {
-              const oStart = formatTimeShort(os.startTime, use24h);
-              const oEnd = formatTimeShort(os.endTime, use24h);
-              const when =
-                oStart && oEnd ? ` ${oStart}–${oEnd}` : oStart ? ` from ${oStart}` : "";
-              tooltipParts.push(`Scheduled: ${os.gameName}${when}`);
+              const when = formatSessionTimeWindow(os.startTime, os.endTime, use24h);
+              tooltipParts.push(`Scheduled: ${os.gameName}${when ? ` ${when}` : ""}`);
             }
           }
           const gmNote = playDateNotes?.get(dateStr);
@@ -986,6 +987,7 @@ interface NoteEditorPopoverProps {
   isGmOrCoGm?: boolean;
   gmNoteText?: string;
   onGmNoteChange?: (value: string) => void;
+  otherGameSessions?: OtherGameSessionInfo[];
 }
 
 function NoteEditorPopover({
@@ -1006,6 +1008,7 @@ function NoteEditorPopover({
   isGmOrCoGm,
   gmNoteText,
   onGmNoteChange,
+  otherGameSessions,
 }: NoteEditorPopoverProps) {
   const timeOptions = getTimeOptions(use24h);
   return (
@@ -1028,6 +1031,28 @@ function NoteEditorPopover({
             &times;
           </button>
         </div>
+
+        {/* Scheduled elsewhere — confirmed sessions you have in other games that
+            night. Matches the calendar's accent badge so the two read as one idea. */}
+        {otherGameSessions && otherGameSessions.length > 0 && (
+          <div className="mb-3">
+            <EyebrowLabel variant="muted" className="block mb-2">Scheduled elsewhere</EyebrowLabel>
+            <div className="rounded-md border border-accent/30 bg-accent/10 p-3 space-y-1.5">
+              {otherGameSessions.map((os) => {
+                const when = formatSessionTimeWindow(os.startTime, os.endTime, use24h);
+                return (
+                  <div key={os.gameId} className="flex items-start gap-2 text-sm" data-testid="popover-other-game">
+                    <CalendarDays className="size-3.5 mt-0.5 shrink-0 text-accent-foreground" />
+                    <span className="text-foreground">
+                      <span className="font-medium">{os.gameName}</span>
+                      {when && <span className="text-muted-foreground"> · {when}</span>}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {/* GM Note section */}
         {showGmNote && (

--- a/src/lib/otherGameSessions.test.ts
+++ b/src/lib/otherGameSessions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { buildOtherGameSessionMap } from "./otherGameSessions";
+import {
+  buildOtherGameSessionMap,
+  formatSessionTimeWindow,
+} from "./otherGameSessions";
 import type { GameSession } from "@/types";
 
 const makeSession = (over: Partial<GameSession>): GameSession => ({
@@ -57,5 +60,27 @@ describe("buildOtherGameSessionMap", () => {
     const sessions = [makeSession({ id: "1", game_id: "gB", date: "2026-06-26" })];
     const map = buildOtherGameSessionMap(sessions, names, "2026-06-26");
     expect(map.has("2026-06-26")).toBe(true);
+  });
+});
+
+describe("formatSessionTimeWindow", () => {
+  it("joins start and end with an en dash", () => {
+    expect(formatSessionTimeWindow("19:00", "22:00", false)).toBe("7pm–10pm");
+  });
+
+  it("prefixes a start-only window with 'from'", () => {
+    expect(formatSessionTimeWindow("19:00", null, false)).toBe("from 7pm");
+  });
+
+  it("prefixes an end-only window with 'until'", () => {
+    expect(formatSessionTimeWindow(null, "22:00", false)).toBe("until 10pm");
+  });
+
+  it("returns an empty string when neither time is set", () => {
+    expect(formatSessionTimeWindow(null, null, false)).toBe("");
+  });
+
+  it("respects the 24-hour preference", () => {
+    expect(formatSessionTimeWindow("19:00", "22:00", true)).toBe("19:00–22:00");
   });
 });

--- a/src/lib/otherGameSessions.ts
+++ b/src/lib/otherGameSessions.ts
@@ -1,4 +1,5 @@
 import type { GameSession } from "@/types";
+import { formatTimeShort } from "./formatting";
 
 export interface OtherGameSessionInfo {
   gameId: string;
@@ -40,4 +41,21 @@ export function buildOtherGameSessionMap(
     infos.sort((a, b) => a.gameName.localeCompare(b.gameName));
   }
   return map;
+}
+
+/**
+ * Human-readable time window for an other-game session — e.g. "7pm–10pm",
+ * "from 7pm", "until 10pm", or "" when the session has no times set.
+ */
+export function formatSessionTimeWindow(
+  startTime: string | null,
+  endTime: string | null,
+  use24h: boolean,
+): string {
+  const start = formatTimeShort(startTime, use24h);
+  const end = formatTimeShort(endTime, use24h);
+  if (start && end) return `${start}–${end}`;
+  if (start) return `from ${start}`;
+  if (end) return `until ${end}`;
+  return "";
 }


### PR DESCRIPTION
Adds a "Scheduled elsewhere" section to the availability date popover so a player's confirmed session in another game that night is reachable on mobile, where the existing calendar badge was hover/tooltip-only (a tap on it just toggled availability). The time formatting is extracted into a tested `formatSessionTimeWindow` helper that the existing day-cell tooltip now also reuses. The user guide gains documentation for default availability, the copy-from conflict prompt, and the other-game badge. Covered by a new unit suite for the helper and a new e2e that opens the popover and asserts it names the conflicting game and time; full unit suite (531) and the cross-game e2e spec pass, lint and build clean.