### PR TITLE
Rolling 7-day windows for admin engagement charts (no incomplete-data plunge)

### DIFF
--- a/src/app/api/admin/engagement/route.ts
+++ b/src/app/api/admin/engagement/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin, paginate } from '@/lib/api/admin';
-import { startOfWeek, subWeeks, format } from 'date-fns';
+import { buildRollingEngagement } from '@/lib/adminEngagement';
+import { startOfDay, subDays, format } from 'date-fns';
 
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -10,14 +11,6 @@ const VALID_WEEKS = [8, 12, 26] as const;
 // In serverless, this only helps when the function instance is reused across
 // requests (Fluid Compute). Misses silently on cold starts — that's fine.
 const cache = new Map<string, { data: unknown; timestamp: number }>();
-
-interface WeekBucket {
-  week: string; // ISO date string for the Monday of that week
-  newUsers: number;
-  newGames: number;
-  sessionsConfirmed: number;
-  activeUsers: number;
-}
 
 export async function GET(request: NextRequest): Promise<Response> {
   try {
@@ -41,9 +34,11 @@ export async function GET(request: NextRequest): Promise<Response> {
     }
 
     const now = new Date();
-    const currentWeekStart = startOfWeek(now, { weekStartsOn: 1 }); // Monday
+    // Rolling windows are anchored on midnight today (today is excluded as
+    // incomplete). N "weeks" = N trailing 7-day windows, so fetch N*7 days back.
+    const endExclusive = startOfDay(now);
     const cutoffDate = weeks
-      ? format(subWeeks(currentWeekStart, weeks), 'yyyy-MM-dd')
+      ? format(subDays(endExclusive, weeks * 7), 'yyyy-MM-dd')
       : null;
 
     const cutoff = cutoffDate ?? undefined;
@@ -54,60 +49,13 @@ export async function GET(request: NextRequest): Promise<Response> {
       paginate<{ user_id: string; updated_at: string }>(admin, 'availability', 'user_id, updated_at', { dateColumn: 'updated_at', cutoff }),
     ]);
 
-    // Build week buckets
-    const bucketMap = new Map<string, WeekBucket>();
-
-    function getWeekKey(dateStr: string): string {
-      const weekStart = startOfWeek(new Date(dateStr), { weekStartsOn: 1 });
-      return format(weekStart, 'yyyy-MM-dd');
-    }
-
-    function ensureBucket(weekKey: string): WeekBucket {
-      if (!bucketMap.has(weekKey)) {
-        bucketMap.set(weekKey, {
-          week: weekKey,
-          newUsers: 0,
-          newGames: 0,
-          sessionsConfirmed: 0,
-          activeUsers: 0,
-        });
-      }
-      return bucketMap.get(weekKey)!;
-    }
-
-    // Bucket users
-    for (const u of users) {
-      ensureBucket(getWeekKey(u.created_at)).newUsers++;
-    }
-
-    // Bucket games
-    for (const g of games) {
-      ensureBucket(getWeekKey(g.created_at)).newGames++;
-    }
-
-    // Bucket sessions (only confirmed)
-    for (const s of sessions) {
-      if (s.status === 'confirmed') {
-        ensureBucket(getWeekKey(s.created_at)).sessionsConfirmed++;
-      }
-    }
-
-    // Bucket active users (distinct per week)
-    const activeUsersByWeek = new Map<string, Set<string>>();
-    for (const a of availability) {
-      const weekKey = getWeekKey(a.updated_at);
-      if (!activeUsersByWeek.has(weekKey)) {
-        activeUsersByWeek.set(weekKey, new Set());
-      }
-      activeUsersByWeek.get(weekKey)!.add(a.user_id);
-    }
-    for (const [weekKey, userSet] of activeUsersByWeek) {
-      ensureBucket(weekKey).activeUsers = userSet.size;
-    }
-
-    // Sort buckets chronologically
-    const weeklyData = [...bucketMap.values()].sort((a, b) =>
-      a.week.localeCompare(b.week)
+    // Bucket into rolling 7-day windows. Today is excluded as incomplete, so the
+    // charts never plot partial data yet fresh data appears within a day. Empty
+    // windows are zero-filled for a continuous line — see buildRollingEngagement.
+    const weeklyData = buildRollingEngagement(
+      { users, games, sessions, availability },
+      now,
+      weeks ?? undefined
     );
 
     const responseData = { weeklyData };

--- a/src/components/admin/EngagementCharts.tsx
+++ b/src/components/admin/EngagementCharts.tsx
@@ -12,7 +12,7 @@ import type { HealthGrade } from '@/lib/gameHealth';
 // ── Types ──────────────────────────────────────────────────
 
 interface WeekBucket {
-  week: string;
+  windowEnd: string; // last day of the rolling 7-day window (yesterday for the newest)
   newUsers: number;
   newGames: number;
   sessionsConfirmed: number;
@@ -46,8 +46,8 @@ const HEALTH_GRADE_COLORS: Record<string, string> = {
 
 // ── Helpers ────────────────────────────────────────────────
 
-function formatWeekLabel(weekStr: string): string {
-  const date = new Date(weekStr + 'T00:00:00');
+function formatDayLabel(dayStr: string): string {
+  const date = new Date(dayStr + 'T00:00:00');
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
@@ -100,7 +100,7 @@ export default function EngagementCharts({ games }: EngagementChartsProps) {
 
   const chartData = data?.weeklyData.map((w) => ({
     ...w,
-    label: formatWeekLabel(w.week),
+    label: formatDayLabel(w.windowEnd),
   })) ?? [];
 
   const healthData = useMemo(() => {

--- a/src/lib/adminEngagement.test.ts
+++ b/src/lib/adminEngagement.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildRollingEngagement,
+  getRollingBucketKey,
+  type EngagementInputs,
+} from './adminEngagement';
+import { startOfDay } from 'date-fns';
+
+const EMPTY: EngagementInputs = { users: [], games: [], sessions: [], availability: [] };
+
+// Reference "now": Wed 2025-01-15, midday-local. Timestamps use local values (no
+// trailing Z) so day bucketing is stable across the runner's timezone — matching
+// the local-day bucketing the app itself does.
+const NOW = new Date('2025-01-15T12:00:00');
+const END_EXCLUSIVE = startOfDay(NOW); // 2025-01-15T00:00 local
+
+// Rolling windows anchored on 2025-01-15, labeled by their END day:
+//   bucket 0 = Jan 8–14 (last 7 complete days) -> windowEnd '2025-01-14' (yesterday)
+//   bucket 1 = Jan 1–7                          -> windowEnd '2025-01-07'
+//   bucket 2 = Dec 25–31                        -> windowEnd '2024-12-31'
+const BUCKET0 = '2025-01-14';
+const BUCKET1 = '2025-01-07';
+const BUCKET2 = '2024-12-31';
+
+const TODAY = '2025-01-15T09:00:00'; // incomplete -> excluded
+const YESTERDAY = '2025-01-14T18:00:00'; // most recent complete day -> bucket 0
+const IN_BUCKET0 = '2025-01-10T12:00:00';
+const IN_BUCKET1 = '2025-01-03T12:00:00';
+const IN_BUCKET2 = '2024-12-28T12:00:00';
+
+describe('getRollingBucketKey', () => {
+  it('maps yesterday and the last 7 days into the most recent window', () => {
+    expect(getRollingBucketKey(YESTERDAY, END_EXCLUSIVE)).toBe(BUCKET0);
+    expect(getRollingBucketKey('2025-01-08T00:00:00', END_EXCLUSIVE)).toBe(BUCKET0); // 7 days ago -> still bucket 0
+  });
+
+  it('steps back a full 7 days for the previous window', () => {
+    expect(getRollingBucketKey('2025-01-07T23:00:00', END_EXCLUSIVE)).toBe(BUCKET1);
+    expect(getRollingBucketKey(IN_BUCKET2, END_EXCLUSIVE)).toBe(BUCKET2);
+  });
+
+  it('returns null for today and future dates (incomplete)', () => {
+    expect(getRollingBucketKey(TODAY, END_EXCLUSIVE)).toBeNull();
+    expect(getRollingBucketKey('2025-01-20T12:00:00', END_EXCLUSIVE)).toBeNull();
+  });
+
+  it('accepts a Date as well as a string', () => {
+    expect(getRollingBucketKey(new Date(YESTERDAY), END_EXCLUSIVE)).toBe(BUCKET0);
+  });
+});
+
+describe('buildRollingEngagement', () => {
+  it('returns an empty array with no data', () => {
+    expect(buildRollingEngagement(EMPTY, NOW)).toEqual([]);
+  });
+
+  it('includes yesterday in the most recent window — no multi-day lag', () => {
+    const result = buildRollingEngagement({ ...EMPTY, users: [{ created_at: YESTERDAY }] }, NOW);
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET0]);
+    expect(result[0].newUsers).toBe(1);
+  });
+
+  it('excludes the current (incomplete) day', () => {
+    const result = buildRollingEngagement(
+      {
+        ...EMPTY,
+        users: [{ created_at: TODAY }, { created_at: IN_BUCKET0 }],
+      },
+      NOW
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET0]);
+    expect(result[0].newUsers).toBe(1);
+  });
+
+  it('drops future-dated rows too', () => {
+    const result = buildRollingEngagement(
+      {
+        ...EMPTY,
+        games: [{ created_at: '2025-02-01T12:00:00' }, { created_at: IN_BUCKET0 }],
+      },
+      NOW
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET0]);
+  });
+
+  it('buckets each metric into the correct rolling window and sorts chronologically', () => {
+    const result = buildRollingEngagement(
+      {
+        users: [{ created_at: IN_BUCKET0 }, { created_at: IN_BUCKET1 }],
+        games: [{ created_at: IN_BUCKET0 }],
+        sessions: [
+          { created_at: IN_BUCKET0, status: 'confirmed' },
+          { created_at: IN_BUCKET0, status: 'pending' }, // ignored
+        ],
+        availability: [],
+      },
+      NOW
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET1, BUCKET0]);
+    expect(result.find((b) => b.windowEnd === BUCKET0)!).toMatchObject({
+      newUsers: 1,
+      newGames: 1,
+      sessionsConfirmed: 1,
+    });
+    expect(result.find((b) => b.windowEnd === BUCKET1)!.newUsers).toBe(1);
+  });
+
+  it('counts distinct active users per window', () => {
+    const result = buildRollingEngagement(
+      {
+        ...EMPTY,
+        availability: [
+          { user_id: 'a', updated_at: IN_BUCKET0 },
+          { user_id: 'a', updated_at: YESTERDAY }, // same user, same window
+          { user_id: 'b', updated_at: IN_BUCKET0 },
+          { user_id: 'a', updated_at: TODAY }, // today -> dropped
+        ],
+      },
+      NOW
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET0]);
+    expect(result[0].activeUsers).toBe(2);
+  });
+
+  it('zero-fills gaps between data windows (all time)', () => {
+    // Data in bucket 0 and bucket 2, nothing in bucket 1 -> continuous, gap = 0.
+    const result = buildRollingEngagement(
+      {
+        ...EMPTY,
+        users: [{ created_at: IN_BUCKET0 }, { created_at: IN_BUCKET2 }],
+      },
+      NOW
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET2, BUCKET1, BUCKET0]);
+    expect(result.find((b) => b.windowEnd === BUCKET1)).toMatchObject({
+      newUsers: 0,
+      newGames: 0,
+      sessionsConfirmed: 0,
+      activeUsers: 0,
+    });
+  });
+
+  it('emits exactly `windows` windows, zero-filling empties (bounded range)', () => {
+    const result = buildRollingEngagement(
+      { ...EMPTY, users: [{ created_at: IN_BUCKET0 }] },
+      NOW,
+      3
+    );
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET2, BUCKET1, BUCKET0]);
+    expect(result[0]).toMatchObject({ windowEnd: BUCKET2, newUsers: 0 });
+    expect(result[1]).toMatchObject({ windowEnd: BUCKET1, newUsers: 0 });
+    expect(result[2]).toMatchObject({ windowEnd: BUCKET0, newUsers: 1 });
+  });
+
+  it('emits all-zero windows when the bounded range has no data at all', () => {
+    const result = buildRollingEngagement(EMPTY, NOW, 2);
+    expect(result.map((b) => b.windowEnd)).toEqual([BUCKET1, BUCKET0]);
+    expect(result.every((b) => b.newUsers === 0 && b.activeUsers === 0)).toBe(true);
+  });
+});

--- a/src/lib/adminEngagement.ts
+++ b/src/lib/adminEngagement.ts
@@ -1,0 +1,135 @@
+import { startOfDay, differenceInCalendarDays, subDays, format } from 'date-fns';
+
+export interface EngagementBucket {
+  windowEnd: string; // ISO date (yyyy-MM-dd) for the last day of the 7-day window
+  newUsers: number;
+  newGames: number;
+  sessionsConfirmed: number;
+  activeUsers: number;
+}
+
+export interface EngagementInputs {
+  users: { created_at: string }[];
+  games: { created_at: string }[];
+  sessions: { created_at: string; status: string }[];
+  availability: { user_id: string; updated_at: string }[];
+}
+
+/**
+ * Rolling 7-day bucket index for a row, or null if the row falls on the current
+ * (incomplete) day or in the future.
+ *
+ * Buckets are discrete, non-overlapping 7-day windows anchored on `endExclusive`
+ * (midnight of the current day). Index 0 is the most recent complete window —
+ * yesterday back through 7 days ago — and each higher index steps back another
+ * 7 days. Because the anchor is "today", the newest window advances every day, so
+ * fresh data shows up within a day instead of waiting for a calendar week to close.
+ */
+function getBucketIndex(date: string | Date, endExclusive: Date): number | null {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  // Whole days between the row's day and today. 1 = yesterday, 7 = a week ago.
+  // <= 0 means today or the future — incomplete, so excluded.
+  const daysAgo = differenceInCalendarDays(endExclusive, d);
+  if (daysAgo <= 0) return null;
+  return Math.floor((daysAgo - 1) / 7);
+}
+
+/** Last day (yyyy-MM-dd) of the rolling window at `index`. Index 0 ends yesterday. */
+function windowEndKey(index: number, endExclusive: Date): string {
+  return format(subDays(endExclusive, 7 * index + 1), 'yyyy-MM-dd');
+}
+
+/**
+ * Rolling 7-day bucket key (last day of the window) for a row, or null if the
+ * row falls on the current incomplete day or in the future. Thin wrapper over the
+ * index math — handy for callers that just need the key.
+ */
+export function getRollingBucketKey(date: string | Date, endExclusive: Date): string | null {
+  const index = getBucketIndex(date, endExclusive);
+  return index === null ? null : windowEndKey(index, endExclusive);
+}
+
+interface BucketTally {
+  newUsers: number;
+  newGames: number;
+  sessionsConfirmed: number;
+  activeUsers: Set<string>;
+}
+
+/**
+ * Aggregate raw engagement rows into discrete rolling 7-day windows, sorted
+ * chronologically (oldest first). The current day is excluded as incomplete, so
+ * no window is ever built from partial data.
+ *
+ * The output is dense — every window in the range is emitted, empty ones as
+ * zeros — so the charts render a continuous line rather than skipping gaps.
+ *
+ * @param inputs  Raw rows fetched from the database.
+ * @param now     Reference "current time" used to anchor the rolling windows.
+ * @param windows Number of trailing windows to emit (windows 0..windows-1). When
+ *                omitted ("all time"), spans from window 0 through the oldest
+ *                window that contains data.
+ */
+export function buildRollingEngagement(
+  inputs: EngagementInputs,
+  now: Date,
+  windows?: number
+): EngagementBucket[] {
+  const { users, games, sessions, availability } = inputs;
+  const endExclusive = startOfDay(now); // midnight today — today itself is incomplete
+
+  // Tally each metric by window index.
+  const tally = new Map<number, BucketTally>();
+  function ensure(index: number): BucketTally {
+    let t = tally.get(index);
+    if (!t) {
+      t = { newUsers: 0, newGames: 0, sessionsConfirmed: 0, activeUsers: new Set() };
+      tally.set(index, t);
+    }
+    return t;
+  }
+
+  for (const u of users) {
+    const i = getBucketIndex(u.created_at, endExclusive);
+    if (i !== null) ensure(i).newUsers++;
+  }
+  for (const g of games) {
+    const i = getBucketIndex(g.created_at, endExclusive);
+    if (i !== null) ensure(i).newGames++;
+  }
+  for (const s of sessions) {
+    if (s.status !== 'confirmed') continue;
+    const i = getBucketIndex(s.created_at, endExclusive);
+    if (i !== null) ensure(i).sessionsConfirmed++;
+  }
+  for (const a of availability) {
+    const i = getBucketIndex(a.updated_at, endExclusive);
+    if (i !== null) ensure(i).activeUsers.add(a.user_id);
+  }
+
+  // Decide how many windows to emit. Bounded ranges emit exactly `windows`;
+  // "all time" spans from window 0 through the oldest window that has data.
+  let count: number;
+  if (windows != null) {
+    count = windows;
+  } else {
+    const maxIndex = tally.size ? Math.max(...tally.keys()) : -1;
+    if (maxIndex < 0) return [];
+    count = maxIndex + 1;
+  }
+
+  // Emit every window, zero-filling gaps. Chronological order (oldest first) is
+  // descending index, since higher index = further in the past.
+  const result: EngagementBucket[] = [];
+  for (let index = count - 1; index >= 0; index--) {
+    const t = tally.get(index);
+    result.push({
+      windowEnd: windowEndKey(index, endExclusive),
+      newUsers: t?.newUsers ?? 0,
+      newGames: t?.newGames ?? 0,
+      sessionsConfirmed: t?.sessionsConfirmed ?? 0,
+      activeUsers: t?.activeUsers.size ?? 0,
+    });
+  }
+  return result;
+}


### PR DESCRIPTION
The admin engagement charts bucketed by calendar week, so the almost-always-incomplete current week made the latest point plunge and misread as a downward trend. This reworks the aggregation to use discrete rolling 7-day windows anchored on midnight today: the current day is excluded as incomplete, the newest window is the last 7 complete days (ending yesterday) and advances daily rather than waiting for a calendar week to close, and empty windows are zero-filled so the line stays continuous. Points are now labeled by each window's end day (far-right point is yesterday). The bucketing logic is extracted from the API route into a pure, unit-tested `buildRollingEngagement()` helper. Verified with `npm run test:run` (13 new tests), `npm run lint`, and `npm run build`.