### PR TITLE
Move blocked-action explanations next to the disabled control

### DIFF
--- a/e2e/tests/rls/usage-limits.spec.ts
+++ b/e2e/tests/rls/usage-limits.spec.ts
@@ -72,6 +72,12 @@ test.describe('Usage Limits - RLS Policy Enforcement', () => {
       // The Create Game button should be disabled
       const createButton = page.getByRole('button', { name: /create game/i });
       await expect(createButton).toBeDisabled();
+
+      // The reason is now also shown as a hint right next to the button (in
+      // addition to the top-of-page banner), so it's visible at the point of
+      // the disabled action without needing to scroll back up. Distinct
+      // wording from the banner text above avoids an ambiguous double-match.
+      await expect(page.getByText(/game limit reached — remove a game/i)).toBeVisible();
     });
   });
 

--- a/e2e/tests/settings/default-availability.spec.ts
+++ b/e2e/tests/settings/default-availability.spec.ts
@@ -103,8 +103,9 @@ test.describe('Default availability', () => {
     await expect(page.getByRole('button', { name: /^availability$/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
     await page.getByRole('button', { name: /^availability$/i }).click();
 
-    // Open the editor via the "Edit defaults" link on the Availability tab.
-    await page.getByRole('link', { name: /edit defaults/i }).click();
+    // Open the editor via the defaults link on the Availability tab. This is a
+    // fresh game with no saved defaults yet, so the link reads "Set up defaults".
+    await page.getByRole('link', { name: 'Set up defaults' }).click();
     await expect(page).toHaveURL(/\/settings\/default-availability\?returnTo=/, { timeout: TEST_TIMEOUTS.DEFAULT });
 
     // The back link returns to the game's Availability tab (not Settings, and
@@ -117,5 +118,37 @@ test.describe('Default availability', () => {
     await expect(page.getByRole('button', { name: /apply my default availability/i })).toBeVisible({
       timeout: TEST_TIMEOUTS.LONG,
     });
+  });
+
+  test('Apply button is disabled with a "Set up defaults" link until defaults are saved', async ({ page }) => {
+    const user = await loginTestUser(page, {
+      email: `default-none-${Date.now()}@e2e.local`,
+      name: 'No Defaults User',
+      is_gm: true,
+    });
+    const game = await createTestGame({ gm_id: user.id, name: 'No Defaults Game', play_days: [5] });
+
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /^availability$/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await page.getByRole('button', { name: /^availability$/i }).click();
+
+    await expect(page.getByRole('button', { name: /apply my default availability/i })).toBeDisabled();
+    await expect(page.getByRole('link', { name: 'Set up defaults' })).toBeVisible();
+
+    // Set defaults, then confirm the button flips to enabled with "Edit defaults".
+    // Use the editor's "Back to game" link (not browser back) — it round-trips
+    // through the `returnTo` query param to land back on the Availability tab
+    // specifically; the tab switch itself doesn't change the URL, so a plain
+    // back-navigation would land on the default tab instead.
+    await page.getByRole('link', { name: 'Set up defaults' }).click();
+    await expect(page.getByRole('heading', { name: /default availability/i })).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+    await setDefault(page, 'friday', 'available');
+    await saveDefaults(page);
+    await page.getByRole('link', { name: /back to game/i }).click();
+
+    await expect(page.getByRole('button', { name: /apply my default availability/i })).toBeEnabled({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await expect(page.getByRole('link', { name: 'Edit defaults' })).toBeVisible();
   });
 });

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function GameDetailPage() {
 
   const ready = !!game;
   const availabilityHook = useAvailability(gameId, userId, game);
-  const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, applyDefaults, removePlayerData } = availabilityHook;
+  const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, applyDefaults, removePlayerData, hasDefaults } = availabilityHook;
 
   const sessionsHook = useSessions(gameId, ready);
   const { sessions, confirmSession: confirmSessionRaw, updateSession, cancelSession } = sessionsHook;
@@ -331,6 +331,7 @@ export default function GameDetailPage() {
           otherGameSessionsByDate={otherGameSessionsByDate}
           onCopyFromGame={copyFromGame}
           onApplyDefaults={() => applyDefaults(extraDateStrings)}
+          hasDefaults={hasDefaults}
           playDateNotes={playDateNotes}
           onUpdatePlayDateNote={updatePlayDateNote}
           hasCampaignDates={!!(game.campaign_start_date || game.campaign_end_date)}

--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -155,7 +155,11 @@ export default function NewGamePage() {
         initial={initial}
         busy={creating}
         error={error}
-        disabledReason={atGameLimit ? 'limit' : null}
+        disabledReason={
+          atGameLimit
+            ? 'Game limit reached — remove a game to unlock this.'
+            : null
+        }
         onSubmit={handleCreate}
         onCancel={() => router.back()}
       />

--- a/src/components/games/availability/ApplyDefaultsButton.test.tsx
+++ b/src/components/games/availability/ApplyDefaultsButton.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToastProvider } from '@/components/ui';
+import { ApplyDefaultsButton } from './ApplyDefaultsButton';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/games/abc',
+}));
+
+function renderButton(hasDefaults: boolean | null, onApplyDefaults = vi.fn()) {
+  render(
+    <ToastProvider>
+      <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} hasDefaults={hasDefaults} />
+    </ToastProvider>,
+  );
+  return { onApplyDefaults };
+}
+
+describe('ApplyDefaultsButton', () => {
+  it('disables the button and labels the link "Set up defaults" when there are no saved defaults', () => {
+    renderButton(false);
+    expect(screen.getByRole('button', { name: /apply my default availability/i })).toBeDisabled();
+    expect(screen.getByRole('link', { name: 'Set up defaults' })).toBeInTheDocument();
+  });
+
+  it('enables the button and labels the link "Edit defaults" when defaults exist', () => {
+    renderButton(true);
+    expect(screen.getByRole('button', { name: /apply my default availability/i })).toBeEnabled();
+    expect(screen.getByRole('link', { name: 'Edit defaults' })).toBeInTheDocument();
+  });
+
+  it('treats hasDefaults=null (still loading) as enabled, matching the has-defaults state', () => {
+    renderButton(null);
+    expect(screen.getByRole('button', { name: /apply my default availability/i })).toBeEnabled();
+    expect(screen.getByRole('link', { name: 'Edit defaults' })).toBeInTheDocument();
+  });
+
+  it('shows a toast after successfully applying defaults', async () => {
+    const onApplyDefaults = vi.fn().mockResolvedValue({ hadDefaults: true, filled: 2 });
+    renderButton(true, onApplyDefaults);
+    await userEvent.click(screen.getByRole('button', { name: /apply my default availability/i }));
+    expect(await screen.findByText('Filled in 2 dates.')).toBeInTheDocument();
+  });
+});

--- a/src/components/games/availability/ApplyDefaultsButton.tsx
+++ b/src/components/games/availability/ApplyDefaultsButton.tsx
@@ -9,9 +9,11 @@ import type { ApplyDefaultsResult } from '@/hooks/useAvailability';
 
 interface ApplyDefaultsButtonProps {
   onApplyDefaults: () => Promise<ApplyDefaultsResult>;
+  /** Whether the user has any default availability saved. `null` while still loading. */
+  hasDefaults: boolean | null;
 }
 
-export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProps) {
+export function ApplyDefaultsButton({ onApplyDefaults, hasDefaults }: ApplyDefaultsButtonProps) {
   const toast = useToast();
   const pathname = usePathname();
   const [busy, setBusy] = useState(false);
@@ -43,14 +45,19 @@ export function ApplyDefaultsButton({ onApplyDefaults }: ApplyDefaultsButtonProp
 
   return (
     <div className="flex items-center gap-2">
-      <Button size="sm" className="h-8" onClick={handleClick} disabled={busy}>
+      <Button
+        size="sm"
+        className="h-8"
+        onClick={handleClick}
+        disabled={busy || hasDefaults === false}
+      >
         {busy ? 'Applying…' : 'Apply my default availability'}
       </Button>
       <Link
         href={editHref}
         className="text-xs text-muted-foreground hover:text-foreground"
       >
-        Edit defaults
+        {hasDefaults === false ? 'Set up defaults' : 'Edit defaults'}
       </Link>
     </div>
   );

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -39,6 +39,7 @@ export interface AvailabilityTabContentProps {
     conflict: import('@/lib/copyAvailability').CopyConflict | null,
   ) => Promise<{ copied: number; overridden: number }>;
   onApplyDefaults?: () => Promise<ApplyDefaultsResult>;
+  hasDefaults?: boolean | null;
   playDateNotes: Map<string, string>;
   onUpdatePlayDateNote: (date: string, note: string | null) => void;
   hasCampaignDates: boolean;
@@ -55,7 +56,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
     windowStart, windowEnd, currentUserId, completionByUserId,
     playDays, availability, onToggle, confirmedSessions, extraPlayDates,
     isGmOrCoGm, onToggleExtraDate, weekStartDay, use24h, otherGames,
-    onCopyFromGame, onApplyDefaults, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
+    onCopyFromGame, onApplyDefaults, hasDefaults, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
     adHocOnly, readOnly = false, otherGameSessionsByDate = new Map(),
   } = props;
 
@@ -106,7 +107,9 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         otherGameSessionsByDate={otherGameSessionsByDate}
         onCopyFromGame={onCopyFromGame}
         bulkActionsLead={
-          onApplyDefaults ? <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} /> : undefined
+          onApplyDefaults ? (
+            <ApplyDefaultsButton onApplyDefaults={onApplyDefaults} hasDefaults={hasDefaults ?? null} />
+          ) : undefined
         }
         playDateNotes={playDateNotes}
         onUpdatePlayDateNote={onUpdatePlayDateNote}

--- a/src/components/games/forms/GameForm.test.tsx
+++ b/src/components/games/forms/GameForm.test.tsx
@@ -102,4 +102,24 @@ describe('GameForm', () => {
       }),
     );
   });
+
+  it('disables the submit button and shows the disabled reason as a hint', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <GameForm
+        mode="create"
+        initial={baseInitial}
+        busy={false}
+        disabledReason="Game limit reached — remove a game to unlock this."
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /create game/i })).toBeDisabled();
+    expect(
+      screen.getByText('Game limit reached — remove a game to unlock this.'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/games/forms/GameForm.tsx
+++ b/src/components/games/forms/GameForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useReducer } from 'react';
-import { Button, EyebrowLabel, Input, Panel, Textarea, ToggleSwitch } from '@/components/ui';
+import { Button, EyebrowLabel, HintText, Input, Panel, Textarea, ToggleSwitch } from '@/components/ui';
 import {
   DAY_OPTIONS,
   SCHEDULING_WINDOW_OPTIONS,
@@ -48,7 +48,7 @@ export interface GameFormProps {
   busy: boolean;
   /** Optional informational message shown above Schedule (used by edit mode for ad-hoc conversion notice). */
   noticeMessage?: string | null;
-  /** Optional disabling reason (e.g. game-limit reached on create). When set, the submit button is disabled. */
+  /** Optional reason the submit button is disabled (e.g. at game limit). Rendered as a hint below the submit button, in addition to disabling it. */
   disabledReason?: string | null;
   /** Validation/submission error rendered above the submit button. */
   error?: string;
@@ -373,6 +373,7 @@ export function GameForm({
           Cancel
         </Button>
       </div>
+      {disabledReason && <HintText>{disabledReason}</HintText>}
     </form>
   );
 }

--- a/src/components/ui/HintText.tsx
+++ b/src/components/ui/HintText.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export function HintText({ children }: { children: ReactNode }) {
+  return <p className="mt-1.5 text-xs text-muted-foreground">{children}</p>;
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,5 +11,6 @@ export { StatePill, type PillState } from './StatePill';
 export { RankCircle } from './RankCircle';
 export { EyebrowLabel } from './EyebrowLabel';
 export { Modal } from './Modal';
+export { HintText } from './HintText';
 export { OnboardingBanner, type OnboardingBannerProps } from './OnboardingBanner';
 export { ToastProvider, useToast } from './Toast';

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -39,6 +39,8 @@ export interface UseAvailabilityReturn {
   availability: Record<string, AvailabilityEntry>;
   allAvailability: Availability[];
   loading: boolean;
+  /** Whether the user has any default availability saved. `null` while the initial fetch is in flight. */
+  hasDefaults: boolean | null;
   changeAvailability: (
     date: string,
     status: AvailabilityStatus,
@@ -64,12 +66,14 @@ export function useAvailability(
   const [availability, setAvailability] = useState<Record<string, AvailabilityEntry>>({});
   const [allAvailability, setAllAvailability] = useState<Availability[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hasDefaults, setHasDefaults] = useState<boolean | null>(null);
 
   const fetchAll = useCallback(async () => {
     if (!gameId || !userId) return;
-    const [userAvailRes, allAvailRes] = await Promise.all([
+    const [userAvailRes, allAvailRes, defaultsRes] = await Promise.all([
       fetchUserAvailability(supabase, gameId, userId),
       fetchAllAvailability(supabase, gameId),
+      fetchUserDefaults(supabase, userId),
     ]);
 
     const map: Record<string, AvailabilityEntry> = {};
@@ -83,6 +87,7 @@ export function useAvailability(
     });
     setAvailability(map);
     setAllAvailability(allAvailRes.data || []);
+    setHasDefaults((defaultsRes.data?.length ?? 0) > 0);
     setLoading(false);
   }, [gameId, userId]);
 
@@ -360,6 +365,7 @@ export function useAvailability(
     availability,
     allAvailability,
     loading,
+    hasDefaults,
     changeAvailability,
     copyFromGame,
     applyDefaults,


### PR DESCRIPTION
Clicking "Apply my default availability" with no saved defaults previously showed a toast far from the button; now `useAvailability` learns whether defaults exist up front, and the button disables itself with a relabeled "Set up defaults" link instead of a delayed, disconnected toast. The new-game form's game-limit explanation previously only appeared in a banner at the top of the page, disconnected from the disabled Submit button at the bottom of the form; it now also renders as an inline hint (via a new shared `HintText` component) directly beside the button, alongside the existing banner. Both changes establish and apply the same principle: a control disabled for a non-obvious reason must explain why immediately next to itself, not in a toast or a scrolled-away banner. Includes new unit and e2e test coverage for both flows.