### PR TITLE
Add paginated Upcoming Games tab to admin dashboard

### DIFF
--- a/e2e/tests/admin/dashboard.spec.ts
+++ b/e2e/tests/admin/dashboard.spec.ts
@@ -53,7 +53,7 @@ test.describe('Admin Dashboard', () => {
 
     // Should see tabs
     await expect(page.getByRole('button', { name: /overview/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /games/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Games', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: /activity/i })).toBeVisible();
   });
 
@@ -183,7 +183,7 @@ test.describe('Admin Dashboard', () => {
     await page.goto('/admin');
 
     // Click Games tab
-    await page.getByRole('button', { name: /games/i }).click();
+    await page.getByRole('button', { name: 'Games', exact: true }).click();
 
     // Should see the game in the list
     await expect(page.getByText('Games Tab Test Campaign')).toBeVisible({

--- a/e2e/tests/admin/upcoming-games.spec.ts
+++ b/e2e/tests/admin/upcoming-games.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame, createTestSession } from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+/**
+ * The "Upcoming Games" admin tab surfaces confirmed sessions across ALL games
+ * in the system (not just games the admin belongs to), so it can never be
+ * fully isolated from other tests' seeded data in this parallel, shared-DB
+ * test suite. To stay robust:
+ *  - The empty-state test mocks the API response (page.route) rather than
+ *    relying on zero sessions system-wide, which no other test can guarantee.
+ *  - The pagination test seeds real data and reads `total`/`totalPages` back
+ *    from the rendered page rather than hardcoding exact numbers, so it still
+ *    passes if another concurrently-run spec has added upcoming sessions.
+ *  - Ordering is checked via uniquely-tagged rows (by `location`) and their
+ *    relative order, not by absolute row index. Critically, this check walks
+ *    ALL pages (not just page 1): other specs (e.g.
+ *    dashboard/upcoming-sessions.spec.ts) concurrently seed sessions dated
+ *    today/tomorrow that sort ahead of this test's markers system-wide, which
+ *    can push even the soonest marker past page 1 if enough of them land at
+ *    once. Concatenating every page's rows before asserting order removes
+ *    that page-1 assumption entirely.
+ *
+ * Run serially — the empty-state test's route interception can interfere
+ * with the second test's real network requests if run concurrently.
+ */
+test.describe.configure({ mode: 'serial' });
+
+/** Local YYYY-MM-DD date `daysFromNow` days out (matches the app's local-date storage format). */
+function futureDate(daysFromNow: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+test.describe('Admin Upcoming Games tab', () => {
+  test('shows an empty state when there are no upcoming sessions', async ({ page, request }) => {
+    const admin = await createTestUser(request, {
+      email: `admin-upcoming-empty-${Date.now()}@e2e.local`,
+      name: 'Admin Upcoming Empty',
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+
+    // Mock a zero-session response — this route is system-wide, so genuinely
+    // zero upcoming sessions can't be guaranteed while other specs run.
+    await page.route('**/api/admin/upcoming-sessions**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sessions: [], total: 0, page: 1, pageSize: 20, totalPages: 0 }),
+      })
+    );
+
+    await page.goto('/admin');
+    await page.getByRole('button', { name: 'Upcoming Games', exact: true }).click();
+
+    await expect(page.getByText(/no upcoming sessions/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+
+  test('shows sessions from multiple games ordered soonest-first, paginated', async ({ page, request }) => {
+    const ts = Date.now();
+    const admin = await createTestUser(request, {
+      email: `admin-upcoming-${ts}@e2e.local`,
+      name: 'Admin Upcoming User',
+      is_gm: false,
+      is_admin: true,
+    });
+    const gmAlpha = await createTestUser(request, {
+      email: `upcoming-gm-alpha-${ts}@e2e.local`,
+      name: 'Upcoming GM Alpha',
+      is_gm: true,
+      is_admin: false,
+    });
+    const gmBeta = await createTestUser(request, {
+      email: `upcoming-gm-beta-${ts}@e2e.local`,
+      name: 'Upcoming GM Beta',
+      is_gm: true,
+      is_admin: false,
+    });
+
+    const gameAlpha = await createTestGame({
+      gm_id: gmAlpha.id,
+      name: `Upcoming Games Alpha Campaign ${ts}`,
+      play_days: [5, 6],
+      timezone: 'America/Los_Angeles',
+    });
+    const gameBeta = await createTestGame({
+      gm_id: gmBeta.id,
+      name: `Upcoming Games Beta Campaign ${ts}`,
+      play_days: [5, 6],
+      timezone: 'America/Los_Angeles',
+    });
+
+    // 25 sessions across 2 games spread over distinct future dates (more than
+    // one page's worth). Even offsets -> Alpha, odd -> Beta. The four earliest
+    // sessions get a unique `location` tag so we can find their exact rows and
+    // check *relative* soonest-first order, regardless of any other upcoming
+    // sessions concurrently seeded elsewhere in the system.
+    const markers: Record<number, string> = {
+      2: `Marker-${ts}-A`, // Alpha, soonest
+      3: `Marker-${ts}-B`, // Beta
+      4: `Marker-${ts}-C`, // Alpha
+      5: `Marker-${ts}-D`, // Beta
+    };
+    const offsets = Array.from({ length: 25 }, (_, i) => i + 2); // 2..26
+    for (const offset of offsets) {
+      const isAlpha = offset % 2 === 0;
+      await createTestSession({
+        game_id: isAlpha ? gameAlpha.id : gameBeta.id,
+        date: futureDate(offset),
+        confirmed_by: isAlpha ? gmAlpha.id : gmBeta.id,
+        start_time: '18:00',
+        end_time: '21:00',
+        location: markers[offset] ?? null,
+      });
+    }
+
+    await loginTestUser(page, {
+      email: admin.email,
+      name: admin.name,
+      is_gm: false,
+      is_admin: true,
+    });
+
+    await page.goto('/admin');
+    await page.getByRole('button', { name: 'Upcoming Games', exact: true }).click();
+
+    const rows = page.locator('table tbody tr');
+    // Page size is 20 and we alone seeded 25 upcoming sessions, so page 1 is
+    // always a full page regardless of any other upcoming sessions elsewhere.
+    await expect(rows).toHaveCount(20, { timeout: TEST_TIMEOUTS.LONG });
+
+    // Read total/totalPages back from the pager rather than hardcoding them,
+    // so this stays correct even if other specs add upcoming sessions too.
+    const pagerText = await page.getByText(/page \d+ of \d+/i).innerText();
+    const pageMatch = pagerText.match(/page (\d+) of (\d+)/i);
+    const totalMatch = pagerText.match(/(\d+)\s+total session/i);
+    expect(pageMatch).not.toBeNull();
+    expect(totalMatch).not.toBeNull();
+    const totalPages = Number(pageMatch![2]);
+    const total = Number(totalMatch![1]);
+    expect(total).toBeGreaterThanOrEqual(25);
+    expect(totalPages).toBeGreaterThanOrEqual(2);
+
+    const previousButton = page.getByRole('button', { name: 'Previous page of upcoming sessions' });
+    const nextButton = page.getByRole('button', { name: 'Next page of upcoming sessions' });
+    await expect(previousButton).toBeDisabled();
+    await expect(nextButton).toBeEnabled();
+
+    // Walk every page and concatenate row text in DOM order. This route is
+    // system-wide, so our four markers can't be assumed to land on page 1 --
+    // other concurrently-run specs may seed sessions dated sooner (e.g.
+    // today/tomorrow) that push our markers onto later pages.
+    const allRowTexts: string[] = await rows.allTextContents();
+    for (let p = 2; p <= totalPages; p++) {
+      await nextButton.click();
+      // The table and pager re-render together only once the new page's data
+      // has loaded (the component shows a spinner in place of both while
+      // loading), so waiting for the new page number confirms rows are fresh.
+      await expect(page.getByText(new RegExp(`page ${p} of`, 'i'))).toBeVisible();
+      const expectedCount = p < totalPages ? 20 : total - 20 * (totalPages - 1);
+      await expect(rows).toHaveCount(expectedCount);
+      allRowTexts.push(...(await rows.allTextContents()));
+    }
+    expect(allRowTexts.length).toBe(total);
+    await expect(nextButton).toBeDisabled();
+
+    // Soonest-first, interleaved across both games: A (Alpha) < B (Beta) < C (Alpha) < D (Beta).
+    // Each marker must appear exactly once across all pages combined.
+    const findIndices = (marker: string) =>
+      allRowTexts.reduce<number[]>((acc, text, i) => (text.includes(marker) ? [...acc, i] : acc), []);
+    const indicesA = findIndices(markers[2]);
+    const indicesB = findIndices(markers[3]);
+    const indicesC = findIndices(markers[4]);
+    const indicesD = findIndices(markers[5]);
+    expect(indicesA).toHaveLength(1);
+    expect(indicesB).toHaveLength(1);
+    expect(indicesC).toHaveLength(1);
+    expect(indicesD).toHaveLength(1);
+    const [idxA] = indicesA;
+    const [idxB] = indicesB;
+    const [idxC] = indicesC;
+    const [idxD] = indicesD;
+    expect(idxB).toBeGreaterThan(idxA);
+    expect(idxC).toBeGreaterThan(idxB);
+    expect(idxD).toBeGreaterThan(idxC);
+
+    // The soonest two markers' rows link to the right game and show the
+    // right GM, checked via the captured row text since the row locator
+    // itself may be on whatever page it happened to land on.
+    expect(allRowTexts[idxA]).toContain(`Upcoming Games Alpha Campaign ${ts}`);
+    expect(allRowTexts[idxA]).toContain('Upcoming GM Alpha');
+    expect(allRowTexts[idxB]).toContain(`Upcoming Games Beta Campaign ${ts}`);
+    expect(allRowTexts[idxB]).toContain('Upcoming GM Beta');
+
+    // Previous walks all the way back down to a full first page.
+    for (let p = totalPages - 1; p >= 1; p--) {
+      await previousButton.click();
+      await expect(page.getByText(new RegExp(`page ${p} of`, 'i'))).toBeVisible();
+    }
+    await expect(rows).toHaveCount(20);
+    await expect(previousButton).toBeDisabled();
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,15 +2,19 @@
 
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { parseISO } from 'date-fns';
 import { ChevronRight, Eye } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
-import { Avatar, Card, CardContent, CardHeader, LoadingSpinner } from '@/components/ui';
+import { useUserPreferences } from '@/hooks/useUserPreferences';
+import { Avatar, Button, Card, CardContent, CardHeader, EmptyState, LoadingSpinner } from '@/components/ui';
 import EngagementCharts from '@/components/admin/EngagementCharts';
+import { formatTimeShort } from '@/lib/formatting';
 import type { HealthBreakdown, HealthGrade } from '@/lib/gameHealth';
 import type { TopUsersResult, TopGmEntry, TopPlayerEntry } from '@/lib/topUsers';
+import type { AdminUpcomingSessionRow } from '@/types';
 
-type Tab = 'overview' | 'games' | 'topUsers' | 'activity';
+type Tab = 'overview' | 'games' | 'topUsers' | 'activity' | 'upcomingGames';
 
 interface AdminStats {
   totalUsers: number;
@@ -119,6 +123,7 @@ export default function AdminPage() {
     { id: 'games', label: 'Games' },
     { id: 'topUsers', label: 'Top Users' },
     { id: 'activity', label: 'Activity' },
+    { id: 'upcomingGames', label: 'Upcoming Games' },
   ];
 
   return (
@@ -127,12 +132,12 @@ export default function AdminPage() {
 
       {/* Tabs */}
       <div className="border-b border-border mb-6">
-        <nav className="-mb-px flex space-x-8">
+        <nav className="-mb-px flex space-x-8 overflow-x-auto">
           {tabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+              className={`py-2 px-1 border-b-2 font-medium text-sm whitespace-nowrap transition-colors ${
                 activeTab === tab.id
                   ? 'border-primary text-primary'
                   : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
@@ -156,6 +161,7 @@ export default function AdminPage() {
           {activeTab === 'games' && <GamesTab games={games} />}
           {activeTab === 'topUsers' && topUsers && <TopUsersTab topUsers={topUsers} />}
           {activeTab === 'activity' && stats && <ActivityTab stats={stats} />}
+          {activeTab === 'upcomingGames' && <UpcomingGamesTab />}
         </>
       )}
     </div>
@@ -625,5 +631,170 @@ function ActivityTab({ stats }: { stats: AdminStats }) {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+interface UpcomingSessionsResponse {
+  sessions: AdminUpcomingSessionRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+function formatUpcomingSessionDate(dateStr: string): string {
+  return parseISO(dateStr).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function UpcomingGamesTab() {
+  const { use24h } = useUserPreferences();
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<UpcomingSessionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/admin/upcoming-sessions?page=${page}`);
+        if (!res.ok) throw new Error('Failed to fetch upcoming sessions');
+        const json = await res.json();
+        if (!cancelled) setData(json);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [page]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-destructive text-center py-12">{error}</div>;
+  }
+
+  if (!data || data.total === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <EmptyState
+            title="No upcoming sessions"
+            description="Confirmed sessions across all games will appear here once scheduled."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-card-foreground">
+          Upcoming Games
+          <span className="text-sm font-normal text-muted-foreground ml-2">
+            {data.total} upcoming session{data.total !== 1 ? 's' : ''}
+          </span>
+        </h2>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Date</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Time</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Game</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">GM</th>
+                <th className="text-left py-3 px-2 font-medium text-muted-foreground">Location</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.sessions.map((row) => (
+                <tr key={row.session.id} className="border-b border-border/50 hover:bg-muted/50">
+                  <td className="py-3 px-2 text-foreground whitespace-nowrap">
+                    <div className="flex items-center gap-2">
+                      {formatUpcomingSessionDate(row.session.date)}
+                      {row.dayHighlight && (
+                        <span className="inline-block rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary">
+                          {row.dayHighlight === 'today' ? 'Today' : 'Tomorrow'}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="py-3 px-2 text-muted-foreground whitespace-nowrap">
+                    {row.session.start_time
+                      ? `${formatTimeShort(row.session.start_time, use24h)}${
+                          row.session.end_time
+                            ? `–${formatTimeShort(row.session.end_time, use24h)}`
+                            : ''
+                        }`
+                      : 'TBD'}
+                  </td>
+                  <td className="py-3 px-2 font-medium text-foreground">
+                    <Link
+                      href={`/admin/games/${row.gameId}`}
+                      className="hover:text-primary hover:underline"
+                      title="Open read-only admin view"
+                    >
+                      {row.gameName}
+                    </Link>
+                  </td>
+                  <td className="py-3 px-2 text-muted-foreground">{row.gmName}</td>
+                  <td className="py-3 px-2 text-muted-foreground">{row.session.location ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            Page {data.page} of {data.totalPages} &middot; {data.total} total session
+            {data.total !== 1 ? 's' : ''}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={data.page <= 1}
+              aria-label="Previous page of upcoming sessions"
+            >
+              Previous
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={data.page >= data.totalPages}
+              aria-label="Next page of upcoming sessions"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/api/admin/upcoming-sessions/route.ts
+++ b/src/app/api/admin/upcoming-sessions/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin, paginate } from '@/lib/api/admin';
+import {
+  buildUpcomingSessionRows,
+  getTodayLocalDate,
+  getUpcomingQueryFloor,
+  type GameDisplayInfo,
+} from '@/lib/upcomingSessions';
+import { paginateArray } from '@/lib/pagination';
+import type { GameSession, AdminUpcomingSessionRow } from '@/types';
+
+// Rows per page for the "Upcoming Games" admin table.
+const PAGE_SIZE = 20;
+
+interface GameWithGmNameRow {
+  id: string;
+  name: string;
+  timezone: string | null;
+  gm: { name: string } | null;
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  try {
+    const result = await requireAdmin();
+    if (result instanceof NextResponse) return result;
+    const { admin } = result;
+
+    const pageParam = Number(request.nextUrl.searchParams.get('page'));
+    const page = Number.isFinite(pageParam) && pageParam >= 1 ? Math.floor(pageParam) : 1;
+
+    const nowMs = Date.now();
+    const today = getTodayLocalDate();
+    // Two-day buffer covers the full UTC-12..UTC+14 span; buildUpcomingSessionRows
+    // then trims precisely against each game's own timezone (see DashboardContent).
+    const floor = getUpcomingQueryFloor(nowMs);
+
+    const [sessions, games] = await Promise.all([
+      paginate<GameSession>(admin, 'sessions', '*', { dateColumn: 'date', cutoff: floor }),
+      paginate<GameWithGmNameRow>(
+        admin,
+        'games',
+        'id, name, timezone, gm:users!games_gm_id_fkey(name)'
+      ),
+    ]);
+
+    const gameInfo = new Map<string, GameDisplayInfo & { gmName: string }>(
+      games.map((g) => [
+        g.id,
+        { name: g.name, timezone: g.timezone, gmName: g.gm?.name ?? 'Unknown' },
+      ])
+    );
+
+    const rows: AdminUpcomingSessionRow[] = buildUpcomingSessionRows(
+      sessions,
+      gameInfo,
+      today,
+      nowMs
+    ).map((row) => ({
+      ...row,
+      gmName: gameInfo.get(row.gameId)?.gmName ?? 'Unknown',
+    }));
+
+    const { items, pageSize, total, totalPages } = paginateArray(rows, page, PAGE_SIZE);
+
+    return NextResponse.json({
+      sessions: items,
+      total,
+      page,
+      pageSize,
+      totalPages,
+    });
+  } catch (error) {
+    console.error('Admin upcoming sessions error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePage, paginateArray } from './pagination';
+
+describe('normalizePage', () => {
+  it('clamps page numbers below 1 to 1', () => {
+    expect(normalizePage(0)).toBe(1);
+    expect(normalizePage(-5)).toBe(1);
+  });
+
+  it('clamps NaN to 1', () => {
+    expect(normalizePage(NaN)).toBe(1);
+  });
+
+  it('floors fractional page numbers', () => {
+    expect(normalizePage(2.9)).toBe(2);
+  });
+
+  it('passes through valid integer pages unchanged', () => {
+    expect(normalizePage(3)).toBe(3);
+  });
+});
+
+describe('paginateArray', () => {
+  it('returns an empty page with zero totalPages for an empty list', () => {
+    const result = paginateArray<number>([], 1, 20);
+    expect(result).toEqual({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 });
+  });
+
+  it('returns exactly one full page when total is an exact multiple of pageSize', () => {
+    const items = Array.from({ length: 40 }, (_, i) => i);
+    const page1 = paginateArray(items, 1, 20);
+    const page2 = paginateArray(items, 2, 20);
+
+    expect(page1.items).toHaveLength(20);
+    expect(page1.items[0]).toBe(0);
+    expect(page1.totalPages).toBe(2);
+
+    expect(page2.items).toHaveLength(20);
+    expect(page2.items[0]).toBe(20);
+    expect(page2.totalPages).toBe(2);
+  });
+
+  it('returns an empty items array with correct total/totalPages for an overflow page', () => {
+    const items = Array.from({ length: 45 }, (_, i) => i);
+    const result = paginateArray(items, 5, 20);
+
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(45);
+    expect(result.totalPages).toBe(3);
+    expect(result.page).toBe(5);
+  });
+
+  it('clamps a page below 1 or NaN to page 1', () => {
+    const items = Array.from({ length: 5 }, (_, i) => i);
+    expect(paginateArray(items, 0, 20).page).toBe(1);
+    expect(paginateArray(items, -3, 20).page).toBe(1);
+    expect(paginateArray(items, NaN, 20).page).toBe(1);
+  });
+});

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,30 @@
+// Pure page-window math shared by paginated admin API routes.
+
+export interface PagedResult<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+/** Clamp a raw page value: NaN or < 1 becomes 1; otherwise floor to an integer. */
+export function normalizePage(rawPage: number): number {
+  if (!Number.isFinite(rawPage) || rawPage < 1) return 1;
+  return Math.floor(rawPage);
+}
+
+/**
+ * Slice a full array of items into a single page, clamping the page number
+ * and computing the total page count. A page past the end returns an empty
+ * `items` array with the correct `total`/`totalPages`.
+ */
+export function paginateArray<T>(items: T[], rawPage: number, pageSize: number): PagedResult<T> {
+  const page = normalizePage(rawPage);
+  const total = items.length;
+  const totalPages = pageSize > 0 ? Math.ceil(total / pageSize) : 0;
+  const start = (page - 1) * pageSize;
+  const pageItems = items.slice(start, start + pageSize);
+
+  return { items: pageItems, page, pageSize, total, totalPages };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // Database types
 
 import type { SchedulingWindowMonths } from "@/lib/constants";
+import type { UpcomingSessionRow } from "@/lib/upcomingSessions";
 
 export interface User {
   id: string;
@@ -98,6 +99,11 @@ export interface MemberWithRole extends User {
 export interface GameWithMembers extends Game {
   gm: User;
   members: MemberWithRole[];
+}
+
+/** Admin "Upcoming Games" row: an upcoming session row plus the game's GM name. */
+export interface AdminUpcomingSessionRow extends UpcomingSessionRow {
+  gmName: string;
 }
 
 // Supabase query result types for relations


### PR DESCRIPTION
## Summary

Adds an **Upcoming Games** tab to the admin dashboard showing upcoming sessions across all games in the system, paginated 20 per page and ordered soonest first.

- **New admin API route** `GET /api/admin/upcoming-sessions?page=N` — `requireAdmin()` guard, service-role client (RLS scopes sessions to participants, so the cross-game view must bypass it server-side), reuses the dashboard's timezone-correct upcoming-sessions engine (`getUpcomingQueryFloor` + `buildUpcomingSessionRows`) and joins GM names via `games_gm_id_fkey`. Page-window math extracted to pure helpers in `src/lib/pagination.ts`.
- **New tab UI** in `src/app/admin/page.tsx` — self-fetching panel (EngagementCharts pattern): date with Today/Tomorrow badge, game-local time honoring the 12/24h preference, game name linking to `/admin/games/[id]`, GM, location, Previous/Next pager. Table scrolls horizontally on mobile inside its own container.
- **Responsive fix**: the tab nav now uses `overflow-x-auto` + `whitespace-nowrap` — with five tabs the bar overflowed a 390px viewport at page level (whole document panned sideways); the tab row now scrolls within itself.
- **Locator hygiene**: tightened two pre-existing `/games/i` button locators in `dashboard.spec.ts` that the new "Upcoming Games" button would otherwise match.

## Test plan

- [x] Unit: 8 new tests for the pagination helpers (empty list, exact page-size multiple, overflow page, NaN/negative clamping) — full suite 557 passed
- [x] E2E: new `admin/upcoming-games.spec.ts` — tab visibility, rows from multiple games, cross-page soonest-first ordering via uniquely-tagged marker rows (robust to concurrent seeding in the fullyParallel shared-DB suite), pager bounds forward and back, empty state (mocked response, matching the outage-banner precedent)
- [x] Full e2e suite: 297 passed
- [x] `npm run lint` and `npm run build` clean
- [x] Manual browser validation at desktop (1440px) and mobile (390px) widths against local Supabase: badges, times, pager behavior, no body-level horizontal overflow, no console errors