### PR TITLE
Hide clock indicator on unavailable days (fix dead affordance)

### DIFF
--- a/e2e/tests/availability/time-constraints.spec.ts
+++ b/e2e/tests/availability/time-constraints.spec.ts
@@ -243,6 +243,63 @@ test.describe('Time Availability Constraints', () => {
     await expect(endTimeInput).toHaveValue('23:00');
   });
 
+  test('clock indicator is hidden on unavailable days (no dead affordance)', async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-time-unavail-${Date.now()}@e2e.local`,
+      name: 'Time Unavail GM',
+      is_gm: true,
+    });
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Time Unavail Campaign',
+      play_days: [5, 6],
+    });
+
+    await loginTestUser(page, {
+      email: gm.email,
+      name: gm.name,
+      is_gm: true,
+    });
+
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.getByRole('button', { name: /availability/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible();
+
+    const playDates = getPlayDates([5, 6], 2);
+    const targetDate = playDates[0];
+
+    const dateButton = page.locator(`button[data-date="${targetDate}"]`);
+    await expect(dateButton).toBeVisible();
+
+    // Mark available and set a time constraint
+    await dateButton.click();
+    await expect(dateButton).toHaveAttribute('data-status', 'available');
+
+    const editIcon = dateButton.locator('span[title="Add note"]');
+    await editIcon.click();
+    await page.getByLabel('Available after').selectOption('20:00');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Clock indicator visible while available
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
+
+    // Cycle to unavailable — time windows don't apply, so the clock (an editor
+    // that can't edit the time for unavailable) must NOT be shown.
+    await dateButton.click();
+    await expect(dateButton).toHaveAttribute('data-status', 'unavailable');
+    await expect(dateButton.getByTestId('time-indicator')).toHaveCount(0);
+
+    // Cycle to maybe — the preserved constraint round-trips back into view.
+    await dateButton.click();
+    await expect(dateButton).toHaveAttribute('data-status', 'maybe');
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
+  });
+
   test('time constraints persist when cycling availability states', async ({ page, request }) => {
     const gm = await createTestUser(request, {
       email: `gm-time-persist-${Date.now()}@e2e.local`,

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -725,6 +725,13 @@ function MonthCalendar({
 
           const hasComment = !!avail?.comment;
           const hasTimeConstraint = !!(avail?.available_after || avail?.available_until);
+          // Time windows only apply to available/maybe. The data is preserved
+          // through an "unavailable" toggle so it round-trips, but don't surface
+          // the clock — its editor hides the time fields when unavailable, so the
+          // icon would be a dead affordance the user can't edit or clear.
+          const showTimeConstraint =
+            hasTimeConstraint &&
+            (avail?.status === "available" || avail?.status === "maybe");
           const hasAvailability = !!avail;
 
           // Build tooltip
@@ -747,7 +754,7 @@ function MonthCalendar({
               tooltipParts.push(`Your status: ${statusLabel}`);
             }
           }
-          if (hasTimeConstraint) {
+          if (showTimeConstraint) {
             const after = formatTimeShort(avail?.available_after ?? null, use24h);
             const until = formatTimeShort(avail?.available_until ?? null, use24h);
             if (after && until) {
@@ -897,7 +904,7 @@ function MonthCalendar({
                 </span>
               )}
               {/* Bottom-left status icons (clickable — open editor popover) */}
-              {isPlayDay && !isPast && (hasTimeConstraint || playDateNotes?.has(dateStr)) && (
+              {isPlayDay && !isPast && (showTimeConstraint || playDateNotes?.has(dateStr)) && (
                 <span
                   className="absolute bottom-0 left-0.5 leading-none cursor-pointer flex items-center gap-px hover:scale-125 transition-all"
                   data-testid="note-icons"
@@ -910,7 +917,7 @@ function MonthCalendar({
                     onEditComment(dateStr);
                   }}
                 >
-                  {hasTimeConstraint && (
+                  {showTimeConstraint && (
                     <span
                       data-testid="time-indicator"
                       title={(() => {


### PR DESCRIPTION
A day's time constraint is preserved through an "unavailable" toggle so it round-trips back to available/maybe, but the clock icon was still rendered while the day was unavailable. Clicking it opened the editor with the time fields hidden, leaving the user unable to edit or clear the time — a dead affordance. This gates the clock indicator (and its tooltip line) on available/maybe status to match the editor, while the underlying time data stays preserved for round-tripping. Added an e2e test verifying the clock shows on available, disappears on unavailable, and reappears on maybe.