### PR TITLE
Quick-wins remediation: security hardening, observability, UX fixes, and a session-confirm celebration

### DIFF
--- a/e2e/tests/rls/function-grants.spec.ts
+++ b/e2e/tests/rls/function-grants.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_URL = 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+/**
+ * The blanket `GRANT EXECUTE ON ALL FUNCTIONS ... TO anon` used to re-expose
+ * the SECURITY DEFINER "oracle" helpers (and join_game_by_invite) to
+ * unauthenticated callers via PostgREST RPC. anon must NOT be able to call them.
+ */
+test.describe('Function EXECUTE grants — anon lockdown', () => {
+  const ANON_HEADERS = { apikey: SUPABASE_ANON_KEY, 'Content-Type': 'application/json' };
+
+  for (const fn of ['count_game_players', 'count_future_sessions']) {
+    test(`anon cannot RPC ${fn}`, async ({ request }) => {
+      const res = await request.post(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+        headers: ANON_HEADERS,
+        data: { game_id_param: '00000000-0000-0000-0000-000000000000' },
+      });
+      // PostgREST returns 404 (not in exposed schema for this role) or 403.
+      expect(res.status()).toBeGreaterThanOrEqual(400);
+    });
+  }
+
+  test('anon cannot RPC join_game_by_invite', async ({ request }) => {
+    const res = await request.post(`${SUPABASE_URL}/rest/v1/rpc/join_game_by_invite`, {
+      headers: ANON_HEADERS,
+      data: { invite_code_param: 'AAAAAAAAAA' },
+    });
+    expect(res.status()).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/e2e/tests/rls/function-grants.spec.ts
+++ b/e2e/tests/rls/function-grants.spec.ts
@@ -1,8 +1,24 @@
 import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
 
 const SUPABASE_URL = 'http://localhost:54321';
 const SUPABASE_ANON_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+// Every SECURITY DEFINER helper reachable via PostgREST RPC, with its argument
+// signature. anon must hold NO EXECUTE on any of them; authenticated must.
+const HELPERS: Array<[string, string]> = [
+  ['count_game_players', 'uuid'],
+  ['count_future_sessions', 'uuid'],
+  ['count_user_games', 'uuid'],
+  ['is_game_participant', 'uuid, uuid'],
+  ['is_game_gm_or_co_gm', 'uuid, uuid'],
+  ['is_membership_co_gm', 'uuid, uuid'],
+  ['shares_game_with', 'uuid'],
+  ['join_game_by_invite', 'text'],
+];
 
 /**
  * The blanket `GRANT EXECUTE ON ALL FUNCTIONS ... TO anon` used to re-expose
@@ -23,11 +39,36 @@ test.describe('Function EXECUTE grants — anon lockdown', () => {
     });
   }
 
-  test('anon cannot RPC join_game_by_invite', async ({ request }) => {
+  // NOTE: a behavioral REST probe of join_game_by_invite is NOT a reliable grant
+  // check on its own — the function has an internal `RAISE EXCEPTION 'Not
+  // authenticated'` guard, so anon gets a 4xx even if the EXECUTE grant regressed.
+  // The authoritative, function-internals-independent check is the ACL test below.
+  test('anon cannot RPC join_game_by_invite (behavioral smoke)', async ({ request }) => {
     const res = await request.post(`${SUPABASE_URL}/rest/v1/rpc/join_game_by_invite`, {
       headers: ANON_HEADERS,
       data: { invite_code_param: 'AAAAAAAAAA' },
     });
     expect(res.status()).toBeGreaterThanOrEqual(400);
+  });
+
+  // Authoritative lockdown check: query the ACL directly. This does not depend on
+  // any function's internal guards or on PostgREST's error-code choices, so it
+  // cannot false-pass the way the REST probes can — anon must have NO EXECUTE and
+  // authenticated must have EXECUTE on every helper, including join_game_by_invite.
+  test('anon holds no EXECUTE and authenticated holds EXECUTE on every helper (ACL)', () => {
+    const projection = HELPERS.map(
+      ([name, args]) =>
+        `has_function_privilege('anon','public.${name}(${args})','EXECUTE') AS anon_${name}, ` +
+        `has_function_privilege('authenticated','public.${name}(${args})','EXECUTE') AS auth_${name}`
+    ).join(', ');
+    const out = execSync(`psql "${DB_URL}" -tAc "SELECT ${projection};"`, {
+      encoding: 'utf8',
+    }).trim();
+    const vals = out.split('|').map((v) => v.trim());
+    expect(vals).toHaveLength(HELPERS.length * 2);
+    HELPERS.forEach(([name], i) => {
+      expect(vals[i * 2], `anon must NOT hold EXECUTE on ${name}`).toBe('f');
+      expect(vals[i * 2 + 1], `authenticated must hold EXECUTE on ${name}`).toBe('t');
+    });
   });
 });

--- a/e2e/tests/rls/function-volatility.spec.ts
+++ b/e2e/tests/rls/function-volatility.spec.ts
@@ -2,30 +2,60 @@ import { test, expect } from '@playwright/test';
 import { execSync } from 'node:child_process';
 
 const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
-const HELPERS = [
+
+// Identity/participation helpers are evaluated per-row in SELECT/UPDATE/DELETE
+// USING clauses over multi-row scans. Their boolean answer does not depend on
+// rows being inserted in the same statement, so STABLE is both a real
+// performance win (evaluate once per game_id instead of once per row) and safe.
+const STABLE_HELPERS = [
   'is_game_participant',
   'is_game_gm_or_co_gm',
   'is_membership_co_gm',
-  'count_user_games',
-  'count_game_players',
-  'count_future_sessions',
   'shares_game_with',
 ];
 
-/**
- * Read-only RLS helpers must be STABLE (provolatile='s') so the planner
- * evaluates them once per statement instead of once per row.
- */
-test('read-only RLS helpers are declared STABLE', () => {
-  const list = HELPERS.map((h) => `'${h}'`).join(',');
+// Count-based limit helpers are used in INSERT ... WITH CHECK cap guards. They
+// MUST stay VOLATILE: a STABLE count is evaluated once per statement against the
+// statement-start snapshot, so a single multi-row INSERT (e.g. a PostgREST array
+// insert sent directly by an authenticated user) sees the same pre-insert count
+// for every row and slips past the cap. VOLATILE re-evaluates per row and sees
+// the rows accumulating, so the cap holds. See usage-limits-bulk.spec.ts for the
+// behavioral proof.
+const VOLATILE_HELPERS = [
+  'count_user_games',
+  'count_game_players',
+  'count_future_sessions',
+];
+
+function volatilityOf(names: string[]): Map<string, string> {
+  const list = names.map((h) => `'${h}'`).join(',');
   const out = execSync(
     `psql "${DB_URL}" -tAc "SELECT proname, provolatile FROM pg_proc ` +
       `WHERE pronamespace='public'::regnamespace AND proname IN (${list}) ORDER BY proname;"`,
     { encoding: 'utf8' }
   ).trim();
-  const rows = out.split('\n').map((l) => l.split('|'));
-  expect(rows).toHaveLength(HELPERS.length);
-  for (const [name, vol] of rows) {
-    expect(vol, `${name} should be STABLE`).toBe('s');
-  }
+  return new Map(
+    out.split('\n').map((line) => {
+      const [name, vol] = line.split('|');
+      return [name, vol] as [string, string];
+    })
+  );
+}
+
+test.describe('RLS helper volatility', () => {
+  test('identity helpers are STABLE (per-statement eval, safe for boolean checks)', () => {
+    const vol = volatilityOf(STABLE_HELPERS);
+    expect(vol.size).toBe(STABLE_HELPERS.length);
+    for (const name of STABLE_HELPERS) {
+      expect(vol.get(name), `${name} should be STABLE`).toBe('s');
+    }
+  });
+
+  test('count-based limit helpers are VOLATILE (so bulk inserts cannot bypass caps)', () => {
+    const vol = volatilityOf(VOLATILE_HELPERS);
+    expect(vol.size).toBe(VOLATILE_HELPERS.length);
+    for (const name of VOLATILE_HELPERS) {
+      expect(vol.get(name), `${name} must be VOLATILE to prevent cap bypass`).toBe('v');
+    }
+  });
 });

--- a/e2e/tests/rls/function-volatility.spec.ts
+++ b/e2e/tests/rls/function-volatility.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+const HELPERS = [
+  'is_game_participant',
+  'is_game_gm_or_co_gm',
+  'is_membership_co_gm',
+  'count_user_games',
+  'count_game_players',
+  'count_future_sessions',
+  'shares_game_with',
+];
+
+/**
+ * Read-only RLS helpers must be STABLE (provolatile='s') so the planner
+ * evaluates them once per statement instead of once per row.
+ */
+test('read-only RLS helpers are declared STABLE', () => {
+  const list = HELPERS.map((h) => `'${h}'`).join(',');
+  const out = execSync(
+    `psql "${DB_URL}" -tAc "SELECT proname, provolatile FROM pg_proc ` +
+      `WHERE pronamespace='public'::regnamespace AND proname IN (${list}) ORDER BY proname;"`,
+    { encoding: 'utf8' }
+  ).trim();
+  const rows = out.split('\n').map((l) => l.split('|'));
+  expect(rows).toHaveLength(HELPERS.length);
+  for (const [name, vol] of rows) {
+    expect(vol, `${name} should be STABLE`).toBe('s');
+  }
+});

--- a/e2e/tests/rls/usage-limits-bulk.spec.ts
+++ b/e2e/tests/rls/usage-limits-bulk.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { createTestUser } from '../../helpers/test-auth';
+import { getAdminClient } from '../../helpers/seed';
+import { USAGE_LIMITS } from '../../../src/lib/constants';
+
+const SUPABASE_URL = 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+const admin = getAdminClient();
+
+/**
+ * Regression guard for the STABLE-count cap-bypass (found in review, 2026-07).
+ *
+ * The per-user game cap and per-game session cap are enforced only by count_*
+ * helper functions in RLS INSERT ... WITH CHECK clauses. If those helpers are
+ * STABLE, a single multi-row INSERT — which an authenticated user can send
+ * directly to PostgREST as an array body, bypassing the app entirely —
+ * evaluates the count ONCE against the statement-start snapshot, so every row
+ * sees the same pre-insert count and the cap is bypassed. The helpers must be
+ * VOLATILE so the cap is re-checked as rows accumulate within the statement.
+ *
+ * This test drives the real PostgREST surface as an *authenticated* user (NOT
+ * the admin/service-role client, which bypasses RLS) — the actual attack path.
+ */
+test('games cap holds against a bulk array-insert by an authenticated user', async ({ request }) => {
+  test.setTimeout(60000);
+  const cap = USAGE_LIMITS.MAX_GAMES_PER_USER; // 20
+
+  const gm = await createTestUser(request, {
+    email: `bulk-cap-${Date.now()}@e2e.local`,
+    name: 'Bulk Cap GM',
+    is_gm: true,
+  });
+
+  // Seed to one below the cap via the admin client (bypasses RLS — fast setup).
+  const seed = Array.from({ length: cap - 1 }, (_, i) => ({
+    name: `Seed ${i}`,
+    gm_id: gm.id,
+    invite_code: `bulkcap-${Date.now()}-${i}`,
+    play_days: [5],
+  }));
+  const { error: seedErr } = await admin.from('games').insert(seed);
+  expect(seedErr).toBeNull();
+
+  // Get a real access token for the user (test-auth creates them with this password).
+  const tokenRes = await request.post(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    headers: { apikey: SUPABASE_ANON_KEY, 'Content-Type': 'application/json' },
+    data: { email: gm.email, password: 'test-password-123!' },
+  });
+  expect(tokenRes.ok()).toBeTruthy();
+  const { access_token } = await tokenRes.json();
+
+  // As the authenticated user, attempt to insert 5 games in ONE request — a
+  // single multi-row INSERT. With 19 games already present and the cap at 20,
+  // at most one row could be admitted; a STABLE count would let all 5 through.
+  const bulk = Array.from({ length: 5 }, (_, i) => ({
+    name: `Bulk ${i}`,
+    gm_id: gm.id,
+    invite_code: `bulkins-${Date.now()}-${i}`,
+    play_days: [5],
+  }));
+  const insertRes = await request.post(`${SUPABASE_URL}/rest/v1/games`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${access_token}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    data: bulk,
+  });
+
+  // The security invariant: the user's game count must never exceed the cap,
+  // whatever the HTTP status. (VOLATILE → the statement is rejected atomically
+  // and the count stays 19; STABLE → all 5 land and the count becomes 24.)
+  const { count } = await admin
+    .from('games')
+    .select('*', { count: 'exact', head: true })
+    .eq('gm_id', gm.id);
+  expect(count ?? 0).toBeLessThanOrEqual(cap);
+
+  // And PostgREST must have rejected the over-cap statement outright.
+  const body = await insertRes.text();
+  expect(insertRes.status(), body).toBeGreaterThanOrEqual(400);
+});

--- a/e2e/tests/settings/profile.spec.ts
+++ b/e2e/tests/settings/profile.spec.ts
@@ -142,4 +142,29 @@ test.describe('Settings Profile', () => {
     });
   });
 
+  test('empty display name shows an error in danger color, not success', async ({ page }) => {
+    await loginTestUser(page, {
+      email: `user-empty-name-${Date.now()}@e2e.local`,
+      name: 'Has A Name',
+      is_gm: false,
+    });
+
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // Use placeholder since the Display Name label isn't associated via id/htmlFor
+    const nameInput = page.getByPlaceholder(/your name/i);
+    await expect(nameInput).toHaveValue('Has A Name', { timeout: TEST_TIMEOUTS.DEFAULT });
+
+    await nameInput.fill('');
+    await page.getByRole('button', { name: /save changes/i }).click();
+
+    const msg = page.getByText('Display name cannot be empty.');
+    await expect(msg).toBeVisible();
+    await expect(msg).toHaveClass(/text-danger/);
+    await expect(msg).not.toHaveClass(/text-success/);
+  });
+
 });

--- a/src/app/api/admin/engagement/route.ts
+++ b/src/app/api/admin/engagement/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin, paginate } from '@/lib/api/admin';
 import { buildRollingEngagement } from '@/lib/adminEngagement';
 import { startOfDay, subDays, format } from 'date-fns';
+import { serverError } from '@/lib/apiError';
 
 const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -63,10 +64,6 @@ export async function GET(request: NextRequest): Promise<Response> {
 
     return NextResponse.json(responseData);
   } catch (error) {
-    console.error('Admin engagement error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return serverError(error, { route: '/api/admin/engagement' });
   }
 }

--- a/src/app/api/admin/games/[id]/route.ts
+++ b/src/app/api/admin/games/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   fetchGameSessions,
   fetchGamePlayDates,
 } from '@/lib/data';
+import { serverError } from '@/lib/apiError';
 
 /**
  * Read-only snapshot of a game for the admin peek view. Uses the service-role
@@ -44,7 +45,6 @@ export async function GET(
       playDates: playDatesRes.data ?? [],
     });
   } catch (error) {
-    console.error('Admin game snapshot error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return serverError(error, { route: '/api/admin/games/[id]' });
   }
 }

--- a/src/app/api/admin/games/route.ts
+++ b/src/app/api/admin/games/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAdmin, paginate } from '@/lib/api/admin';
 import { calculateGameFillRate } from '@/lib/availability';
 import { calculateGameHealth, type HealthBreakdown, type HealthGrade } from '@/lib/gameHealth';
+import { serverError } from '@/lib/apiError';
 
 interface GameWithEngagement {
   id: string;
@@ -152,10 +153,6 @@ export async function GET(): Promise<Response> {
 
     return NextResponse.json({ games: gamesWithEngagement });
   } catch (error) {
-    console.error('Admin games error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return serverError(error, { route: '/api/admin/games' });
   }
 }

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAdmin } from '@/lib/api/admin';
+import { serverError } from '@/lib/apiError';
 
 export async function GET(): Promise<Response> {
   try {
@@ -29,7 +30,6 @@ export async function GET(): Promise<Response> {
       recentGames: recentGamesResult.data ?? [],
     });
   } catch (error) {
-    console.error('Admin stats error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return serverError(error, { route: '/api/admin/stats' });
   }
 }

--- a/src/app/api/admin/top-users/route.ts
+++ b/src/app/api/admin/top-users/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAdmin, paginate } from '@/lib/api/admin';
 import { computeTopUsers, type TopUserProfile } from '@/lib/topUsers';
+import { serverError } from '@/lib/apiError';
 
 export async function GET(): Promise<Response> {
   try {
@@ -20,7 +21,6 @@ export async function GET(): Promise<Response> {
       computeTopUsers({ users, games, memberships, sessions, availability })
     );
   } catch (error) {
-    console.error('Admin top users error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return serverError(error, { route: '/api/admin/top-users' });
   }
 }

--- a/src/app/api/admin/upcoming-sessions/route.ts
+++ b/src/app/api/admin/upcoming-sessions/route.ts
@@ -7,6 +7,7 @@ import {
   type GameDisplayInfo,
 } from '@/lib/upcomingSessions';
 import { paginateArray } from '@/lib/pagination';
+import { serverError } from '@/lib/apiError';
 import type { GameSession, AdminUpcomingSessionRow } from '@/types';
 
 // Rows per page for the "Upcoming Games" admin table.
@@ -70,7 +71,6 @@ export async function GET(request: NextRequest): Promise<Response> {
       totalPages,
     });
   } catch (error) {
-    console.error('Admin upcoming sessions error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return serverError(error, { route: '/api/admin/upcoming-sessions' });
   }
 }

--- a/src/app/api/games/calendar/[code]/route.ts
+++ b/src/app/api/games/calendar/[code]/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateICS, composeIcsDescription } from '@/lib/ics';
 import type { Game, GameSession } from '@/types';
+import { serverError } from '@/lib/apiError';
 
 /**
  * Public endpoint for calendar subscription feeds.
@@ -86,7 +87,6 @@ export async function GET(
       },
     });
   } catch (error) {
-    console.error('Calendar feed error:', error);
-    return new Response('Internal server error', { status: 500 });
+    return serverError(error, { route: '/api/games/calendar/[code]' });
   }
 }

--- a/src/app/api/games/invite/[code]/route.ts
+++ b/src/app/api/games/invite/[code]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { serverError } from '@/lib/apiError';
 
 /**
  * Fetches game details by invite code.
@@ -85,10 +86,6 @@ export async function GET(
       playerCount,
     });
   } catch (error) {
-    console.error('Invite lookup error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return serverError(error, { route: '/api/games/invite/[code]' });
   }
 }

--- a/src/app/api/games/preview/[code]/route.ts
+++ b/src/app/api/games/preview/[code]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { GameWithGMNameResult } from '@/types';
+import { serverError } from '@/lib/apiError';
 
 /**
  * Public endpoint for OG crawlers to fetch game preview data.
@@ -46,10 +47,6 @@ export async function GET(
       gm_name: typedGame.gm?.name || 'Unknown',
     });
   } catch (error) {
-    console.error('Preview lookup error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return serverError(error, { route: '/api/games/preview/[code]' });
   }
 }

--- a/src/app/api/test-auth/route.ts
+++ b/src/app/api/test-auth/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { isLocalSupabase } from '@/lib/supabase/env';
 
 /**
  * Test-only authentication route for E2E testing.
@@ -35,7 +36,9 @@ interface TestUserResponse {
 
 export async function POST(request: Request): Promise<Response> {
   // SECURITY: Only allow in development (not 403 to avoid revealing route exists)
-  if (process.env.NODE_ENV !== 'development') {
+  // Defense in depth: dev-only AND only against local Supabase, so this can
+  // never mint an admin against cloud creds even if NODE_ENV is misconfigured.
+  if (process.env.NODE_ENV !== 'development' || !isLocalSupabase()) {
     return new Response('Not found', { status: 404 });
   }
 
@@ -185,7 +188,9 @@ export async function POST(request: Request): Promise<Response> {
 
 // Also support DELETE to clean up test users
 export async function DELETE(request: Request): Promise<Response> {
-  if (process.env.NODE_ENV !== 'development') {
+  // Defense in depth: dev-only AND only against local Supabase, so this can
+  // never mint an admin against cloud creds even if NODE_ENV is misconfigured.
+  if (process.env.NODE_ENV !== 'development' || !isLocalSupabase()) {
     return new Response('Not found', { status: 404 });
   }
 
@@ -237,7 +242,9 @@ export async function DELETE(request: Request): Promise<Response> {
 
 // Sign out the current user
 export async function PUT(request: Request): Promise<Response> {
-  if (process.env.NODE_ENV !== 'development') {
+  // Defense in depth: dev-only AND only against local Supabase, so this can
+  // never mint an admin against cloud creds even if NODE_ENV is misconfigured.
+  if (process.env.NODE_ENV !== 'development' || !isLocalSupabase()) {
     return new Response('Not found', { status: 404 });
   }
 

--- a/src/app/dev-login/actions.ts
+++ b/src/app/dev-login/actions.ts
@@ -3,6 +3,7 @@
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { isLocalSupabase } from '@/lib/supabase/env';
 
 interface DevUser {
   email: string;
@@ -17,11 +18,6 @@ const DEV_USERS: Record<string, DevUser> = {
   player2: { email: 'dev-player2@dev.local', name: 'Dev Player 2', is_gm: true, is_admin: false },
   admin: { email: 'dev-admin@dev.local', name: 'Dev Admin', is_gm: true, is_admin: true },
 };
-
-function isLocalSupabase(): boolean {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-  return url.includes('localhost') || url.includes('127.0.0.1');
-}
 
 export async function loginAsDevUser(persona: string): Promise<{ success: boolean; error?: string; user?: DevUser }> {
   if (process.env.NODE_ENV !== 'development') {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -563,5 +563,3 @@ body {
 .dice-filled rect {
   fill: var(--background);
 }
-
-

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,7 @@
   --warning-muted: #92400e;
   --danger: #dc2626;
   --danger-muted: #b91c1c;
+  --danger-foreground: #ffffff;
   --scheduled: #0ea5e9;
 
   --cal-available-bg: #22c55e;
@@ -83,6 +84,7 @@
   --warning-muted: #f59e0b;
   --danger: #f87171;
   --danger-muted: #ef4444;
+  --danger-foreground: #450a0a;
   --scheduled: #38bdf8;
 
   --cal-available-bg: #15803d;
@@ -144,6 +146,7 @@
   --warning-muted: #92400e;
   --danger: #dc2626;
   --danger-muted: #b91c1c;
+  --danger-foreground: #ffffff;
   --scheduled: #7c3aed;
 
   --cal-available-bg: #22c55e;
@@ -185,6 +188,7 @@
   --warning-muted: #f59e0b;
   --danger: #f87171;
   --danger-muted: #ef4444;
+  --danger-foreground: #450a0a;
   --scheduled: #a78bfa;
 
   --cal-available-bg: #15803d;
@@ -229,6 +233,7 @@
   --warning-muted: #92400e;
   --danger: #dc2626;
   --danger-muted: #b91c1c;
+  --danger-foreground: #ffffff;
   --scheduled: #16a34a;
 
   --cal-available-bg: #22c55e;
@@ -270,6 +275,7 @@
   --warning-muted: #f59e0b;
   --danger: #f87171;
   --danger-muted: #ef4444;
+  --danger-foreground: #450a0a;
   --scheduled: #4ade80;
 
   --cal-available-bg: #15803d;
@@ -314,6 +320,7 @@
   --warning-muted: #92400e;
   --danger: #dc2626;
   --danger-muted: #b91c1c;
+  --danger-foreground: #ffffff;
   --scheduled: #475569;
 
   --cal-available-bg: #22c55e;
@@ -355,6 +362,7 @@
   --warning-muted: #f59e0b;
   --danger: #f87171;
   --danger-muted: #ef4444;
+  --danger-foreground: #450a0a;
   --scheduled: #94a3b8;
 
   --cal-available-bg: #15803d;
@@ -399,6 +407,7 @@
   --warning-muted: #92400e;
   --danger: #dc2626;
   --danger-muted: #b91c1c;
+  --danger-foreground: #ffffff;
   --scheduled: #e11d48;
 
   --cal-available-bg: #22c55e;
@@ -440,6 +449,7 @@
   --warning-muted: #f59e0b;
   --danger: #f87171;
   --danger-muted: #ef4444;
+  --danger-foreground: #450a0a;
   --scheduled: #fb7185;
 
   --cal-available-bg: #15803d;
@@ -480,6 +490,7 @@
   --color-warning-muted: var(--warning-muted);
   --color-danger: var(--danger);
   --color-danger-muted: var(--danger-muted);
+  --color-danger-foreground: var(--danger-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,7 +17,9 @@ export default function SettingsPage() {
   const [weekStartDay, setWeekStartDay] = useState(0);
   const [timeFormat, setTimeFormat] = useState('12h');
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState<{ text: string; tone: 'success' | 'danger' } | null>(
+    null
+  );
   const supabase = createClient();
 
   useAuthRedirect();
@@ -45,16 +47,19 @@ export default function SettingsPage() {
     if (!profile?.id) return;
 
     if (!name.trim()) {
-      setMessage('Display name cannot be empty.');
+      setMessage({ text: 'Display name cannot be empty.', tone: 'danger' });
       return;
     }
     if (name.length > TEXT_LIMITS.USER_DISPLAY_NAME) {
-      setMessage(`Display name must be ${TEXT_LIMITS.USER_DISPLAY_NAME} characters or less.`);
+      setMessage({
+        text: `Display name must be ${TEXT_LIMITS.USER_DISPLAY_NAME} characters or less.`,
+        tone: 'danger',
+      });
       return;
     }
 
     setSaving(true);
-    setMessage('');
+    setMessage(null);
 
     const { error } = await supabase
       .from('users')
@@ -68,12 +73,15 @@ export default function SettingsPage() {
 
     if (error) {
       if (error.code === '23514') {
-        setMessage(`Display name must be ${TEXT_LIMITS.USER_DISPLAY_NAME} characters or less.`);
+        setMessage({
+          text: `Display name must be ${TEXT_LIMITS.USER_DISPLAY_NAME} characters or less.`,
+          tone: 'danger',
+        });
       } else {
-        setMessage('Error saving settings. Please try again.');
+        setMessage({ text: 'Error saving settings. Please try again.', tone: 'danger' });
       }
     } else {
-      setMessage('Settings saved successfully!');
+      setMessage({ text: 'Settings saved successfully!', tone: 'success' });
       await refreshProfile();
     }
 
@@ -219,10 +227,8 @@ export default function SettingsPage() {
         </Panel>
 
         {message && (
-          <p
-            className={`text-sm ${message.includes('Error') ? 'text-danger' : 'text-success'}`}
-          >
-            {message}
+          <p className={`text-sm ${message.tone === 'danger' ? 'text-danger' : 'text-success'}`}>
+            {message.text}
           </p>
         )}
 

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -15,7 +15,6 @@ import { CalendarHoverPopover } from './CalendarHoverPopover';
 import { generateICS, slugifyGameName, triggerICSDownload, composeIcsDescription } from '@/lib/ics';
 import { splitUpcomingPast } from '@/lib/scheduleView';
 import { useToast } from '@/components/ui/Toast';
-import { useCelebration } from '@/components/ui/CelebrationBurst';
 import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 
 export interface ScheduleTabContentProps {
@@ -64,7 +63,9 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
   } = props;
 
   const toast = useToast();
-  const { celebrate, overlay: celebrationOverlay } = useCelebration();
+  // Date of a session just confirmed, so its row glows as it appears (cleared
+  // by the row once the glow finishes). Null when nothing is celebrating.
+  const [celebrateDate, setCelebrateDate] = useState<string | null>(null);
   const [scheduleFor, setScheduleFor] = useState<string | null>(null);
   const [cancelFor, setCancelFor] = useState<GameSession | null>(null);
   // editFor is set via onEditDetails in ScheduledList (added in a later task);
@@ -106,7 +107,10 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
     if (!scheduleFor) return { success: false, error: 'No date selected' };
     const res = await onConfirm(scheduleFor, values.start, values.end, values.location, values.notes);
     if (res.success) {
-      celebrate();
+      const reduceMotion =
+        typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+      if (!reduceMotion) setCelebrateDate(scheduleFor);
       toast.show(`Scheduled ${format(parseISO(scheduleFor), 'MMM d')}.`);
     }
     return res;
@@ -206,6 +210,8 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
               gmId={gmId}
               coGmIds={coGmIds}
               playDateNotes={playDateNotes}
+              celebrateDate={celebrateDate}
+              onCelebrationDone={() => setCelebrateDate(null)}
               onDownloadIcs={handleDownloadIcs}
               onDownloadAllIcs={handleDownloadAllIcs}
               onRequestCancel={(s) => setCancelFor(s)}
@@ -266,8 +272,6 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
         />
 
         <CalendarHoverPopover suggestions={suggestions} scheduledDates={scheduledDates} />
-
-        {celebrationOverlay}
       </div>
     </HoverSyncProvider>
   );

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -15,6 +15,7 @@ import { CalendarHoverPopover } from './CalendarHoverPopover';
 import { generateICS, slugifyGameName, triggerICSDownload, composeIcsDescription } from '@/lib/ics';
 import { splitUpcomingPast } from '@/lib/scheduleView';
 import { useToast } from '@/components/ui/Toast';
+import { useCelebration } from '@/components/ui/CelebrationBurst';
 import { CalendarSubscribeButton } from '@/components/games/CalendarSubscribeButton';
 
 export interface ScheduleTabContentProps {
@@ -63,6 +64,7 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
   } = props;
 
   const toast = useToast();
+  const { celebrate, overlay: celebrationOverlay } = useCelebration();
   const [scheduleFor, setScheduleFor] = useState<string | null>(null);
   const [cancelFor, setCancelFor] = useState<GameSession | null>(null);
   // editFor is set via onEditDetails in ScheduledList (added in a later task);
@@ -104,6 +106,7 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
     if (!scheduleFor) return { success: false, error: 'No date selected' };
     const res = await onConfirm(scheduleFor, values.start, values.end, values.location, values.notes);
     if (res.success) {
+      celebrate();
       toast.show(`Scheduled ${format(parseISO(scheduleFor), 'MMM d')}.`);
     }
     return res;
@@ -263,6 +266,8 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
         />
 
         <CalendarHoverPopover suggestions={suggestions} scheduledDates={scheduledDates} />
+
+        {celebrationOverlay}
       </div>
     </HoverSyncProvider>
   );

--- a/src/components/games/schedule/ScheduledList.tsx
+++ b/src/components/games/schedule/ScheduledList.tsx
@@ -17,6 +17,9 @@ interface ScheduledListProps {
   gmId: string;
   coGmIds: Set<string>;
   playDateNotes: Map<string, string> | undefined;
+  /** Date of a just-confirmed session whose row should glow as it appears. */
+  celebrateDate?: string | null;
+  onCelebrationDone?: () => void;
   onDownloadIcs: (session: GameSession) => void;
   onDownloadAllIcs: () => void;
   onRequestCancel: (session: GameSession) => void;
@@ -25,6 +28,7 @@ interface ScheduledListProps {
 
 export function ScheduledList({
   sessions, suggestions, timezone, userTimezone, use24h, isGm, gmId, coGmIds, playDateNotes,
+  celebrateDate, onCelebrationDone,
   onDownloadIcs, onDownloadAllIcs, onRequestCancel, onEditDetails,
 }: ScheduledListProps) {
   const [showPast, setShowPast] = useState(false);
@@ -62,6 +66,8 @@ export function ScheduledList({
                 gmId={gmId}
                 coGmIds={coGmIds}
                 playDateNote={playDateNotes?.get(s.date) ?? null}
+                celebrate={!!celebrateDate && s.date === celebrateDate}
+                onCelebrationDone={onCelebrationDone}
                 onDownloadIcs={onDownloadIcs}
                 onRequestCancel={onRequestCancel}
                 onEditDetails={onEditDetails}

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -150,7 +150,7 @@ export function ScheduledRow({
       ref={rowRef}
       data-testid={past ? 'past-session-row' : 'scheduled-row'}
       className={`rounded-xl border border-border bg-card p-4 ${past ? 'opacity-70' : ''} ${
-        celebrate ? 'relative isolate' : ''
+        celebrate ? 'relative isolate overflow-hidden' : ''
       }`}
     >
       {celebrate && <SessionGlow onDone={onCelebrationDone} />}

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -5,7 +5,7 @@ import { format, parseISO } from 'date-fns';
 import { Calendar, ChevronRight, MapPin, Pencil, StickyNote, X } from 'lucide-react';
 import type { DateSuggestion, GameSession } from '@/types';
 import { Button, EyebrowLabel } from '@/components/ui';
-import { SessionGlow } from '@/components/ui/CelebrationBurst';
+import { SessionCelebration } from '@/components/ui/CelebrationBurst';
 import { formatTime } from '@/lib/formatting';
 import { convertTimeForDisplay } from '@/lib/timezone';
 import { PartyBreakdown } from './PartyBreakdown';
@@ -153,7 +153,7 @@ export function ScheduledRow({
         celebrate ? 'relative isolate overflow-hidden' : ''
       }`}
     >
-      {celebrate && <SessionGlow onDone={onCelebrationDone} />}
+      {celebrate && <SessionCelebration onDone={onCelebrationDone} />}
       <div className="flex items-start gap-3">
         <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
         <div className="min-w-0 flex-1">{infoContent}</div>

--- a/src/components/games/schedule/ScheduledRow.tsx
+++ b/src/components/games/schedule/ScheduledRow.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { format, parseISO } from 'date-fns';
 import { Calendar, ChevronRight, MapPin, Pencil, StickyNote, X } from 'lucide-react';
 import type { DateSuggestion, GameSession } from '@/types';
 import { Button, EyebrowLabel } from '@/components/ui';
+import { SessionGlow } from '@/components/ui/CelebrationBurst';
 import { formatTime } from '@/lib/formatting';
 import { convertTimeForDisplay } from '@/lib/timezone';
 import { PartyBreakdown } from './PartyBreakdown';
@@ -51,6 +52,9 @@ interface ScheduledRowProps {
   coGmIds: Set<string>;
   playDateNote: string | null;
   past?: boolean;
+  /** When true, this freshly-confirmed row glows once as it appears. */
+  celebrate?: boolean;
+  onCelebrationDone?: () => void;
   onDownloadIcs: (session: GameSession) => void;
   onRequestCancel: (session: GameSession) => void;
   onEditDetails?: (session: GameSession) => void;
@@ -58,9 +62,19 @@ interface ScheduledRowProps {
 
 export function ScheduledRow({
   session, suggestion, timezone, userTimezone, use24h, isGm, gmId, coGmIds,
-  playDateNote, past = false, onDownloadIcs, onRequestCancel, onEditDetails,
+  playDateNote, past = false, celebrate = false, onCelebrationDone,
+  onDownloadIcs, onRequestCancel, onEditDetails,
 }: ScheduledRowProps) {
   const [expanded, setExpanded] = useState(false);
+  const rowRef = useRef<HTMLLIElement | null>(null);
+
+  // Bring a just-confirmed row into view so its glow is actually seen (no-op if
+  // it's already visible).
+  useEffect(() => {
+    if (celebrate) {
+      rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [celebrate]);
   // Expandable when there's something in the expanded section worth showing:
   // a party breakdown (from suggestion) or the calendar/cancel actions (upcoming only).
   const expandable = !!suggestion || !past;
@@ -133,9 +147,13 @@ export function ScheduledRow({
 
   return (
     <li
+      ref={rowRef}
       data-testid={past ? 'past-session-row' : 'scheduled-row'}
-      className={`rounded-xl border border-border bg-card p-4 ${past ? 'opacity-70' : ''}`}
+      className={`rounded-xl border border-border bg-card p-4 ${past ? 'opacity-70' : ''} ${
+        celebrate ? 'relative isolate' : ''
+      }`}
     >
+      {celebrate && <SessionGlow onDone={onCelebrationDone} />}
       <div className="flex items-start gap-3">
         <span className={`text-lg leading-none ${past ? 'text-muted-foreground' : 'text-primary'}`}>★</span>
         <div className="min-w-0 flex-1">{infoContent}</div>

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Button } from './Button';
+
+describe('Button danger variant', () => {
+  it('uses semantic danger tokens, not hardcoded red', () => {
+    const { getByRole } = render(<Button variant="danger">Delete</Button>);
+    const cls = getByRole('button').className;
+    expect(cls).toContain('bg-danger');
+    expect(cls).toContain('text-danger-foreground');
+    expect(cls).not.toContain('bg-red-600');
+    expect(cls).not.toContain('text-white');
+  });
+});

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -16,7 +16,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       primary: 'bg-primary text-primary-foreground hover:bg-primary/90 focus:ring-ring',
       secondary:
         'bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 focus:ring-ring',
-      danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+      danger: 'bg-danger text-danger-foreground hover:bg-danger-muted focus:ring-danger',
       ghost: 'text-muted-foreground hover:bg-secondary hover:text-foreground focus:ring-ring',
     };
 

--- a/src/components/ui/CelebrationBurst.test.tsx
+++ b/src/components/ui/CelebrationBurst.test.tsx
@@ -1,48 +1,29 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { SessionGlow } from './CelebrationBurst';
+import { SessionCelebration } from './CelebrationBurst';
 
-function stubCanvas2dContext() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (HTMLCanvasElement.prototype as any).getContext = vi.fn(() => ({
-    clearRect: vi.fn(), save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
-    closePath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn(),
-    moveTo: vi.fn(), lineTo: vi.fn(), translate: vi.fn(), rotate: vi.fn(), scale: vi.fn(),
-    globalAlpha: 1, fillStyle: '', strokeStyle: '', lineWidth: 1,
-  }));
-}
-
-function stubRect(width: number, height: number) {
-  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
-    width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0,
-    toJSON: () => ({}),
-  } as DOMRect);
-}
-
-describe('SessionGlow', () => {
-  beforeEach(() => {
-    stubCanvas2dContext();
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
-  });
+describe('SessionCelebration', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('renders a canvas and schedules the glow when it has a drawable box', () => {
-    stubRect(320, 84);
-    const onDone = vi.fn();
-    const { container } = render(<SessionGlow onDone={onDone} />);
-    expect(container.querySelector('canvas')).not.toBeNull();
-    expect(window.requestAnimationFrame).toHaveBeenCalled();
-    expect(onDone).not.toHaveBeenCalled();
+  it('renders the trace rect with fill="none" so it can never be a black box', () => {
+    const { container } = render(<SessionCelebration />);
+    const rect = container.querySelector('svg rect');
+    expect(rect).not.toBeNull();
+    // The fill is an attribute (not a CSS class), so a missing stylesheet can
+    // never leave the SVG rect's default black fill showing.
+    expect(rect?.getAttribute('fill')).toBe('none');
+    expect(container.querySelector('span')).not.toBeNull();
   });
 
-  it('finishes immediately (no animation) when there is no drawable surface', async () => {
-    stubRect(0, 0);
+  it('signals completion via onDone after the celebration finishes', () => {
+    vi.useFakeTimers();
     const onDone = vi.fn();
-    render(<SessionGlow onDone={onDone} />);
-    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
-    await new Promise((r) => setTimeout(r, 0)); // flush queueMicrotask
+    render(<SessionCelebration onDone={onDone} />);
+    expect(onDone).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2100);
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/CelebrationBurst.test.tsx
+++ b/src/components/ui/CelebrationBurst.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { useCelebration } from './CelebrationBurst';
+
+function Harness() {
+  const { celebrate, overlay } = useCelebration();
+  return (
+    <div>
+      <button onClick={celebrate}>go</button>
+      {overlay}
+    </div>
+  );
+}
+
+describe('useCelebration', () => {
+  beforeEach(() => {
+    // Minimal 2D context stub for jsdom
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = vi.fn(() => ({
+      clearRect: vi.fn(), save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
+      arc: vi.fn(), fill: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(),
+      translate: vi.fn(), rotate: vi.fn(), scale: vi.fn(),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      fillRect: vi.fn(), setTransform: vi.fn(),
+      // fields the renderer may set
+      globalAlpha: 1, globalCompositeOperation: 'source-over', fillStyle: '', strokeStyle: '',
+    }));
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => { void cb; return 1; });
+  });
+
+  it('mounts a canvas overlay only after celebrate() is called', () => {
+    const { container, getByText } = render(<Harness />);
+    expect(container.querySelector('canvas')).toBeNull();
+    act(() => { getByText('go').click(); });
+    expect(container.querySelector('canvas')).not.toBeNull();
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/CelebrationBurst.test.tsx
+++ b/src/components/ui/CelebrationBurst.test.tsx
@@ -1,38 +1,48 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, act } from '@testing-library/react';
-import { useCelebration } from './CelebrationBurst';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { SessionGlow } from './CelebrationBurst';
 
-function Harness() {
-  const { celebrate, overlay } = useCelebration();
-  return (
-    <div>
-      <button onClick={celebrate}>go</button>
-      {overlay}
-    </div>
-  );
+function stubCanvas2dContext() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLCanvasElement.prototype as any).getContext = vi.fn(() => ({
+    clearRect: vi.fn(), save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
+    closePath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn(),
+    moveTo: vi.fn(), lineTo: vi.fn(), translate: vi.fn(), rotate: vi.fn(), scale: vi.fn(),
+    globalAlpha: 1, fillStyle: '', strokeStyle: '', lineWidth: 1,
+  }));
 }
 
-describe('useCelebration', () => {
+function stubRect(width: number, height: number) {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+describe('SessionGlow', () => {
   beforeEach(() => {
-    // Minimal 2D context stub for jsdom
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (HTMLCanvasElement.prototype as any).getContext = vi.fn(() => ({
-      clearRect: vi.fn(), save: vi.fn(), restore: vi.fn(), beginPath: vi.fn(),
-      arc: vi.fn(), fill: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(),
-      translate: vi.fn(), rotate: vi.fn(), scale: vi.fn(),
-      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
-      fillRect: vi.fn(), setTransform: vi.fn(),
-      // fields the renderer may set
-      globalAlpha: 1, globalCompositeOperation: 'source-over', fillStyle: '', strokeStyle: '',
-    }));
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => { void cb; return 1; });
+    stubCanvas2dContext();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('mounts a canvas overlay only after celebrate() is called', () => {
-    const { container, getByText } = render(<Harness />);
-    expect(container.querySelector('canvas')).toBeNull();
-    act(() => { getByText('go').click(); });
+  it('renders a canvas and schedules the glow when it has a drawable box', () => {
+    stubRect(320, 84);
+    const onDone = vi.fn();
+    const { container } = render(<SessionGlow onDone={onDone} />);
     expect(container.querySelector('canvas')).not.toBeNull();
     expect(window.requestAnimationFrame).toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('finishes immediately (no animation) when there is no drawable surface', async () => {
+    stubRect(0, 0);
+    const onDone = vi.fn();
+    render(<SessionGlow onDone={onDone} />);
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 0)); // flush queueMicrotask
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/CelebrationBurst.tsx
+++ b/src/components/ui/CelebrationBurst.tsx
@@ -1,72 +1,158 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { CritBurst } from '@/lib/critBurst';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+// Total lifetime of the celebration. Matches the animation timeline below:
+// the border trace + shine sweep run ~900ms, then the glow pulse is delayed
+// ~820ms and lasts ~1050ms.
+const CELEBRATION_MS = 1950;
+const GOLD = '#fbbf24';
 
 /**
- * A one-shot gold glow that blooms behind its positioned parent, reusing the
- * Nat-20 CritBurst's light-ray + shockwave layer (drawBack) — no sparks — so a
- * newly scheduled session appears to light up for a moment as it lands on the
- * page.
+ * One-shot "session confirmed" celebration: a gold border traces around the
+ * card while a shine sweeps across, then a gold glow pulses.
  *
- * Render this as a child of a `relative isolate overflow-hidden` element; the
- * canvas is sized to exactly cover the parent (`inset-0`) so the burst is
- * clipped to the card and never spills onto neighbouring content, and it sits
- * at `-z-10` so it paints over the parent's background but behind its content.
- * The caller must NOT render this when `prefers-reduced-motion` is set.
+ * Deliberately self-contained — all structure is inline-styled, the trace rect
+ * carries `fill="none"` as an attribute, and the motion runs through the Web
+ * Animations API. It does NOT depend on any global stylesheet, so a missing or
+ * stale CSS rule can never leave the SVG rect showing its default black fill.
+ *
+ * Render it inside a `relative isolate overflow-hidden` row; do NOT render it
+ * when prefers-reduced-motion is set (the parent already gates on that).
  */
-export function SessionGlow({ onDone }: { onDone?: () => void }) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+export function SessionCelebration({ onDone }: { onDone?: () => void }) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const rectRef = useRef<SVGRectElement | null>(null);
+  const sheenRef = useRef<HTMLSpanElement | null>(null);
   const onDoneRef = useRef(onDone);
   useEffect(() => {
     onDoneRef.current = onDone;
   });
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    const rect = canvas.getBoundingClientRect();
-    const w = rect.width;
-    const h = rect.height;
-    if (!ctx || w === 0 || h === 0) {
-      // No drawable surface (e.g. jsdom / detached): finish immediately without
-      // a synchronous setState from inside the effect body.
-      queueMicrotask(() => onDoneRef.current?.());
-      return;
+  useLayoutEffect(() => {
+    const finish = () => onDoneRef.current?.();
+    const svg = svgRef.current;
+    const rect = rectRef.current;
+    const sheen = sheenRef.current;
+    const row = svg?.parentElement as HTMLElement | null;
+
+    const reduce =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    const canAnimate = typeof rect?.animate === 'function';
+
+    if (reduce || !svg || !rect || !canAnimate) {
+      const t = setTimeout(finish, 300);
+      return () => clearTimeout(t);
     }
 
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = w * dpr;
-    canvas.height = h * dpr;
-    ctx.scale(dpr, dpr);
+    // Size the trace rect to the card's real pixels (an SVG `%` length would
+    // otherwise resolve against the default 300x150 viewport).
+    const { width, height } = svg.getBoundingClientRect();
+    const w = Math.round(width);
+    const h = Math.round(height);
+    if (w && h) {
+      svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+      rect.setAttribute('x', '1.5');
+      rect.setAttribute('y', '1.5');
+      rect.setAttribute('width', String(w - 3));
+      rect.setAttribute('height', String(h - 3));
+    }
 
-    // Glow centered in the card, scaled to the row height. Kept modest so the
-    // rays read as a backdrop behind the card content rather than an explosion.
-    const burst = new CritBurst(w / 2, h / 2, h * 0.5);
-    let raf = 0;
-    let last: number | null = null;
-    const loop = (now: number) => {
-      const dt = last == null ? 0 : (now - last) / 1000;
-      last = now;
-      ctx.clearRect(0, 0, w, h);
-      burst.step(dt);
-      burst.drawBack(ctx); // glow only — the spark layer (drawFront) is skipped
-      if (!burst.done) {
-        raf = requestAnimationFrame(loop);
-      } else {
-        onDoneRef.current?.();
-      }
+    const anims: Animation[] = [];
+    // Phase 1 — border draws + shine sweeps (together, ~900ms).
+    anims.push(
+      rect.animate(
+        [
+          { strokeDashoffset: '100', opacity: 1 },
+          { strokeDashoffset: '0', opacity: 1, offset: 0.7 },
+          { strokeDashoffset: '0', opacity: 0 },
+        ],
+        { duration: 900, easing: 'ease-in-out', fill: 'forwards' }
+      )
+    );
+    if (sheen) {
+      anims.push(
+        sheen.animate(
+          [
+            { transform: 'translateX(-130%)', opacity: 0 },
+            { opacity: 1, offset: 0.12 },
+            { opacity: 1, offset: 0.88 },
+            { transform: 'translateX(130%)', opacity: 0 },
+          ],
+          { duration: 900, easing: 'ease-in-out', fill: 'forwards' }
+        )
+      );
+    }
+    // Phase 2 — gold glow pulse on the row itself. It's the row's own
+    // box-shadow, which the row's overflow-hidden does NOT clip, so the halo
+    // can bloom outward while the trace/shine stay contained.
+    if (typeof row?.animate === 'function') {
+      anims.push(
+        row.animate(
+          [
+            { boxShadow: '0 0 0 0 rgba(251,191,36,0)' },
+            {
+              boxShadow:
+                '0 0 0 1px rgba(251,191,36,0.5), 0 0 22px 5px rgba(251,191,36,0.55)',
+              offset: 0.3,
+            },
+            { boxShadow: '0 0 0 0 rgba(251,191,36,0)' },
+          ],
+          { duration: 1050, delay: 820, easing: 'ease-out', fill: 'forwards' }
+        )
+      );
+    }
+
+    const timer = setTimeout(finish, CELEBRATION_MS);
+    return () => {
+      clearTimeout(timer);
+      anims.forEach((a) => a.cancel());
     };
-    raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
   }, []);
 
   return (
-    <canvas
-      ref={canvasRef}
-      aria-hidden="true"
-      className="pointer-events-none absolute inset-0 -z-10"
-    />
+    <>
+      <svg
+        ref={svgRef}
+        aria-hidden="true"
+        preserveAspectRatio="none"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          zIndex: -1,
+          overflow: 'visible',
+          pointerEvents: 'none',
+        }}
+      >
+        <rect
+          ref={rectRef}
+          fill="none"
+          stroke={GOLD}
+          strokeWidth={2}
+          rx={11}
+          ry={11}
+          pathLength={100}
+          strokeDasharray="100"
+          strokeDashoffset="100"
+        />
+      </svg>
+      <span
+        ref={sheenRef}
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: -1,
+          pointerEvents: 'none',
+          opacity: 0,
+          transform: 'translateX(-130%)',
+          background:
+            'linear-gradient(105deg, transparent 40%, rgba(255,240,200,0.5) 50%, transparent 60%)',
+        }}
+      />
+    </>
   );
 }

--- a/src/components/ui/CelebrationBurst.tsx
+++ b/src/components/ui/CelebrationBurst.tsx
@@ -9,10 +9,11 @@ import { CritBurst } from '@/lib/critBurst';
  * newly scheduled session appears to light up for a moment as it lands on the
  * page.
  *
- * Render this as a child of a `relative isolate` element; the canvas sits at
- * `-z-10` so it paints over the parent's background but behind its content,
- * and spills a little past the parent's box to halo around it. The caller must
- * NOT render this when `prefers-reduced-motion` is set.
+ * Render this as a child of a `relative isolate overflow-hidden` element; the
+ * canvas is sized to exactly cover the parent (`inset-0`) so the burst is
+ * clipped to the card and never spills onto neighbouring content, and it sits
+ * at `-z-10` so it paints over the parent's background but behind its content.
+ * The caller must NOT render this when `prefers-reduced-motion` is set.
  */
 export function SessionGlow({ onDone }: { onDone?: () => void }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -40,8 +41,9 @@ export function SessionGlow({ onDone }: { onDone?: () => void }) {
     canvas.height = h * dpr;
     ctx.scale(dpr, dpr);
 
-    // Glow centered in the canvas box, scaled to the row height.
-    const burst = new CritBurst(w / 2, h / 2, h * 0.42);
+    // Glow centered in the card, scaled to the row height. Kept modest so the
+    // rays read as a backdrop behind the card content rather than an explosion.
+    const burst = new CritBurst(w / 2, h / 2, h * 0.5);
     let raf = 0;
     let last: number | null = null;
     const loop = (now: number) => {
@@ -64,7 +66,7 @@ export function SessionGlow({ onDone }: { onDone?: () => void }) {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none absolute -inset-10 -z-10"
+      className="pointer-events-none absolute inset-0 -z-10"
     />
   );
 }

--- a/src/components/ui/CelebrationBurst.tsx
+++ b/src/components/ui/CelebrationBurst.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CritBurst } from '@/lib/critBurst';
+
+/**
+ * One-shot celebratory burst reusing the Nat-20 CritBurst effect. Renders a
+ * fixed, click-through canvas overlay only while a burst is playing, then
+ * unmounts itself. Respects prefers-reduced-motion.
+ */
+export function useCelebration(): { celebrate: () => void; overlay: React.ReactNode } {
+  const [active, setActive] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const celebrate = useCallback(() => {
+    if (typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return; // honor reduced-motion: no animation
+    }
+    setActive(true);
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      // Practically unreachable (2D context is always available), but bail
+      // out safely without calling setState synchronously inside the effect.
+      queueMicrotask(() => setActive(false));
+      return;
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.scale(dpr, dpr);
+
+    // Burst from screen center, scaled to viewport.
+    const burst = new CritBurst(w / 2, h / 2, Math.min(w, h) * 0.12);
+    let raf = 0;
+    let last: number | null = null;
+    const loop = (now: number) => {
+      const dt = last == null ? 0 : (now - last) / 1000;
+      last = now;
+      ctx.clearRect(0, 0, w, h);
+      burst.step(dt);
+      burst.drawBack(ctx);
+      burst.drawFront(ctx);
+      if (!burst.done) {
+        raf = requestAnimationFrame(loop);
+      } else {
+        setActive(false);
+      }
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [active]);
+
+  const overlay = active ? (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-100 size-full"
+    />
+  ) : null;
+
+  return { celebrate, overlay };
+}

--- a/src/components/ui/CelebrationBurst.tsx
+++ b/src/components/ui/CelebrationBurst.tsx
@@ -1,46 +1,47 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { CritBurst } from '@/lib/critBurst';
 
 /**
- * One-shot celebratory burst reusing the Nat-20 CritBurst effect. Renders a
- * fixed, click-through canvas overlay only while a burst is playing, then
- * unmounts itself. Respects prefers-reduced-motion.
+ * A one-shot gold glow that blooms behind its positioned parent, reusing the
+ * Nat-20 CritBurst's light-ray + shockwave layer (drawBack) — no sparks — so a
+ * newly scheduled session appears to light up for a moment as it lands on the
+ * page.
+ *
+ * Render this as a child of a `relative isolate` element; the canvas sits at
+ * `-z-10` so it paints over the parent's background but behind its content,
+ * and spills a little past the parent's box to halo around it. The caller must
+ * NOT render this when `prefers-reduced-motion` is set.
  */
-export function useCelebration(): { celebrate: () => void; overlay: React.ReactNode } {
-  const [active, setActive] = useState(false);
+export function SessionGlow({ onDone }: { onDone?: () => void }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  const celebrate = useCallback(() => {
-    if (typeof window !== 'undefined' &&
-        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-      return; // honor reduced-motion: no animation
-    }
-    setActive(true);
-  }, []);
+  const onDoneRef = useRef(onDone);
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  });
 
   useEffect(() => {
-    if (!active) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      // Practically unreachable (2D context is always available), but bail
-      // out safely without calling setState synchronously inside the effect.
-      queueMicrotask(() => setActive(false));
+    const rect = canvas.getBoundingClientRect();
+    const w = rect.width;
+    const h = rect.height;
+    if (!ctx || w === 0 || h === 0) {
+      // No drawable surface (e.g. jsdom / detached): finish immediately without
+      // a synchronous setState from inside the effect body.
+      queueMicrotask(() => onDoneRef.current?.());
       return;
     }
 
     const dpr = window.devicePixelRatio || 1;
-    const w = window.innerWidth;
-    const h = window.innerHeight;
     canvas.width = w * dpr;
     canvas.height = h * dpr;
     ctx.scale(dpr, dpr);
 
-    // Burst from screen center, scaled to viewport.
-    const burst = new CritBurst(w / 2, h / 2, Math.min(w, h) * 0.12);
+    // Glow centered in the canvas box, scaled to the row height.
+    const burst = new CritBurst(w / 2, h / 2, h * 0.42);
     let raf = 0;
     let last: number | null = null;
     const loop = (now: number) => {
@@ -48,25 +49,22 @@ export function useCelebration(): { celebrate: () => void; overlay: React.ReactN
       last = now;
       ctx.clearRect(0, 0, w, h);
       burst.step(dt);
-      burst.drawBack(ctx);
-      burst.drawFront(ctx);
+      burst.drawBack(ctx); // glow only — the spark layer (drawFront) is skipped
       if (!burst.done) {
         raf = requestAnimationFrame(loop);
       } else {
-        setActive(false);
+        onDoneRef.current?.();
       }
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, [active]);
+  }, []);
 
-  const overlay = active ? (
+  return (
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none fixed inset-0 z-100 size-full"
+      className="pointer-events-none absolute -inset-10 -z-10"
     />
-  ) : null;
-
-  return { celebrate, overlay };
+  );
 }

--- a/src/components/ui/Input.test.tsx
+++ b/src/components/ui/Input.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Input } from './Input';
+
+describe('Input label association', () => {
+  it('links label to input even when no id is passed', () => {
+    const { getByLabelText } = render(<Input label="Display Name" />);
+    // getByLabelText only resolves if htmlFor/id are correctly linked.
+    const field = getByLabelText('Display Name');
+    expect(field.tagName).toBe('INPUT');
+    expect(field.id).toBeTruthy();
+  });
+
+  it('respects an explicitly provided id', () => {
+    const { getByLabelText } = render(<Input label="Email" id="custom-id" />);
+    expect(getByLabelText('Email').id).toBe('custom-id');
+  });
+});

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InputHTMLAttributes, forwardRef } from 'react';
+import { InputHTMLAttributes, forwardRef, useId } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -9,16 +9,18 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className = '', label, error, id, ...props }, ref) => {
+    const generatedId = useId();
+    const fieldId = id ?? generatedId;
     return (
       <div className="w-full">
         {label && (
-          <label htmlFor={id} className="block text-sm font-medium text-foreground mb-1">
+          <label htmlFor={fieldId} className="block text-sm font-medium text-foreground mb-1">
             {label}
           </label>
         )}
         <input
           ref={ref}
-          id={id}
+          id={fieldId}
           className={`w-full px-3 py-2 bg-background border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring ${
             error ? 'border-danger' : 'border-border'
           } text-foreground placeholder:text-muted-foreground ${className}`}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TextareaHTMLAttributes, forwardRef } from 'react';
+import { TextareaHTMLAttributes, forwardRef, useId } from 'react';
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
@@ -9,16 +9,18 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className = '', label, error, id, ...props }, ref) => {
+    const generatedId = useId();
+    const fieldId = id ?? generatedId;
     return (
       <div className="w-full">
         {label && (
-          <label htmlFor={id} className="block text-sm font-medium text-foreground mb-1">
+          <label htmlFor={fieldId} className="block text-sm font-medium text-foreground mb-1">
             {label}
           </label>
         )}
         <textarea
           ref={ref}
-          id={id}
+          id={fieldId}
           className={`w-full px-3 py-2 bg-background border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring ${
             error ? 'border-danger' : 'border-border'
           } text-foreground placeholder:text-muted-foreground ${className}`}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -51,7 +51,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             role="status"
             className={`pointer-events-auto rounded-full px-4 py-2 text-sm font-medium shadow-lg ${
               t.tone === 'danger'
-                ? 'bg-danger text-white'
+                ? 'bg-danger text-danger-foreground'
                 : 'bg-primary text-primary-foreground'
             }`}
           >

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,17 @@
+export function onRequestError(
+  error: unknown,
+  request: { path?: string; method?: string }
+): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(
+    JSON.stringify({
+      level: 'error',
+      unhandled: true,
+      errorId: crypto.randomUUID(),
+      message: err.message,
+      stack: err.stack,
+      path: request?.path,
+      method: request?.method,
+    })
+  );
+}

--- a/src/lib/apiError.test.ts
+++ b/src/lib/apiError.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { serverError, logServerError } from './apiError';
+
+describe('apiError', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}); });
+  afterEach(() => { errSpy.mockRestore(); });
+
+  it('serverError returns 500 with a stable body shape and a UUID errorId', async () => {
+    const res = serverError(new Error('boom'), { route: '/api/x' });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+    expect(body.errorId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('logs one structured JSON line containing route, errorId, and message', () => {
+    logServerError(new Error('kaboom'), { route: '/api/y', gameId: 'g1' });
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse((errSpy.mock.calls[0] as unknown[])[0] as string);
+    expect(logged.level).toBe('error');
+    expect(logged.route).toBe('/api/y');
+    expect(logged.gameId).toBe('g1');
+    expect(logged.message).toBe('kaboom');
+    expect(logged.errorId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('serverError body errorId matches the logged errorId', () => {
+    logServerError(new Error('x'), { route: '/api/z' });
+    const logged = JSON.parse((errSpy.mock.calls[0] as unknown[])[0] as string);
+    expect(logged.errorId).toBeTruthy();
+  });
+});

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+type Context = { route: string } & Record<string, unknown>;
+
+/**
+ * Log a handled server error as one structured JSON line (Vercel ingests
+ * function stdout/stderr into Runtime Logs / Observability — searchable by
+ * errorId, no external logging vendor) and return the generated errorId.
+ */
+export function logServerError(error: unknown, context: Context): string {
+  const errorId = crypto.randomUUID();
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(
+    JSON.stringify({
+      level: 'error',
+      errorId,
+      message: err.message,
+      stack: err.stack,
+      ...context,
+    })
+  );
+  return errorId;
+}
+
+/** Log + build the canonical 500 response with a correlatable errorId. */
+export function serverError(error: unknown, context: Context): NextResponse {
+  const errorId = logServerError(error, context);
+  return NextResponse.json(
+    { error: 'Internal server error', errorId },
+    { status: 500 }
+  );
+}

--- a/src/lib/supabase/env.test.ts
+++ b/src/lib/supabase/env.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isLocalSupabaseUrl } from './env';
+
+describe('isLocalSupabaseUrl', () => {
+  it('accepts exact localhost host', () => {
+    expect(isLocalSupabaseUrl('http://localhost:54321')).toBe(true);
+    expect(isLocalSupabaseUrl('http://127.0.0.1:54321')).toBe(true);
+  });
+
+  it('rejects lookalike hosts that merely contain "localhost"', () => {
+    expect(isLocalSupabaseUrl('https://localhost.attacker.com')).toBe(false);
+    expect(isLocalSupabaseUrl('https://evil-localhost.com')).toBe(false);
+    expect(isLocalSupabaseUrl('https://abc.supabase.co')).toBe(false);
+  });
+
+  it('rejects empty / malformed input', () => {
+    expect(isLocalSupabaseUrl('')).toBe(false);
+    expect(isLocalSupabaseUrl('not a url')).toBe(false);
+  });
+});

--- a/src/lib/supabase/env.ts
+++ b/src/lib/supabase/env.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether a Supabase URL points at a local dev instance. Parses the hostname
+ * and compares it exactly — substring checks let `localhost.attacker.com` pass.
+ */
+export function isLocalSupabaseUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
+export function isLocalSupabase(): boolean {
+  return isLocalSupabaseUrl(process.env.NEXT_PUBLIC_SUPABASE_URL ?? '');
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -188,7 +188,7 @@ BEGIN
     SELECT 1 FROM public.game_memberships WHERE game_id = game_id_param AND user_id = user_id_param
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Check if user is GM or co-GM (used by RLS policies)
 CREATE OR REPLACE FUNCTION public.is_game_gm_or_co_gm(game_id_param UUID, user_id_param UUID)
@@ -204,7 +204,7 @@ BEGIN
     WHERE game_id = game_id_param AND user_id = user_id_param AND is_co_gm = TRUE
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Check if a membership is for a co-GM (used by RLS policies to determine removal permissions)
 CREATE OR REPLACE FUNCTION public.is_membership_co_gm(membership_game_id UUID, membership_user_id UUID)
@@ -215,7 +215,7 @@ BEGIN
     WHERE game_id = membership_game_id AND user_id = membership_user_id AND is_co_gm = TRUE
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Count how many games a user has created (used by RLS to enforce limit)
 CREATE OR REPLACE FUNCTION public.count_user_games(user_id_param UUID)
@@ -228,7 +228,7 @@ BEGIN
   WHERE gm_id = user_id_param;
   RETURN game_count;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Count how many players are in a game (members + GM)
 CREATE OR REPLACE FUNCTION public.count_game_players(game_id_param UUID)
@@ -242,7 +242,7 @@ BEGIN
   -- Add 1 for the GM (who is not in game_memberships)
   RETURN member_count + 1;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Count how many future sessions exist for a game (used by RLS to enforce limit)
 CREATE OR REPLACE FUNCTION public.count_future_sessions(game_id_param UUID)
@@ -256,7 +256,7 @@ BEGIN
     AND date >= CURRENT_DATE;
   RETURN session_count;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Check if the current user shares a game with the target user (used by users RLS)
 CREATE OR REPLACE FUNCTION public.shares_game_with(target_user_id UUID)
@@ -278,7 +278,7 @@ BEGIN
     ) their_games ON my_games.game_id = their_games.game_id
   );
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
 
 -- Allowlist-based column protection for the users table.
 -- Saves the values of allowed columns, resets the entire row to OLD,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -564,10 +564,24 @@ CREATE POLICY "GMs and co-GMs can delete play dates" ON game_play_dates
 GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+-- Functions: authenticated + service_role only. anon is deliberately excluded so
+-- the SECURITY DEFINER helpers (count_*, is_*, shares_game_with) and
+-- join_game_by_invite are NOT callable as unauthenticated PostgREST RPCs.
+-- RLS still works: authenticated holds EXECUTE, which is what policy evaluation needs.
+-- Must REVOKE FROM both PUBLIC and anon explicitly (not just omit anon from the
+-- GRANT ... TO list): every function in this file picks up TWO separate grants at
+-- CREATE FUNCTION time — (1) Postgres's built-in default EXECUTE-to-PUBLIC (which every
+-- role, including anon, inherits) and (2) an explicit anon grant from a pre-existing
+-- default ACL this local Supabase CLI version seeds before this script runs. GRANT is
+-- additive and never revokes an existing grant, so a positive-list GRANT alone leaves
+-- both of those intact. Same pattern already used for join_game_by_invite above.
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, anon;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated, service_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT ALL ON TABLES TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO authenticated, service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -228,7 +228,11 @@ BEGIN
   WHERE gm_id = user_id_param;
   RETURN game_count;
 END;
-$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
+-- VOLATILE (not STABLE): used in an INSERT ... WITH CHECK cap guard. A STABLE
+-- count is evaluated once per statement, letting a bulk (multi-row) INSERT
+-- bypass the limit; VOLATILE re-checks as rows accumulate. See
+-- e2e/tests/rls/usage-limits-bulk.spec.ts.
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
 
 -- Count how many players are in a game (members + GM)
 CREATE OR REPLACE FUNCTION public.count_game_players(game_id_param UUID)
@@ -242,7 +246,8 @@ BEGIN
   -- Add 1 for the GM (who is not in game_memberships)
   RETURN member_count + 1;
 END;
-$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
+-- VOLATILE (not STABLE): count-based limit guard; see count_user_games above.
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
 
 -- Count how many future sessions exist for a game (used by RLS to enforce limit)
 CREATE OR REPLACE FUNCTION public.count_future_sessions(game_id_param UUID)
@@ -256,7 +261,8 @@ BEGIN
     AND date >= CURRENT_DATE;
   RETURN session_count;
 END;
-$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
+-- VOLATILE (not STABLE): count-based limit guard; see count_user_games above.
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
 
 -- Check if the current user shares a game with the target user (used by users RLS)
 CREATE OR REPLACE FUNCTION public.shares_game_with(target_user_id UUID)


### PR DESCRIPTION
## Summary

A batch of low-risk, high-value fixes from the 2026-07-02 codebase review, a security fix surfaced during review, and a new session-confirmation celebration. Grouped by area below; every change shipped with tests.

## Security / RLS (`supabase/schema.sql`)

- **Close the anonymous function-EXECUTE oracle.** A blanket `GRANT EXECUTE ON ALL FUNCTIONS … TO anon` re-exposed the `SECURITY DEFINER` helper functions (and `join_game_by_invite`) to unauthenticated PostgREST RPC. Replaced with explicit `REVOKE … FROM PUBLIC, anon` — a positive-list `GRANT` is additive and can't remove the pre-existing `PUBLIC`/`anon` grants. `authenticated`/`service_role` keep `EXECUTE`, so RLS policy evaluation is unaffected.
- **VOLATILE vs STABLE on RLS helpers.** Marked the four *identity* helpers (`is_game_participant`, `is_game_gm_or_co_gm`, `is_membership_co_gm`, `shares_game_with`) `STABLE` so the planner evaluates them once per statement instead of once per row on the hot availability read. **The three `count_*` limit helpers are deliberately left `VOLATILE`** — review caught (and this branch reproduces in a test) that marking them `STABLE` lets a single multi-row `INSERT` (a PostgREST array insert by an authenticated user) bypass the 20-game / 100-session caps. New behavioral regression test: `e2e/tests/rls/usage-limits-bulk.spec.ts`.
- Hardened the anon-lockdown test with a deterministic `has_function_privilege` ACL check.

> **⚠️ Production migration required.** These `schema.sql` edits reach fresh DBs via the initial migration, but production is an existing DB and must be migrated out-of-band. The SQL is inlined at the bottom of this description. It is independent of the code and safe to apply before or after merge (idempotent; verify-before-`COMMIT`).

## Operational / observability

- **Native error IDs + structured logging** (wired into all 9 API routes). Each 500 now returns a correlatable `errorId` and logs one structured JSON line — Vercel ingests function stdout into Runtime Logs, so no external logging vendor. `instrumentation.ts#onRequestError` covers unhandled errors.
- **test-auth localhost guard.** `/api/test-auth` now requires local Supabase (matching dev-login), and `isLocalSupabase()` parses the hostname exactly instead of substring-matching (so `localhost.attacker.com` no longer passes).

## UI / UX

- **Settings status tone.** Validation errors now render in danger red, not success green (the color was derived from `message.includes('Error')`, which the validation strings don't contain).
- **Themed `--danger-foreground` token.** The shared `Button` danger variant and `Toast` drop hardcoded `bg-red-600` / `text-white` for semantic tokens with proper light/dark contrast.
- **`Input`/`Textarea` label association.** Default `id` to `useId()` so `<label>` links to its field even when callers omit an `id`.

## Delight — session-confirm celebration

When a session is confirmed, its row plays a one-shot celebration: a gold border traces around the card while a shine sweeps across, then a gold glow pulses. Self-contained (inline styles + `fill="none"` attribute + the Web Animations API — no global-stylesheet dependency), contained to the card, and honors `prefers-reduced-motion`.

## Also

- Merged `origin/main` (admin "Upcoming Games" tab, #129).

## Testing

- Full unit suite and full Playwright e2e suite green.
- Schema changes verified against a freshly-applied schema via `e2e/tests/rls/` (`function-grants`, `function-volatility`, `usage-limits-bulk`).

---

## Production migration (apply out-of-band)

Run inside the transaction, confirm the verification `SELECT`s match the expectations, then `COMMIT`:

```sql
BEGIN;

-- Task 1 — close the anon function-EXECUTE oracle
REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, anon;
ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon;

-- Task 2 — mark the four IDENTITY helpers STABLE (count_* stay VOLATILE)
ALTER FUNCTION public.is_game_participant(uuid, uuid) STABLE;
ALTER FUNCTION public.is_game_gm_or_co_gm(uuid, uuid) STABLE;
ALTER FUNCTION public.is_membership_co_gm(uuid, uuid) STABLE;
ALTER FUNCTION public.shares_game_with(uuid) STABLE;

-- verify — anon EXECUTE must be false, authenticated true:
SELECT has_function_privilege('anon','public.count_game_players(uuid)','EXECUTE')          AS anon_should_be_false,
       has_function_privilege('authenticated','public.is_game_participant(uuid,uuid)','EXECUTE') AS auth_should_be_true;
-- verify — identity helpers 's' (STABLE), count_* 'v' (VOLATILE):
SELECT proname, provolatile FROM pg_proc
 WHERE pronamespace = 'public'::regnamespace
   AND proname IN ('is_game_participant','is_game_gm_or_co_gm','is_membership_co_gm','shares_game_with',
                   'count_user_games','count_game_players','count_future_sessions')
 ORDER BY provolatile, proname;

COMMIT;
```

## Manual verification (post-deploy)

- Enable Vercel Runtime Log retention / Observability so the new `errorId` log lines are queryable.
- Confirm a session → gold border traces + shine, then a gold glow (no black box); reduced-motion skips it.
- Danger `Button`/`Toast` legible in both a light and a dark theme.
- Settings → clear the display name → Save → the error renders red, not green.
