### PR TITLE
Restructure client data fetching: React Query cache, parallel dashboard fetch, batched bulk availability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,25 @@ RLS uses `auth.uid()` and helper functions (SECURITY DEFINER) like `is_game_part
 - Availability has three states: available, unavailable, maybe (with optional comment and optional time-of-day constraints on available/maybe)
 - GMs/co-GMs can add special play dates for one-off sessions outside regular play days
 
+### Data Fetching & Caching
+
+Client-side reads go through TanStack Query (React Query v5); the `QueryClientProvider` lives in `src/components/layout/Providers.tsx` with a default `staleTime` of `QUERY_STALE_TIME` (45s), so navigating between pages within that window reuses the cache instead of refetching.
+
+- **Every cache key is built via `src/lib/queryKeys.ts`** — never write inline key arrays. Prefix invalidation is used deliberately (e.g. `['dashboard']` invalidates all users' dashboard entries).
+- **Mutations write to the cache** (`queryClient.setQueryData`) with optimistic updates and surgical rollback, then invalidate any *other* keys whose data changed (e.g. confirming a session invalidates `['dashboard']` so the upcoming-sessions panel refreshes). When adding a mutation, ask which cached views its data appears in and invalidate those keys.
+- The dashboard loads via `fetchDashboardData` (`src/lib/dashboardData.ts`): two parallel stages with membership counts embedded in the games queries (`game_memberships(count)`) — do not reintroduce per-game count queries.
+- Game-page hooks (`useGameMeta`, `useAvailability`, `useSessions`, `usePlayDates`, `useOtherGameSessions`) each own one query key and fire in parallel as soon as `gameId`/`userId` are known — don't gate one hook's fetch on another's result; RLS already returns nothing for non-participants.
+- The current user's availability map is **derived** from the all-players availability cache (one query), not fetched separately.
+- Key data fetches off `session.user.id` (available immediately) rather than `profile.id` (needs a round trip); the two are the same value.
+- Bulk availability changes go through `batchUpsertAvailability` / `useAvailability().bulkSetStatus` — one round trip for N dates. Never loop single-row upserts.
+
 ### Shared Utilities
 
 - `src/hooks/useAuthRedirect.ts` - Hook for protected pages (redirects to login, optionally requires GM)
 - `src/hooks/useUserPreferences.ts` - Single source of truth for user i18n preferences (time format, week start)
-- `src/lib/constants.ts` - Shared constants (day labels, timeouts, session defaults, usage limits, text limits)
+- `src/lib/constants.ts` - Shared constants (day labels, timeouts, session defaults, usage limits, text limits, query stale time)
+- `src/lib/queryKeys.ts` - Central registry of React Query cache keys (all queries/invalidations build keys here)
+- `src/lib/dashboardData.ts` - Dashboard fetch (2-stage parallel, embedded member counts) + pure merge helper
 - `src/lib/availability.ts` - Player completion percentage calculations
 - `src/lib/scheduling.ts` - Scheduling window calculation (`getSchedulingWindow()`) for campaign date bounds
 - `src/lib/availabilityStatus.ts` - Availability state cycling (available → unavailable → maybe)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.90.1",
+        "@tanstack/react-query": "^5.101.2",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "cannon-es": "^0.20.0",
@@ -2470,6 +2471,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,6 +2485,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,6 +2499,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2509,6 +2513,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2522,6 +2527,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,6 +2541,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,6 +2555,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2561,6 +2569,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,6 +2583,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2587,6 +2597,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2600,6 +2611,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2613,6 +2625,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2626,6 +2639,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,6 +2653,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2652,6 +2667,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2665,6 +2681,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2678,6 +2695,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2691,6 +2709,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2704,6 +2723,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2717,6 +2737,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2730,6 +2751,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2743,6 +2765,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2756,6 +2779,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2769,6 +2793,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2782,6 +2807,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3183,6 +3209,32 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -10771,6 +10823,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.90.1",
+    "@tanstack/react-query": "^5.101.2",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "cannon-es": "^0.20.0",

--- a/src/app/admin/games/[id]/page.tsx
+++ b/src/app/admin/games/[id]/page.tsx
@@ -238,6 +238,7 @@ export default function AdminGamePeekPage() {
             playDays={game.play_days}
             availability={viewAsAvailability}
             onToggle={() => {}}
+            onBulkSet={() => {}}
             confirmedSessions={confirmedSessions}
             extraPlayDates={extraDateStrings}
             isGmOrCoGm={false}

--- a/src/app/games/[id]/edit/page.tsx
+++ b/src/app/games/[id]/edit/page.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '@/lib/queryKeys';
+import { invalidateGamesLists, queryKeys } from '@/lib/queryKeys';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import {
   Button,
@@ -156,8 +156,7 @@ export default function EditGamePage() {
     // the ad-hoc conversion above may also have added play dates.
     queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.playDates(gameId) });
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
+    invalidateGamesLists(queryClient);
 
     router.push(`/games/${gameId}`);
   };
@@ -188,8 +187,7 @@ export default function EditGamePage() {
       return;
     }
     queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
+    invalidateGamesLists(queryClient);
     router.push('/dashboard');
   };
 

--- a/src/app/games/[id]/edit/page.tsx
+++ b/src/app/games/[id]/edit/page.tsx
@@ -3,6 +3,8 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import {
   Button,
@@ -51,6 +53,7 @@ export default function EditGamePage() {
   const params = useParams();
   const gameId = params.id as string;
   const supabase = createClient();
+  const queryClient = useQueryClient();
 
   const [game, setGame] = useState<Game | null>(null);
   const [loading, setLoading] = useState(true);
@@ -149,6 +152,13 @@ export default function EditGamePage() {
       return;
     }
 
+    // The game page and games lists hold cached copies of this game's settings;
+    // the ad-hoc conversion above may also have added play dates.
+    queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.playDates(gameId) });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
+
     router.push(`/games/${gameId}`);
   };
 
@@ -164,6 +174,7 @@ export default function EditGamePage() {
       return;
     }
     setGame({ ...game, invite_code: newCode });
+    queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
     toast.show('Invite code regenerated. The old link no longer works.');
   };
 
@@ -176,6 +187,9 @@ export default function EditGamePage() {
       toast.show('Could not delete the game. Please try again.', 'danger');
       return;
     }
+    queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
     router.push('/dashboard');
   };
 

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -21,35 +21,35 @@ import { useOtherGameSessions } from "@/hooks/useOtherGameSessions";
 type Tab = "overview" | "availability" | "schedule";
 
 export default function GameDetailPage() {
-  const { profile, authStatus } = useAuth();
+  const { user, authStatus } = useAuth();
   const { weekStartDay, use24h, timezone: userTimezone } = useUserPreferences();
   const router = useRouter();
   const params = useParams();
   const gameId = params.id as string;
 
-  const userId = profile?.id ?? "";
+  // The auth session's user id is available one round trip before the profile
+  // row, so keying the data fetches off it starts them earlier.
+  const userId = user?.id ?? "";
 
-  // Data layer via focused hooks
+  // Data layer via focused hooks — all fetches fire in parallel as soon as
+  // gameId/userId are known (RLS returns nothing for non-participants).
   const meta = useGameMeta(gameId, userId);
   const { game, otherGames, refreshing, leaveGame, removePlayer, toggleCoGm } = meta;
 
-  const ready = !!game;
   const availabilityHook = useAvailability(gameId, userId, game);
-  const { availability, allAvailability, changeAvailability, copyFromGame: copyFromGameRaw, applyDefaults, removePlayerData, hasDefaults } = availabilityHook;
+  const { availability, allAvailability, changeAvailability, bulkSetStatus, copyFromGame: copyFromGameRaw, applyDefaults, removePlayerData, hasDefaults } = availabilityHook;
 
-  const sessionsHook = useSessions(gameId, ready);
+  const sessionsHook = useSessions(gameId);
   const { sessions, confirmSession: confirmSessionRaw, updateSession, cancelSession } = sessionsHook;
 
-  const playDatesHook = usePlayDates(gameId, ready);
+  const playDatesHook = usePlayDates(gameId);
   const { gamePlayDates, toggleExtraDate: toggleExtraDateRaw, updatePlayDateNote } = playDatesHook;
 
-  // Loading is driven by meta until the game resolves; only then do we wait
-  // on downstream hooks. Without the `!game` short-circuit, a non-member
-  // request leaves downstream loading=true forever (their fetches never run).
   const loading =
     meta.loading ||
-    (!!game &&
-      (availabilityHook.loading || sessionsHook.loading || playDatesHook.loading));
+    availabilityHook.loading ||
+    sessionsHook.loading ||
+    playDatesHook.loading;
 
   const refresh = async () => {
     await Promise.all([
@@ -77,11 +77,11 @@ export default function GameDetailPage() {
     }
   }, []);
 
-  const isGm = game?.gm_id === profile?.id;
+  const isGm = !!userId && game?.gm_id === userId;
   const isCoGm =
-    game?.members.some((m) => m.id === profile?.id && m.is_co_gm) ?? false;
+    game?.members.some((m) => m.id === userId && m.is_co_gm) ?? false;
   const canDoGmActions = !!(isGm || isCoGm);
-  const isMember = game?.members.some((m) => m.id === profile?.id);
+  const isMember = game?.members.some((m) => m.id === userId);
 
   const hasAnyAvailability = Object.keys(availability).length > 0;
   // The host GM owns the game via gm_id and is intentionally not a
@@ -117,10 +117,10 @@ export default function GameDetailPage() {
 
   // Redirect to dashboard if game not found after loading
   useEffect(() => {
-    if (!loading && !game && profile?.id) {
+    if (!loading && !game && userId) {
       router.push("/dashboard");
     }
-  }, [loading, game, profile?.id, router]);
+  }, [loading, game, userId, router]);
 
   const toast = useToast();
 
@@ -167,7 +167,7 @@ export default function GameDetailPage() {
     endTime: string,
     location: string | null,
     notes: string | null,
-  ) => confirmSessionRaw(date, startTime, endTime, profile?.id ?? "", location, notes);
+  ) => confirmSessionRaw(date, startTime, endTime, userId, location, notes);
 
   if (authStatus === 'loading' || loading) {
     return (
@@ -312,15 +312,16 @@ export default function GameDetailPage() {
         />
       )}
 
-      {activeTab === "availability" && profile && (
+      {activeTab === "availability" && userId && (
         <AvailabilityTabContent
           windowStart={windowStart}
           windowEnd={windowEnd}
-          currentUserId={profile.id}
+          currentUserId={userId}
           completionByUserId={completionByUserId}
           playDays={game.play_days}
           availability={availability}
           onToggle={changeAvailability}
+          onBulkSet={bulkSetStatus}
           confirmedSessions={confirmedSessions}
           extraPlayDates={extraDateStrings}
           isGmOrCoGm={canDoGmActions}

--- a/src/app/games/join/[code]/page.tsx
+++ b/src/app/games/join/[code]/page.tsx
@@ -9,6 +9,7 @@ import { Button, Card, CardContent, LoadingSpinner } from '@/components/ui';
 import { createClient } from '@/lib/supabase/client';
 import { DAY_LABELS, USAGE_LIMITS } from '@/lib/constants';
 import { joinGame } from '@/lib/data';
+import { invalidateGamesLists } from '@/lib/queryKeys';
 
 interface GamePreview {
   id: string;
@@ -99,8 +100,7 @@ export default function JoinGamePage() {
     }
 
     // The cached games lists don't include the just-joined game yet.
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
+    invalidateGamesLists(queryClient);
 
     router.push(`/games/${game.id}`);
   };

--- a/src/app/games/join/[code]/page.tsx
+++ b/src/app/games/join/[code]/page.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Dice6, Frown } from 'lucide-react';
 import { Button, Card, CardContent, LoadingSpinner } from '@/components/ui';
 import { createClient } from '@/lib/supabase/client';
@@ -27,6 +28,7 @@ export default function JoinGamePage() {
   const params = useParams();
   const code = params.code as string;
   const supabase = createClient();
+  const queryClient = useQueryClient();
 
   const [game, setGame] = useState<GamePreview | null>(null);
   const [loading, setLoading] = useState(true);
@@ -95,6 +97,10 @@ export default function JoinGamePage() {
       setJoining(false);
       return;
     }
+
+    // The cached games lists don't include the just-joined game yet.
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
 
     router.push(`/games/${game.id}`);
   };

--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/ui';
 import { createClient } from '@/lib/supabase/client';
 import { nanoid } from 'nanoid';
 import { fetchUserGameCount, createGame } from '@/lib/data';
+import { invalidateGamesLists } from '@/lib/queryKeys';
 import {
   SESSION_DEFAULTS,
   USAGE_LIMITS,
@@ -124,8 +125,7 @@ export default function NewGamePage() {
     }
 
     // The cached games lists don't include the new game yet.
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
+    invalidateGamesLists(queryClient);
 
     router.push(`/games/${createdGame?.id || '/dashboard'}`);
   };

--- a/src/app/games/new/page.tsx
+++ b/src/app/games/new/page.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuthRedirect } from '@/hooks/useAuthRedirect';
 import { LoadingSpinner } from '@/components/ui';
 import { createClient } from '@/lib/supabase/client';
@@ -30,6 +31,7 @@ export default function NewGamePage() {
   const { timezone: userTimezone } = useUserPreferences();
   const router = useRouter();
   const supabase = createClient();
+  const queryClient = useQueryClient();
 
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState('');
@@ -120,6 +122,10 @@ export default function NewGamePage() {
       setCreating(false);
       return;
     }
+
+    // The cached games lists don't include the new game yet.
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: ['myGamesLite'] });
 
     router.push(`/games/${createdGame?.id || '/dashboard'}`);
   };

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -22,6 +22,7 @@ import {
   getNextStatus,
   AvailabilityEntry,
 } from "@/lib/availabilityStatus";
+import { filterDatesForBulkSet } from "@/lib/bulkAvailability";
 import { formatTimeShort } from "@/lib/formatting";
 import { getTimeOptions } from "@/lib/timeOptions";
 import {
@@ -64,6 +65,8 @@ interface AvailabilityCalendarProps {
   bulkActionsLead?: ReactNode;
   /** Disables all interaction (day clicks, long-press editing, bulk actions). Used by the admin peek view. */
   readOnly?: boolean;
+  /** Applies a bulk status change in one call. When omitted, falls back to per-date onToggle calls. */
+  onBulkSet?: (dates: string[], status: AvailabilityStatus) => void;
 }
 
 export function AvailabilityCalendar({
@@ -86,6 +89,7 @@ export function AvailabilityCalendar({
   hasCampaignDates = false,
   bulkActionsLead,
   readOnly = false,
+  onBulkSet,
 }: AvailabilityCalendarProps) {
   const today = startOfDay(new Date());
   const maxDate = windowEnd;
@@ -232,28 +236,29 @@ export function AvailabilityCalendar({
   };
 
   const bulkSetDays = (filter: string, status: AvailabilityStatus) => {
-    const datesInWindow = eachDayOfInterval({
-      start: windowStart,
-      end: maxDate,
-    }).filter((date) => {
-      const dayOfWeek = getDay(date);
-      const dateStr = format(date, "yyyy-MM-dd");
-      const isExtraPlayDate = extraPlayDates.includes(dateStr);
-      if (!playDays.includes(dayOfWeek) && !isExtraPlayDate) return false;
-      if (isBefore(date, today)) return false;
-
-      if (filter === "remaining") {
-        // Only dates without availability set
-        return !availability[dateStr];
-      } else {
-        // Specific day of week
-        return dayOfWeek === parseInt(filter, 10);
-      }
+    const dates = filterDatesForBulkSet({
+      filter,
+      dates: eachDayOfInterval({ start: windowStart, end: maxDate }),
+      playDays,
+      extraPlayDates,
+      existingAvailability: availability,
+      today,
+      formatDate: (d) => format(d, "yyyy-MM-dd"),
+      getDayOfWeek: getDay,
+      isBefore,
     });
 
-    datesInWindow.forEach((date) => {
-      const dateStr = format(date, "yyyy-MM-dd");
-      // Preserve existing comments and time constraints when bulk setting
+    if (dates.length === 0) return;
+
+    if (onBulkSet) {
+      onBulkSet(dates, status);
+      return;
+    }
+
+    // Fallback for callers that don't provide onBulkSet (e.g. the read-only
+    // admin peek): emit one onToggle call per date, preserving existing
+    // comments and time constraints when bulk setting.
+    dates.forEach((dateStr) => {
       const existing = availability[dateStr];
       onToggle(
         dateStr,

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -65,8 +65,12 @@ interface AvailabilityCalendarProps {
   bulkActionsLead?: ReactNode;
   /** Disables all interaction (day clicks, long-press editing, bulk actions). Used by the admin peek view. */
   readOnly?: boolean;
-  /** Applies a bulk status change in one call. When omitted, falls back to per-date onToggle calls. */
-  onBulkSet?: (dates: string[], status: AvailabilityStatus) => void;
+  /**
+   * Applies a bulk status change in one batched call. Required so a caller
+   * can't silently regress to one write per date; read-only callers pass a
+   * no-op (their bulk-actions bar never renders).
+   */
+  onBulkSet: (dates: string[], status: AvailabilityStatus) => void;
 }
 
 export function AvailabilityCalendar({
@@ -250,24 +254,7 @@ export function AvailabilityCalendar({
 
     if (dates.length === 0) return;
 
-    if (onBulkSet) {
-      onBulkSet(dates, status);
-      return;
-    }
-
-    // Fallback for callers that don't provide onBulkSet (e.g. the read-only
-    // admin peek): emit one onToggle call per date, preserving existing
-    // comments and time constraints when bulk setting.
-    dates.forEach((dateStr) => {
-      const existing = availability[dateStr];
-      onToggle(
-        dateStr,
-        status,
-        existing?.comment || null,
-        existing?.available_after || null,
-        existing?.available_until || null
-      );
-    });
+    onBulkSet(dates, status);
   };
 
   const handleBulkSubmit = () => {

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,133 +1,47 @@
 "use client";
 
 import { useAuth } from "@/contexts/AuthContext";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
 import { Users, Calendar } from "lucide-react";
 import { Button, LoadingSpinner } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
-import { GameWithGM, GameSession } from "@/types";
 import { DAY_LABELS } from "@/lib/constants";
-import {
-  fetchUserMemberships,
-  fetchUserGmGames,
-  fetchMembershipCount,
-  fetchUpcomingSessionsForGames,
-} from "@/lib/data";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
+import { fetchDashboardData, type DashboardGame } from "@/lib/dashboardData";
 import { useUserPreferences } from "@/hooks/useUserPreferences";
-import {
-  buildUpcomingSessionRows,
-  getTodayLocalDate,
-  getUpcomingQueryFloor,
-  type UpcomingSessionRow,
-} from "@/lib/upcomingSessions";
+import { buildUpcomingSessionRows } from "@/lib/upcomingSessions";
 import { WelcomeEmptyState } from "./WelcomeEmptyState";
 import { UpcomingSessionsPanel } from "./UpcomingSessionsPanel";
 
-interface GameWithGMAndCount extends GameWithGM {
-  member_count: number;
-  is_co_gm: boolean;
-}
-
 export function DashboardContent() {
-  const { profile, authStatus } = useAuth();
+  const { user, profile, authStatus } = useAuth();
   const { use24h, timezone: userTimezone } = useUserPreferences();
-  const [games, setGames] = useState<GameWithGMAndCount[]>([]);
-  const [sessionRows, setSessionRows] = useState<UpcomingSessionRow[]>([]);
-  const [loading, setLoading] = useState(true);
   const supabase = createClient();
+  const userId = user?.id ?? '';
 
-  useEffect(() => {
-    async function fetchGames() {
-      if (!profile?.id) {
-        // No profile, nothing to fetch
-        setLoading(false);
-        return;
-      }
+  const { data, isPending } = useQuery({
+    queryKey: queryKeys.dashboard(userId),
+    queryFn: () => fetchDashboardData(supabase, userId),
+    enabled: !!userId,
+  });
 
-      // Fetch games where user is GM or member, including co-GM status
-      const { data: memberships } = await fetchUserMemberships(supabase, profile.id);
+  const games: DashboardGame[] = data?.games ?? [];
 
-      const memberGameIds = memberships?.map((m) => m.game_id) || [];
-      const coGmGameIds = new Set(
-        memberships?.filter((m) => m.is_co_gm).map((m) => m.game_id) || []
-      );
+  // The clock comes from the queryFn (see DashboardData.fetchedAtMs) — reading
+  // it here would be an impure render (react-hooks/purity). staleTime plus
+  // refetch-on-focus keep the fetch-time clock close enough for day-granularity
+  // highlighting.
+  const sessionRows = useMemo(() => {
+    if (!data) return [];
+    const gameInfo = new Map<string, { name: string; timezone: string | null }>(
+      data.games.map((g) => [g.id, { name: g.name, timezone: g.timezone }])
+    );
+    return buildUpcomingSessionRows(data.upcoming, gameInfo, data.fetchedToday, data.fetchedAtMs);
+  }, [data]);
 
-      const { data: gmGames } = await fetchUserGmGames(supabase, profile.id);
-
-      // Only query for member games if user has memberships
-      const memberGames =
-        memberGameIds.length > 0
-          ? (
-              await supabase
-                .from("games")
-                .select("*, gm:users!games_gm_id_fkey(*)")
-                .in("id", memberGameIds)
-            ).data
-          : [];
-
-      // Combine and dedupe
-      const allGames = [...(gmGames || []), ...(memberGames || [])];
-      const uniqueGames = Array.from(
-        new Map(allGames.map((g) => [g.id, g])).values()
-      );
-
-      // Get member counts and add co-GM status
-      const gamesWithCounts = await Promise.all(
-        uniqueGames.map(async (game) => {
-          const { count } = await fetchMembershipCount(supabase, game.id);
-
-          return {
-            ...game,
-            member_count: (count || 0) + 1, // +1 for GM
-            is_co_gm: coGmGameIds.has(game.id),
-          };
-        })
-      );
-
-      setGames(gamesWithCounts as GameWithGMAndCount[]);
-
-      const nowMs = Date.now();
-      const today = getTodayLocalDate();
-      // Two-day buffer covers the full UTC-12..UTC+14 span; the per-game-timezone
-      // filter in buildUpcomingSessionRows then trims it precisely.
-      const queryFloor = getUpcomingQueryFloor(nowMs);
-      const gameIds = uniqueGames.map((g) => g.id);
-      const gameInfo = new Map<string, { name: string; timezone: string | null }>(
-        uniqueGames.map((g) => [g.id, { name: g.name, timezone: g.timezone }])
-      );
-      const { data: upcoming, error: sessionsError } = await fetchUpcomingSessionsForGames(
-        supabase,
-        gameIds,
-        queryFloor
-      );
-      if (sessionsError) {
-        // Games already rendered above; surface the failure rather than showing
-        // a silently-empty panel that looks like "no upcoming sessions".
-        console.error('[UpcomingSessions] failed to fetch upcoming sessions:', sessionsError);
-      }
-      setSessionRows(
-        buildUpcomingSessionRows(
-          (upcoming ?? []) as GameSession[],
-          gameInfo,
-          today,
-          nowMs
-        )
-      );
-
-      setLoading(false);
-    }
-
-    if (profile?.id) {
-      fetchGames();
-    } else if (authStatus !== 'loading') {
-      // Auth finished but no profile - stop loading
-      setLoading(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- supabase is stable
-  }, [profile?.id, authStatus]);
-
-  if (authStatus === 'loading' || loading) {
+  if (authStatus === 'loading' || (!!userId && isPending)) {
     return (
       <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center">
         <LoadingSpinner size="lg" />
@@ -161,7 +75,7 @@ export function DashboardContent() {
           <div className="order-last lg:order-first lg:flex-1">
             <ul className="grid gap-5 md:grid-cols-2">
               {games.map((game) => {
-            const isOwner = game.gm_id === profile?.id;
+            const isOwner = game.gm_id === userId;
             const cadence = game.ad_hoc_only
               ? 'Ad-hoc'
               : game.play_days.map((d) => DAY_LABELS.short[d]).join(', ');

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useAuth } from "@/contexts/AuthContext";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import Link from "next/link";
 import { Users, Calendar } from "lucide-react";
 import { Button, LoadingSpinner } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
 import { DAY_LABELS } from "@/lib/constants";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
 import { fetchDashboardData, type DashboardGame } from "@/lib/dashboardData";
 import { useUserPreferences } from "@/hooks/useUserPreferences";
@@ -21,11 +21,23 @@ export function DashboardContent() {
   const supabase = createClient();
   const userId = user?.id ?? '';
 
+  const queryClient = useQueryClient();
   const { data, isPending } = useQuery({
     queryKey: queryKeys.dashboard(userId),
     queryFn: () => fetchDashboardData(supabase, userId),
     enabled: !!userId,
   });
+
+  // The dashboard result already contains every game's id and name, so seed
+  // the my-games cache: the common dashboard -> game navigation then skips
+  // fetchMyGamesLite's two round trips entirely.
+  useEffect(() => {
+    if (!data || !userId) return;
+    queryClient.setQueryData(
+      queryKeys.myGamesLite(userId),
+      data.games.map((g) => ({ id: g.id, name: g.name }))
+    );
+  }, [data, userId, queryClient]);
 
   const games: DashboardGame[] = data?.games ?? [];
 

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -26,6 +26,8 @@ export interface AvailabilityTabContentProps {
     availableAfter: string | null,
     availableUntil: string | null
   ) => void;
+  /** Applies a bulk status change in one call. When omitted, the calendar falls back to per-date onToggle calls. */
+  onBulkSet?: (dates: string[], status: AvailabilityStatus) => void;
   confirmedSessions: GameSession[];
   extraPlayDates: string[];
   isGmOrCoGm: boolean;
@@ -54,7 +56,7 @@ export interface AvailabilityTabContentProps {
 export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
   const {
     windowStart, windowEnd, currentUserId, completionByUserId,
-    playDays, availability, onToggle, confirmedSessions, extraPlayDates,
+    playDays, availability, onToggle, onBulkSet, confirmedSessions, extraPlayDates,
     isGmOrCoGm, onToggleExtraDate, weekStartDay, use24h, otherGames,
     onCopyFromGame, onApplyDefaults, hasDefaults, playDateNotes, onUpdatePlayDateNote, hasCampaignDates,
     adHocOnly, readOnly = false, otherGameSessionsByDate = new Map(),
@@ -97,6 +99,7 @@ export function AvailabilityTabContent(props: AvailabilityTabContentProps) {
         windowEnd={windowEnd}
         availability={availability}
         onToggle={onToggle}
+        onBulkSet={onBulkSet}
         confirmedSessions={confirmedSessions}
         extraPlayDates={extraPlayDates}
         isGmOrCoGm={isGmOrCoGm}

--- a/src/components/games/availability/AvailabilityTabContent.tsx
+++ b/src/components/games/availability/AvailabilityTabContent.tsx
@@ -26,8 +26,8 @@ export interface AvailabilityTabContentProps {
     availableAfter: string | null,
     availableUntil: string | null
   ) => void;
-  /** Applies a bulk status change in one call. When omitted, the calendar falls back to per-date onToggle calls. */
-  onBulkSet?: (dates: string[], status: AvailabilityStatus) => void;
+  /** Applies a bulk status change in one batched call (read-only callers pass a no-op). */
+  onBulkSet: (dates: string[], status: AvailabilityStatus) => void;
   confirmedSessions: GameSession[];
   extraPlayDates: string[];
   isGmOrCoGm: boolean;

--- a/src/components/layout/Providers.tsx
+++ b/src/components/layout/Providers.tsx
@@ -1,19 +1,37 @@
 'use client';
 
 import { ThemeProvider } from 'next-themes';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { ThemeContextProvider } from '@/contexts/ThemeContext';
 import { ThemeCycler } from '@/components/dev/ThemeCycler';
 import { ToastProvider } from '@/components/ui/Toast';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
+import { QUERY_STALE_TIME } from '@/lib/constants';
 
 export function Providers({ children }: { children: ReactNode }) {
+  // useState keeps a single QueryClient for the life of the app while still
+  // creating a fresh one per render tree (avoids sharing cache across SSR requests).
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: QUERY_STALE_TIME,
+            retry: 1,
+          },
+        },
+      })
+  );
+
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <ThemeContextProvider>
-        <AuthProvider>
-          <ToastProvider>{children}</ToastProvider>
-        </AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </AuthProvider>
+        </QueryClientProvider>
         <ThemeCycler />
       </ThemeContextProvider>
     </ThemeProvider>

--- a/src/components/settings/DefaultAvailabilityEditor.tsx
+++ b/src/components/settings/DefaultAvailabilityEditor.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui';
 import { DAY_LABELS } from '@/lib/constants';
+import { queryKeys } from '@/lib/queryKeys';
 import type { WeekdayDefault } from '@/lib/defaultAvailability';
 import { fetchUserDefaults, upsertUserDefault, deleteUserDefault } from '@/lib/data';
 import { DefaultDayRow } from './DefaultDayRow';
@@ -29,6 +31,7 @@ function sameDefault(a: WeekdayDefault | undefined, b: WeekdayDefault | undefine
 
 export function DefaultAvailabilityEditor() {
   const { profile } = useAuth();
+  const queryClient = useQueryClient();
   const { weekStartDay, use24h } = useUserPreferences();
   const [defaults, setDefaults] = useState<DefaultsMap>({});
   const [saved, setSaved] = useState<DefaultsMap>({});
@@ -98,6 +101,11 @@ export function DefaultAvailabilityEditor() {
     } else {
       setSaved(defaults);
       setMessage('Default availability saved!');
+    }
+    // Game pages cache the defaults (for the "Apply defaults" button); refresh
+    // even on partial failure since some rows may have been written.
+    if (userId) {
+      queryClient.invalidateQueries({ queryKey: queryKeys.userDefaults(userId) });
     }
     setSaving(false);
   };

--- a/src/components/settings/DefaultAvailabilityEditor.tsx
+++ b/src/components/settings/DefaultAvailabilityEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import { createClient } from '@/lib/supabase/client';
@@ -35,35 +35,40 @@ export function DefaultAvailabilityEditor() {
   const { weekStartDay, use24h } = useUserPreferences();
   const [defaults, setDefaults] = useState<DefaultsMap>({});
   const [saved, setSaved] = useState<DefaultsMap>({});
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
 
   const userId = profile?.id;
 
+  // Read through the shared userDefaults cache (same key the game pages use)
+  // so navigating settings <-> game doesn't fetch the same rows twice.
+  const defaultsQuery = useQuery({
+    queryKey: queryKeys.userDefaults(userId ?? ''),
+    enabled: !!userId,
+    queryFn: async () => (await fetchUserDefaults(supabase, userId!)).data ?? [],
+  });
+  const loading = defaultsQuery.isPending;
+
+  // Hydrate the editable local state ONCE from the first resolved data.
+  // Background refetches (window refocus etc.) update the cache for other
+  // consumers but must not clobber unsaved edits here.
+  const hydratedRef = useRef(false);
   useEffect(() => {
-    if (!userId) return;
-    let cancelled = false;
-    (async () => {
-      const { data } = await fetchUserDefaults(supabase, userId);
-      if (cancelled) return;
-      const map: DefaultsMap = {};
-      data?.forEach((d) => {
-        map[d.day_of_week] = {
-          status: d.status,
-          comment: d.comment,
-          available_after: d.available_after,
-          available_until: d.available_until,
-        };
-      });
-      setDefaults(map);
-      setSaved(map);
-      setLoading(false);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [userId]);
+    if (hydratedRef.current || !defaultsQuery.data) return;
+    hydratedRef.current = true;
+    const map: DefaultsMap = {};
+    defaultsQuery.data.forEach((d) => {
+      map[d.day_of_week] = {
+        status: d.status,
+        comment: d.comment,
+        available_after: d.available_after,
+        available_until: d.available_until,
+      };
+    });
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time hydration of editable state from the first fetch
+    setDefaults(map);
+    setSaved(map);
+  }, [defaultsQuery.data]);
 
   // Edits only update local state; changes are persisted on Save.
   const handleChange = (dayOfWeek: number, next: WeekdayDefault | undefined) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, useRef, useMemo, ReactNode } from 'react';
 import { User as SupabaseUser, Session } from '@supabase/supabase-js';
+import { useQueryClient } from '@tanstack/react-query';
 import { createClient, onSupabaseStatus } from '@/lib/supabase/client';
 import { User } from '@/types';
 import { TIMEOUTS } from '@/lib/constants';
@@ -57,6 +58,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [backendError, setBackendError] = useState(false);
   const supabase = getSupabaseClient();
+  const queryClient = useQueryClient();
 
   const authStatus = useMemo(
     () => deriveAuthStatus(isLoading, session, profile, backendError),
@@ -181,6 +183,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       const newUserId = session?.user?.id ?? null;
       const userChanged = newUserId !== currentUserId;
+      // Game/availability/session caches are keyed by gameId, not userId, so a
+      // sign-out or account switch (which Supabase syncs across tabs without a
+      // reload) must drop the previous identity's cached data entirely.
+      if (userChanged && currentUserId !== null) {
+        queryClient.clear();
+      }
       currentUserId = newUserId;
 
       setSession(session);
@@ -230,7 +238,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         clearTimeout(sessionGraceRef.current);
       }
     };
-  }, [supabase, fetchProfile]);
+  }, [supabase, fetchProfile, queryClient]);
 
   async function signInWithGoogle(redirectTo?: string) {
     const redirectUrl = `${window.location.origin}/auth/callback${

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   getDay,
   startOfDay,
@@ -8,6 +8,7 @@ import {
   eachDayOfInterval,
   format,
 } from 'date-fns';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type {
   Availability,
@@ -22,11 +23,15 @@ import {
   batchUpsertAvailability,
   fetchUserDefaults,
 } from '@/lib/data';
+import { queryKeys } from '@/lib/queryKeys';
 import { filterAvailabilityForCopy, applyCopyConflicts, type CopyConflict } from '@/lib/copyAvailability';
+import { buildBulkUpsertEntries } from '@/lib/bulkAvailability';
 import { computeDefaultEntries, type WeekdayDefault } from '@/lib/defaultAvailability';
 import { getSchedulingWindow } from '@/lib/scheduling';
 
 const supabase = createClient();
+
+const EMPTY_AVAILABILITY: Availability[] = [];
 
 export interface ApplyDefaultsResult {
   /** False when the user has not configured any default availability yet. */
@@ -48,6 +53,8 @@ export interface UseAvailabilityReturn {
     availableAfter: string | null,
     availableUntil: string | null,
   ) => Promise<void>;
+  /** Set one status on many dates with a single batched upsert (bulk-actions bar). */
+  bulkSetStatus: (dates: string[], status: AvailabilityStatus) => Promise<void>;
   copyFromGame: (
     sourceGameId: string,
     extraDateStrings: string[],
@@ -63,40 +70,92 @@ export function useAvailability(
   userId: string,
   game: GameWithMembers | null,
 ): UseAvailabilityReturn {
-  const [availability, setAvailability] = useState<Record<string, AvailabilityEntry>>({});
-  const [allAvailability, setAllAvailability] = useState<Availability[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [hasDefaults, setHasDefaults] = useState<boolean | null>(null);
+  const queryClient = useQueryClient();
 
-  const fetchAll = useCallback(async () => {
-    if (!gameId || !userId) return;
-    const [userAvailRes, allAvailRes, defaultsRes] = await Promise.all([
-      fetchUserAvailability(supabase, gameId, userId),
-      fetchAllAvailability(supabase, gameId),
-      fetchUserDefaults(supabase, userId),
-    ]);
+  // Single source of truth: every player's rows for this game. The current
+  // user's own entries (the old separate fetchUserAvailability query) are
+  // derived from this set instead of fetched twice.
+  const allQuery = useQuery({
+    queryKey: queryKeys.availability(gameId),
+    enabled: !!gameId && !!userId,
+    queryFn: async () => (await fetchAllAvailability(supabase, gameId)).data ?? [],
+  });
+  const allAvailability = allQuery.data ?? EMPTY_AVAILABILITY;
 
+  const availability = useMemo(() => {
     const map: Record<string, AvailabilityEntry> = {};
-    userAvailRes.data?.forEach((a) => {
+    for (const a of allAvailability) {
+      if (a.user_id !== userId) continue;
       map[a.date] = {
         status: a.status,
         comment: a.comment,
         available_after: a.available_after,
         available_until: a.available_until,
       };
-    });
-    setAvailability(map);
-    setAllAvailability(allAvailRes.data || []);
-    setHasDefaults((defaultsRes.data?.length ?? 0) > 0);
-    setLoading(false);
-  }, [gameId, userId]);
+    }
+    return map;
+  }, [allAvailability, userId]);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-    if (userId) fetchAll();
-  }, [userId, fetchAll]);
+  const defaultsQueryFn = useCallback(
+    async () => (await fetchUserDefaults(supabase, userId)).data ?? [],
+    [userId]
+  );
+  const defaultsQuery = useQuery({
+    queryKey: queryKeys.userDefaults(userId),
+    enabled: !!userId,
+    queryFn: defaultsQueryFn,
+  });
+  const hasDefaults = defaultsQuery.data === undefined ? null : defaultsQuery.data.length > 0;
 
-  const refresh = fetchAll;
+  /**
+   * Optimistically write the current user's rows for the given dates into the
+   * availability cache. Returns a revert function that restores exactly the
+   * rows that were replaced or removed (not a whole-cache snapshot, so two
+   * in-flight changes to different dates can't clobber each other).
+   */
+  const optimisticallyApply = useCallback(
+    (entries: { date: string; entry: AvailabilityEntry }[]) => {
+      const key = queryKeys.availability(gameId);
+      const dates = new Set(entries.map((e) => e.date));
+      const prevRows = (queryClient.getQueryData<Availability[]>(key) ?? []).filter(
+        (a) => a.user_id === userId && dates.has(a.date)
+      );
+      const prevByDate = new Map(prevRows.map((r) => [r.date, r]));
+      const nowIso = new Date().toISOString();
+      const nextRows: Availability[] = entries.map(({ date, entry }) => ({
+        id: prevByDate.get(date)?.id ?? 'temp',
+        user_id: userId,
+        game_id: gameId,
+        date,
+        status: entry.status,
+        comment: entry.comment,
+        available_after: entry.available_after,
+        available_until: entry.available_until,
+        created_at: prevByDate.get(date)?.created_at ?? nowIso,
+        updated_at: nowIso,
+      }));
+
+      queryClient.setQueryData<Availability[]>(key, (cur = []) => [
+        ...cur.filter((a) => !(a.user_id === userId && dates.has(a.date))),
+        ...nextRows,
+      ]);
+
+      return () => {
+        queryClient.setQueryData<Availability[]>(key, (cur = []) => [
+          ...cur.filter((a) => !(a.user_id === userId && dates.has(a.date))),
+          ...prevRows,
+        ]);
+      };
+    },
+    [queryClient, gameId, userId]
+  );
+
+  const refresh = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.availability(gameId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.userDefaults(userId) }),
+    ]);
+  }, [queryClient, gameId, userId]);
 
   const changeAvailability = useCallback(
     async (
@@ -108,15 +167,17 @@ export function useAvailability(
     ) => {
       if (!userId || !gameId) return;
 
-      setAvailability((prev) => ({
-        ...prev,
-        [date]: {
-          status,
-          comment,
-          available_after: availableAfter,
-          available_until: availableUntil,
+      const revert = optimisticallyApply([
+        {
+          date,
+          entry: {
+            status,
+            comment,
+            available_after: availableAfter,
+            available_until: availableUntil,
+          },
         },
-      }));
+      ]);
 
       const { error } = await upsertAvailability(supabase, {
         user_id: userId,
@@ -128,47 +189,33 @@ export function useAvailability(
         available_until: availableUntil,
       });
 
-      if (error) {
-        setAvailability((prev) => {
-          const next = { ...prev };
-          delete next[date];
-          return next;
-        });
-        return;
-      }
-
-      setAllAvailability((prev) => {
-        const existing = prev.findIndex((a) => a.user_id === userId && a.date === date);
-        const now = new Date().toISOString();
-        if (existing >= 0) {
-          const updated = [...prev];
-          updated[existing] = {
-            ...updated[existing],
-            status,
-            comment,
-            available_after: availableAfter,
-            available_until: availableUntil,
-          };
-          return updated;
-        }
-        return [
-          ...prev,
-          {
-            id: 'temp',
-            user_id: userId,
-            game_id: gameId,
-            date,
-            status,
-            comment,
-            available_after: availableAfter,
-            available_until: availableUntil,
-            created_at: now,
-            updated_at: now,
-          },
-        ];
-      });
+      if (error) revert();
     },
-    [userId, gameId],
+    [userId, gameId, optimisticallyApply],
+  );
+
+  const bulkSetStatus = useCallback(
+    async (dates: string[], status: AvailabilityStatus) => {
+      if (!userId || !gameId || dates.length === 0) return;
+
+      // Preserve existing comments/time constraints, matching single-date toggles.
+      const entries = buildBulkUpsertEntries(dates, status, availability);
+      const revert = optimisticallyApply(entries);
+
+      const rows = entries.map(({ date, entry }) => ({
+        user_id: userId,
+        game_id: gameId,
+        date,
+        status: entry.status,
+        comment: entry.comment,
+        available_after: entry.available_after,
+        available_until: entry.available_until,
+      }));
+
+      const { error } = await batchUpsertAvailability(supabase, rows);
+      if (error) revert();
+    },
+    [userId, gameId, availability, optimisticallyApply],
   );
 
   const copyFromGame = useCallback(
@@ -213,11 +260,7 @@ export function useAvailability(
 
       if (finalEntries.length === 0) return { copied: 0, overridden: 0 };
 
-      setAvailability((prev) => {
-        const next = { ...prev };
-        for (const { date, entry } of finalEntries) next[date] = entry;
-        return next;
-      });
+      const revert = optimisticallyApply(finalEntries);
 
       const rows = finalEntries.map(({ date, entry }) => ({
         user_id: userId,
@@ -232,42 +275,27 @@ export function useAvailability(
       const { error } = await batchUpsertAvailability(supabase, rows);
 
       if (error) {
-        setAvailability((prev) => {
-          const next = { ...prev };
-          for (const { date } of finalEntries) delete next[date];
-          return next;
-        });
+        revert();
         throw error;
       }
-
-      const now = new Date().toISOString();
-      setAllAvailability((prev) => [
-        ...prev,
-        ...finalEntries.map(({ date, entry }) => ({
-          id: 'temp',
-          user_id: userId,
-          game_id: gameId,
-          date,
-          status: entry.status,
-          comment: entry.comment,
-          available_after: entry.available_after,
-          available_until: entry.available_until,
-          created_at: now,
-          updated_at: now,
-        })),
-      ]);
 
       const overridden = conflict ? conflict.dates.length : 0;
       return { copied: finalEntries.length - overridden, overridden };
     },
-    [userId, gameId, game, availability],
+    [userId, gameId, game, availability, optimisticallyApply],
   );
 
   const applyDefaults = useCallback(
     async (extraDateStrings: string[]): Promise<ApplyDefaultsResult> => {
       if (!userId || !gameId || !game) return { hadDefaults: false, filled: 0 };
 
-      const { data: defaultRows } = await fetchUserDefaults(supabase, userId);
+      // Force a fresh read (defaults may have been edited in another tab) and
+      // refresh the cached copy while we're at it.
+      const defaultRows = await queryClient.fetchQuery({
+        queryKey: queryKeys.userDefaults(userId),
+        queryFn: defaultsQueryFn,
+        staleTime: 0,
+      });
       if (!defaultRows || defaultRows.length === 0) {
         return { hadDefaults: false, filled: 0 };
       }
@@ -301,19 +329,17 @@ export function useAvailability(
 
       if (entries.length === 0) return { hadDefaults: true, filled: 0 };
 
-      // Optimistic local update.
-      setAvailability((prev) => {
-        const next = { ...prev };
-        for (const e of entries) {
-          next[e.date] = {
+      const revert = optimisticallyApply(
+        entries.map((e) => ({
+          date: e.date,
+          entry: {
             status: e.status,
             comment: e.comment,
             available_after: e.available_after,
             available_until: e.available_until,
-          };
-        }
-        return next;
-      });
+          },
+        }))
+      );
 
       const rows = entries.map((e) => ({
         user_id: userId,
@@ -327,46 +353,32 @@ export function useAvailability(
 
       const { error } = await batchUpsertAvailability(supabase, rows);
       if (error) {
-        setAvailability((prev) => {
-          const next = { ...prev };
-          for (const e of entries) delete next[e.date];
-          return next;
-        });
+        revert();
         throw error;
       }
 
-      const now = new Date().toISOString();
-      setAllAvailability((prev) => [
-        ...prev,
-        ...entries.map((e) => ({
-          id: 'temp',
-          user_id: userId,
-          game_id: gameId,
-          date: e.date,
-          status: e.status,
-          comment: e.comment,
-          available_after: e.available_after,
-          available_until: e.available_until,
-          created_at: now,
-          updated_at: now,
-        })),
-      ]);
-
       return { hadDefaults: true, filled: entries.length };
     },
-    [userId, gameId, game, availability],
+    [userId, gameId, game, availability, optimisticallyApply, queryClient, defaultsQueryFn],
   );
 
-  const removePlayerData = useCallback((playerId: string) => {
-    setAllAvailability((prev) => prev.filter((a) => a.user_id !== playerId));
-  }, []);
+  const removePlayerData = useCallback(
+    (playerId: string) => {
+      queryClient.setQueryData<Availability[]>(
+        queryKeys.availability(gameId),
+        (prev = []) => prev.filter((a) => a.user_id !== playerId)
+      );
+    },
+    [queryClient, gameId]
+  );
 
   return {
     availability,
     allAvailability,
-    loading,
+    loading: allQuery.isPending,
     hasDefaults,
     changeAvailability,
+    bulkSetStatus,
     copyFromGame,
     applyDefaults,
     removePlayerData,

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -107,6 +107,34 @@ export function useAvailability(
   });
   const hasDefaults = defaultsQuery.data === undefined ? null : defaultsQuery.data.length > 0;
 
+  /** Build a full upsert row for the current user from a per-date entry. */
+  const toUpsertRow = useCallback(
+    (date: string, entry: AvailabilityEntry) => ({
+      user_id: userId,
+      game_id: gameId,
+      date,
+      status: entry.status,
+      comment: entry.comment,
+      available_after: entry.available_after,
+      available_until: entry.available_until,
+    }),
+    [userId, gameId]
+  );
+
+  /**
+   * Recover from a failed write: roll back the optimistic rows, then refetch
+   * from the server. The refetch matters when writes to the same date
+   * interleave — an earlier write's rollback can clobber a later write that
+   * succeeded, and only server truth can untangle that.
+   */
+  const revertAndReconcile = useCallback(
+    (revert: () => void) => {
+      revert();
+      queryClient.invalidateQueries({ queryKey: queryKeys.availability(gameId) });
+    },
+    [queryClient, gameId]
+  );
+
   /**
    * Optimistically write the current user's rows for the given dates into the
    * availability cache. Returns a revert function that restores exactly the
@@ -179,19 +207,19 @@ export function useAvailability(
         },
       ]);
 
-      const { error } = await upsertAvailability(supabase, {
-        user_id: userId,
-        game_id: gameId,
-        date,
-        status,
-        comment,
-        available_after: availableAfter,
-        available_until: availableUntil,
-      });
+      const { error } = await upsertAvailability(
+        supabase,
+        toUpsertRow(date, {
+          status,
+          comment,
+          available_after: availableAfter,
+          available_until: availableUntil,
+        })
+      );
 
-      if (error) revert();
+      if (error) revertAndReconcile(revert);
     },
-    [userId, gameId, optimisticallyApply],
+    [userId, gameId, optimisticallyApply, toUpsertRow, revertAndReconcile],
   );
 
   const bulkSetStatus = useCallback(
@@ -202,20 +230,12 @@ export function useAvailability(
       const entries = buildBulkUpsertEntries(dates, status, availability);
       const revert = optimisticallyApply(entries);
 
-      const rows = entries.map(({ date, entry }) => ({
-        user_id: userId,
-        game_id: gameId,
-        date,
-        status: entry.status,
-        comment: entry.comment,
-        available_after: entry.available_after,
-        available_until: entry.available_until,
-      }));
+      const rows = entries.map(({ date, entry }) => toUpsertRow(date, entry));
 
       const { error } = await batchUpsertAvailability(supabase, rows);
-      if (error) revert();
+      if (error) revertAndReconcile(revert);
     },
-    [userId, gameId, availability, optimisticallyApply],
+    [userId, gameId, availability, optimisticallyApply, toUpsertRow, revertAndReconcile],
   );
 
   const copyFromGame = useCallback(
@@ -262,27 +282,19 @@ export function useAvailability(
 
       const revert = optimisticallyApply(finalEntries);
 
-      const rows = finalEntries.map(({ date, entry }) => ({
-        user_id: userId,
-        game_id: gameId,
-        date,
-        status: entry.status,
-        comment: entry.comment,
-        available_after: entry.available_after,
-        available_until: entry.available_until,
-      }));
+      const rows = finalEntries.map(({ date, entry }) => toUpsertRow(date, entry));
 
       const { error } = await batchUpsertAvailability(supabase, rows);
 
       if (error) {
-        revert();
+        revertAndReconcile(revert);
         throw error;
       }
 
       const overridden = conflict ? conflict.dates.length : 0;
       return { copied: finalEntries.length - overridden, overridden };
     },
-    [userId, gameId, game, availability, optimisticallyApply],
+    [userId, gameId, game, availability, optimisticallyApply, toUpsertRow, revertAndReconcile],
   );
 
   const applyDefaults = useCallback(
@@ -329,37 +341,28 @@ export function useAvailability(
 
       if (entries.length === 0) return { hadDefaults: true, filled: 0 };
 
-      const revert = optimisticallyApply(
-        entries.map((e) => ({
-          date: e.date,
-          entry: {
-            status: e.status,
-            comment: e.comment,
-            available_after: e.available_after,
-            available_until: e.available_until,
-          },
-        }))
-      );
-
-      const rows = entries.map((e) => ({
-        user_id: userId,
-        game_id: gameId,
+      const datedEntries = entries.map((e) => ({
         date: e.date,
-        status: e.status,
-        comment: e.comment,
-        available_after: e.available_after,
-        available_until: e.available_until,
+        entry: {
+          status: e.status,
+          comment: e.comment,
+          available_after: e.available_after,
+          available_until: e.available_until,
+        },
       }));
+      const revert = optimisticallyApply(datedEntries);
+
+      const rows = datedEntries.map(({ date, entry }) => toUpsertRow(date, entry));
 
       const { error } = await batchUpsertAvailability(supabase, rows);
       if (error) {
-        revert();
+        revertAndReconcile(revert);
         throw error;
       }
 
       return { hadDefaults: true, filled: entries.length };
     },
-    [userId, gameId, game, availability, optimisticallyApply, queryClient, defaultsQueryFn],
+    [userId, gameId, game, availability, optimisticallyApply, queryClient, defaultsQueryFn, toUpsertRow, revertAndReconcile],
   );
 
   const removePlayerData = useCallback(
@@ -375,7 +378,10 @@ export function useAvailability(
   return {
     availability,
     allAvailability,
-    loading: allQuery.isPending,
+    // Defaults gate loading too (both queries run in parallel, so this costs
+    // nothing): rendering before hasDefaults resolves would flash the
+    // ApplyDefaultsButton's null state for users with no defaults.
+    loading: allQuery.isPending || (!!userId && defaultsQuery.isPending),
     hasDefaults,
     changeAvailability,
     bulkSetStatus,

--- a/src/hooks/useGameMeta.ts
+++ b/src/hooks/useGameMeta.ts
@@ -15,7 +15,7 @@ import {
   deleteGame as deleteGameQuery,
   toggleCoGm as toggleCoGmQuery,
 } from '@/lib/data';
-import { queryKeys } from '@/lib/queryKeys';
+import { invalidateGamesLists, queryKeys } from '@/lib/queryKeys';
 import { withOptimistic } from './withOptimistic';
 
 export interface UseGameMetaReturn {
@@ -100,8 +100,7 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
     if (error) return false;
     // This game must disappear from the games lists on next visit.
     queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLite(userId) });
+    invalidateGamesLists(queryClient);
     return true;
   }, [userId, gameId, queryClient]);
 
@@ -114,7 +113,7 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
         prev ? { ...prev, members: prev.members.filter((m) => m.id !== playerId) } : prev
       );
       // Dashboard shows per-game member counts.
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboardAll });
       return true;
     },
     [gameId, setGame, queryClient]
@@ -125,10 +124,9 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
     const { error } = await deleteGameQuery(supabase, gameId);
     if (error) return false;
     queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
-    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-    queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLite(userId) });
+    invalidateGamesLists(queryClient);
     return true;
-  }, [gameId, userId, queryClient]);
+  }, [gameId, queryClient]);
 
   const toggleCoGm = useCallback(
     async (playerId: string, makeCoGm: boolean): Promise<boolean> => {

--- a/src/hooks/useGameMeta.ts
+++ b/src/hooks/useGameMeta.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { nanoid } from 'nanoid';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 
 const supabase = createClient();
@@ -7,13 +8,14 @@ import type { GameWithMembers } from '@/types';
 import {
   fetchGameWithGM,
   fetchGameMembers,
-  fetchUserOtherGames,
+  fetchMyGamesLite,
   regenerateInviteCode,
   leaveGame as leaveGameQuery,
   removePlayer as removePlayerQuery,
   deleteGame as deleteGameQuery,
   toggleCoGm as toggleCoGmQuery,
 } from '@/lib/data';
+import { queryKeys } from '@/lib/queryKeys';
 import { withOptimistic } from './withOptimistic';
 
 export interface UseGameMetaReturn {
@@ -30,40 +32,56 @@ export interface UseGameMetaReturn {
 }
 
 export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
-  const [game, setGame] = useState<GameWithMembers | null>(null);
-  const [otherGames, setOtherGames] = useState<{ id: string; name: string }[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [refreshing, setRefreshing] = useState(false);
 
-  const fetchAll = useCallback(async () => {
-    if (!gameId || !userId) return;
+  const gameQuery = useQuery({
+    queryKey: queryKeys.game(gameId),
+    enabled: !!gameId && !!userId,
+    queryFn: async (): Promise<GameWithMembers | null> => {
+      // Game and member list are independent; fetch them in parallel.
+      const [gameRes, membersRes] = await Promise.all([
+        fetchGameWithGM(supabase, gameId),
+        fetchGameMembers(supabase, gameId),
+      ]);
+      // Not found (or not a participant, which RLS reports the same way).
+      if (gameRes.error || !gameRes.data) return null;
+      return { ...gameRes.data, members: membersRes.data } as GameWithMembers;
+    },
+  });
 
-    const { data: gameData, error: gameError } = await fetchGameWithGM(supabase, gameId);
-    if (gameError || !gameData) {
-      setLoading(false);
-      return;
-    }
+  // Shared across game pages and kept fresh by join/create/leave invalidations;
+  // the current game is excluded at render rather than baked into the fetch.
+  const myGamesQuery = useQuery({
+    queryKey: queryKeys.myGamesLite(userId),
+    enabled: !!userId,
+    queryFn: () => fetchMyGamesLite(supabase, userId),
+  });
 
-    const [membersRes, otherGamesList] = await Promise.all([
-      fetchGameMembers(supabase, gameId),
-      fetchUserOtherGames(supabase, userId, gameId),
-    ]);
+  const game = gameQuery.data ?? null;
+  const otherGames = useMemo(
+    () => (myGamesQuery.data ?? []).filter((g) => g.id !== gameId),
+    [myGamesQuery.data, gameId]
+  );
 
-    setGame({ ...gameData, members: membersRes.data } as GameWithMembers);
-    setOtherGames(otherGamesList);
-    setLoading(false);
-  }, [gameId, userId]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-    if (userId) fetchAll();
-  }, [userId, fetchAll]);
+  const setGame = useCallback(
+    (updater: (prev: GameWithMembers | null) => GameWithMembers | null) => {
+      queryClient.setQueryData<GameWithMembers | null>(
+        queryKeys.game(gameId),
+        (prev) => updater(prev ?? null)
+      );
+    },
+    [queryClient, gameId]
+  );
 
   const refresh = useCallback(async () => {
     setRefreshing(true);
-    await fetchAll();
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLite(userId) }),
+    ]);
     setRefreshing(false);
-  }, [fetchAll]);
+  }, [queryClient, gameId, userId]);
 
   const regenerateInvite = useCallback(async () => {
     if (!game || !gameId) return;
@@ -74,13 +92,18 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
       revert: () => setGame((prev) => (prev ? { ...prev, invite_code: oldCode } : prev)),
       mutation: () => regenerateInviteCode(supabase, gameId, newCode),
     });
-  }, [game, gameId]);
+  }, [game, gameId, setGame]);
 
   const leaveGame = useCallback(async (): Promise<boolean> => {
     if (!userId || !gameId) return false;
     const { error } = await leaveGameQuery(supabase, gameId, userId);
-    return !error;
-  }, [userId, gameId]);
+    if (error) return false;
+    // This game must disappear from the games lists on next visit.
+    queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLite(userId) });
+    return true;
+  }, [userId, gameId, queryClient]);
 
   const removePlayer = useCallback(
     async (playerId: string): Promise<boolean> => {
@@ -88,18 +111,24 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
       const { error } = await removePlayerQuery(supabase, gameId, playerId);
       if (error) return false;
       setGame((prev) =>
-        prev ? { ...prev, members: prev.members.filter((m) => m.id !== playerId) } : prev,
+        prev ? { ...prev, members: prev.members.filter((m) => m.id !== playerId) } : prev
       );
+      // Dashboard shows per-game member counts.
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       return true;
     },
-    [gameId],
+    [gameId, setGame, queryClient]
   );
 
   const deleteGame = useCallback(async (): Promise<boolean> => {
     if (!gameId) return false;
     const { error } = await deleteGameQuery(supabase, gameId);
-    return !error;
-  }, [gameId]);
+    if (error) return false;
+    queryClient.invalidateQueries({ queryKey: queryKeys.game(gameId) });
+    queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLite(userId) });
+    return true;
+  }, [gameId, userId, queryClient]);
 
   const toggleCoGm = useCallback(
     async (playerId: string, makeCoGm: boolean): Promise<boolean> => {
@@ -111,19 +140,19 @@ export function useGameMeta(gameId: string, userId: string): UseGameMetaReturn {
           ? {
               ...prev,
               members: prev.members.map((m) =>
-                m.id === playerId ? { ...m, is_co_gm: makeCoGm } : m,
+                m.id === playerId ? { ...m, is_co_gm: makeCoGm } : m
               ),
             }
-          : prev,
+          : prev
       );
       return true;
     },
-    [gameId],
+    [gameId, setGame]
   );
 
   return {
     game,
-    loading,
+    loading: gameQuery.isPending,
     refreshing,
     otherGames,
     refresh,

--- a/src/hooks/useOtherGameSessions.ts
+++ b/src/hooks/useOtherGameSessions.ts
@@ -1,6 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { fetchUpcomingSessionsForGames } from '@/lib/data';
+import { queryKeys } from '@/lib/queryKeys';
 import { getTodayLocalDate } from '@/lib/upcomingSessions';
 import {
   buildOtherGameSessionMap,
@@ -8,6 +10,8 @@ import {
 } from '@/lib/otherGameSessions';
 
 const supabase = createClient();
+
+const EMPTY_MAP = new Map<string, OtherGameSessionInfo[]>();
 
 export interface UseOtherGameSessionsReturn {
   otherGameSessionsByDate: Map<string, OtherGameSessionInfo[]>;
@@ -18,45 +22,27 @@ export interface UseOtherGameSessionsReturn {
  * read a game's sessions) and index them by date, so the availability calendar
  * can flag nights the player is already scheduled elsewhere.
  *
- * The serialized key of `otherGames` is the effect dependency, so the fetch only
- * re-runs when the set of other games actually changes (not on every render).
+ * The query key encodes the (sorted) game-id set, so the fetch only re-runs
+ * when the set of other games actually changes.
  */
 export function useOtherGameSessions(
   otherGames: { id: string; name: string }[],
   userId: string,
 ): UseOtherGameSessionsReturn {
-  const [otherGameSessionsByDate, setOtherGameSessionsByDate] = useState<
-    Map<string, OtherGameSessionInfo[]>
-  >(new Map());
+  const gameIds = useMemo(() => otherGames.map((g) => g.id), [otherGames]);
 
-  const gamesKey = otherGames.map((g) => `${g.id}:${g.name}`).join('|');
+  const sessionsQuery = useQuery({
+    queryKey: queryKeys.otherGameSessions(gameIds),
+    enabled: !!userId && gameIds.length > 0,
+    queryFn: async () =>
+      (await fetchUpcomingSessionsForGames(supabase, gameIds, getTodayLocalDate())).data ?? [],
+  });
 
-  useEffect(() => {
-    if (!userId || otherGames.length === 0) {
-      setOtherGameSessionsByDate(new Map());
-      return;
-    }
-
-    let cancelled = false;
-    (async () => {
-      const ids = otherGames.map((g) => g.id);
-      const nameById = new Map(otherGames.map((g) => [g.id, g.name]));
-      const { data } = await fetchUpcomingSessionsForGames(
-        supabase,
-        ids,
-        getTodayLocalDate(),
-      );
-      if (cancelled) return;
-      setOtherGameSessionsByDate(
-        buildOtherGameSessionMap(data ?? [], nameById, getTodayLocalDate()),
-      );
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- gamesKey encodes otherGames; supabase is stable
-  }, [gamesKey, userId]);
+  const otherGameSessionsByDate = useMemo(() => {
+    if (!sessionsQuery.data || otherGames.length === 0) return EMPTY_MAP;
+    const nameById = new Map(otherGames.map((g) => [g.id, g.name]));
+    return buildOtherGameSessionMap(sessionsQuery.data, nameById, getTodayLocalDate());
+  }, [sessionsQuery.data, otherGames]);
 
   return { otherGameSessionsByDate };
 }

--- a/src/hooks/usePlayDates.ts
+++ b/src/hooks/usePlayDates.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { GamePlayDate } from '@/types';
 import {
@@ -8,8 +9,11 @@ import {
   updatePlayDateNote as updatePlayDateNoteQuery,
   upsertPlayDate,
 } from '@/lib/data';
+import { queryKeys } from '@/lib/queryKeys';
 
 const supabase = createClient();
+
+const EMPTY_PLAY_DATES: GamePlayDate[] = [];
 
 export interface UsePlayDatesReturn {
   gamePlayDates: GamePlayDate[];
@@ -19,21 +23,30 @@ export interface UsePlayDatesReturn {
   refresh: () => Promise<void>;
 }
 
-export function usePlayDates(gameId: string, ready: boolean): UsePlayDatesReturn {
-  const [gamePlayDates, setGamePlayDates] = useState<GamePlayDate[]>([]);
-  const [loading, setLoading] = useState(true);
+export function usePlayDates(gameId: string): UsePlayDatesReturn {
+  const queryClient = useQueryClient();
 
-  const fetchAll = useCallback(async () => {
-    if (!gameId) return;
-    const { data } = await fetchGamePlayDates(supabase, gameId);
-    setGamePlayDates(data || []);
-    setLoading(false);
-  }, [gameId]);
+  // Fires as soon as the gameId is known (no need to wait for the game fetch);
+  // RLS returns an empty list for non-participants.
+  const playDatesQuery = useQuery({
+    queryKey: queryKeys.playDates(gameId),
+    enabled: !!gameId,
+    queryFn: async () => (await fetchGamePlayDates(supabase, gameId)).data ?? [],
+  });
+  const gamePlayDates = playDatesQuery.data ?? EMPTY_PLAY_DATES;
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-    if (ready) fetchAll();
-  }, [ready, fetchAll]);
+  const setGamePlayDates = useCallback(
+    (updater: (prev: GamePlayDate[]) => GamePlayDate[]) => {
+      queryClient.setQueryData<GamePlayDate[]>(queryKeys.playDates(gameId), (prev = []) =>
+        updater(prev)
+      );
+    },
+    [queryClient, gameId]
+  );
+
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.playDates(gameId) });
+  }, [queryClient, gameId]);
 
   const toggleExtraDate = useCallback(
     async (date: string, isCurrentlyExtra: boolean) => {
@@ -72,7 +85,7 @@ export function usePlayDates(gameId: string, ready: boolean): UsePlayDatesReturn
         );
       }
     },
-    [gameId, gamePlayDates],
+    [gameId, gamePlayDates, setGamePlayDates],
   );
 
   const updatePlayDateNote = useCallback(
@@ -109,8 +122,8 @@ export function usePlayDates(gameId: string, ready: boolean): UsePlayDatesReturn
         );
       }
     },
-    [gameId, gamePlayDates],
+    [gameId, gamePlayDates, setGamePlayDates],
   );
 
-  return { gamePlayDates, loading, toggleExtraDate, updatePlayDateNote, refresh: fetchAll };
+  return { gamePlayDates, loading: playDatesQuery.isPending, toggleExtraDate, updatePlayDateNote, refresh };
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { parseISO, startOfDay } from 'date-fns';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { GameSession } from '@/types';
 import {
@@ -8,9 +9,12 @@ import {
   cancelSession as cancelSessionQuery,
   updateSession as updateSessionQuery,
 } from '@/lib/data';
+import { queryKeys } from '@/lib/queryKeys';
 import { USAGE_LIMITS } from '@/lib/constants';
 
 const supabase = createClient();
+
+const EMPTY_SESSIONS: GameSession[] = [];
 
 export interface UseSessionsReturn {
   sessions: GameSession[];
@@ -36,21 +40,30 @@ export interface UseSessionsReturn {
   refresh: () => Promise<void>;
 }
 
-export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
-  const [sessions, setSessions] = useState<GameSession[]>([]);
-  const [loading, setLoading] = useState(true);
+export function useSessions(gameId: string): UseSessionsReturn {
+  const queryClient = useQueryClient();
 
-  const fetchAll = useCallback(async () => {
-    if (!gameId) return;
-    const { data } = await fetchGameSessions(supabase, gameId);
-    setSessions(data || []);
-    setLoading(false);
-  }, [gameId]);
+  // Fires as soon as the gameId is known (no need to wait for the game fetch);
+  // RLS returns an empty list for non-participants.
+  const sessionsQuery = useQuery({
+    queryKey: queryKeys.sessions(gameId),
+    enabled: !!gameId,
+    queryFn: async () => (await fetchGameSessions(supabase, gameId)).data ?? [],
+  });
+  const sessions = sessionsQuery.data ?? EMPTY_SESSIONS;
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-    if (ready) fetchAll();
-  }, [ready, fetchAll]);
+  const setSessions = useCallback(
+    (updater: (prev: GameSession[]) => GameSession[]) => {
+      queryClient.setQueryData<GameSession[]>(queryKeys.sessions(gameId), (prev = []) =>
+        updater(prev)
+      );
+    },
+    [queryClient, gameId]
+  );
+
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.sessions(gameId) });
+  }, [queryClient, gameId]);
 
   const confirmSession = useCallback(
     async (
@@ -111,11 +124,13 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
           }
           return [...prev, data].sort((a, b) => a.date.localeCompare(b.date));
         });
+        // The dashboard's upcoming-sessions panel includes this game.
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       }
 
       return { success: true };
     },
-    [gameId, sessions],
+    [gameId, sessions, setSessions, queryClient],
   );
 
   const updateSession = useCallback(
@@ -134,7 +149,7 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
       if (error) {
         if (error.code === 'PGRST116') {
           // Row was deleted by another GM in another tab.
-          await fetchAll();
+          await refresh();
           return { success: false, error: 'This session no longer exists.' };
         }
         if (error.code === '42501') {
@@ -145,10 +160,11 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
 
       if (data) {
         setSessions((prev) => prev.map((s) => (s.id === data.id ? data : s)));
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       }
       return { success: true };
     },
-    [fetchAll, gameId],
+    [gameId, setSessions, refresh, queryClient],
   );
 
   const cancelSession = useCallback(
@@ -157,10 +173,18 @@ export function useSessions(gameId: string, ready: boolean): UseSessionsReturn {
       const { error } = await cancelSessionQuery(supabase, gameId, date);
       if (error) return { success: false, error: error.message };
       setSessions((prev) => prev.filter((s) => s.date !== date));
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
       return { success: true };
     },
-    [gameId],
+    [gameId, setSessions, queryClient],
   );
 
-  return { sessions, loading, confirmSession, updateSession, cancelSession, refresh: fetchAll };
+  return {
+    sessions,
+    loading: sessionsQuery.isPending,
+    confirmSession,
+    updateSession,
+    cancelSession,
+    refresh,
+  };
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -125,7 +125,7 @@ export function useSessions(gameId: string): UseSessionsReturn {
           return [...prev, data].sort((a, b) => a.date.localeCompare(b.date));
         });
         // The dashboard's upcoming-sessions panel includes this game.
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboardAll });
       }
 
       return { success: true };
@@ -160,7 +160,7 @@ export function useSessions(gameId: string): UseSessionsReturn {
 
       if (data) {
         setSessions((prev) => prev.map((s) => (s.id === data.id ? data : s)));
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.dashboardAll });
       }
       return { success: true };
     },
@@ -173,7 +173,7 @@ export function useSessions(gameId: string): UseSessionsReturn {
       const { error } = await cancelSessionQuery(supabase, gameId, date);
       if (error) return { success: false, error: error.message };
       setSessions((prev) => prev.filter((s) => s.date !== date));
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboardAll });
       return { success: true };
     },
     [gameId, setSessions, queryClient],

--- a/src/lib/bulkAvailability.test.ts
+++ b/src/lib/bulkAvailability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterDatesForBulkSet } from "./bulkAvailability";
+import { filterDatesForBulkSet, buildBulkUpsertEntries } from "./bulkAvailability";
 import { AvailabilityEntry } from "@/lib/availabilityStatus";
 
 // Helper functions matching date-fns behavior
@@ -251,5 +251,73 @@ describe("filterDatesForBulkSet", () => {
     });
 
     expect(result).toEqual(["2025-01-18", "2025-01-25"]);
+  });
+});
+
+describe("buildBulkUpsertEntries", () => {
+  it("sets the given status on every date", () => {
+    const dates = ["2025-01-17", "2025-01-18", "2025-01-24"];
+
+    const result = buildBulkUpsertEntries(dates, "available", {});
+
+    expect(result.every((r) => r.entry.status === "available")).toBe(true);
+  });
+
+  it("preserves existing comment/available_after/available_until for dates present in existingAvailability", () => {
+    const dates = ["2025-01-17"];
+    const existingAvailability: Record<string, AvailabilityEntry> = {
+      "2025-01-17": {
+        status: "unavailable",
+        comment: "Depends on work",
+        available_after: "18:00:00",
+        available_until: "23:00:00",
+      },
+    };
+
+    const result = buildBulkUpsertEntries(dates, "maybe", existingAvailability);
+
+    expect(result).toEqual([
+      {
+        date: "2025-01-17",
+        entry: {
+          status: "maybe",
+          comment: "Depends on work",
+          available_after: "18:00:00",
+          available_until: "23:00:00",
+        },
+      },
+    ]);
+  });
+
+  it("nulls comment/available_after/available_until for dates without an entry", () => {
+    const dates = ["2025-01-20"];
+
+    const result = buildBulkUpsertEntries(dates, "unavailable", {});
+
+    expect(result).toEqual([
+      {
+        date: "2025-01-20",
+        entry: {
+          status: "unavailable",
+          comment: null,
+          available_after: null,
+          available_until: null,
+        },
+      },
+    ]);
+  });
+
+  it("returns entries in input date order", () => {
+    const dates = ["2025-01-24", "2025-01-17", "2025-01-20"];
+
+    const result = buildBulkUpsertEntries(dates, "available", {});
+
+    expect(result.map((r) => r.date)).toEqual(["2025-01-24", "2025-01-17", "2025-01-20"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    const result = buildBulkUpsertEntries([], "available", {});
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/lib/bulkAvailability.ts
+++ b/src/lib/bulkAvailability.ts
@@ -1,4 +1,5 @@
 import { AvailabilityEntry } from "@/lib/availabilityStatus";
+import type { AvailabilityStatus } from "@/types";
 
 interface FilterDatesParams {
   filter: string; // "remaining" or day number "0"-"6"
@@ -62,4 +63,28 @@ export function filterDatesForBulkSet({
       }
     })
     .map((date) => formatDate(date));
+}
+
+/**
+ * Build the full availability entries for a bulk status change, preserving any
+ * existing comment and time constraints on dates that already have an entry
+ * (matches the single-date toggle behavior, where only the status cycles).
+ */
+export function buildBulkUpsertEntries(
+  dates: string[],
+  status: AvailabilityStatus,
+  existingAvailability: Record<string, AvailabilityEntry>
+): { date: string; entry: AvailabilityEntry }[] {
+  return dates.map((date) => {
+    const existing = existingAvailability[date];
+    return {
+      date,
+      entry: {
+        status,
+        comment: existing?.comment ?? null,
+        available_after: existing?.available_after ?? null,
+        available_until: existing?.available_until ?? null,
+      },
+    };
+  });
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,11 @@ export const TIMEOUTS = {
   BACKEND_HEALTH_RECHECK: 30000,
 } as const;
 
+// How long React Query treats fetched data as fresh (ms). Within this window,
+// remounting a page (e.g. dashboard -> game -> back) reuses the cache instead
+// of refetching; a window refocus or explicit invalidation refetches sooner.
+export const QUERY_STALE_TIME = 45_000;
+
 // Default session times
 export const SESSION_DEFAULTS = {
   START_TIME: '18:00',

--- a/src/lib/dashboardData.test.ts
+++ b/src/lib/dashboardData.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { mergeDashboardGames, type GameWithGMAndCounts } from "./dashboardData";
+import type { User } from "@/types";
+
+const makeUser = (overrides: Partial<User> = {}): User => ({
+  id: "gm-1",
+  email: "gm@example.com",
+  name: "GM Name",
+  avatar_url: null,
+  is_gm: true,
+  is_admin: false,
+  timezone: null,
+  week_start_day: 0,
+  time_format: "12h",
+  created_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+/** Helper: build a GameWithGMAndCounts fixture with sensible defaults, overriding as needed. */
+function makeGame(
+  overrides: Partial<GameWithGMAndCounts> & { id: string }
+): GameWithGMAndCounts {
+  return {
+    name: "Test Game",
+    description: null,
+    gm_id: "gm-1",
+    play_days: [],
+    invite_code: "abc123",
+    scheduling_window_months: 1,
+    default_start_time: null,
+    default_end_time: null,
+    timezone: null,
+    min_players_needed: 0,
+    ad_hoc_only: false,
+    campaign_start_date: null,
+    campaign_end_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    gm: makeUser(),
+    ...overrides,
+  };
+}
+
+describe("mergeDashboardGames", () => {
+  it("dedupes a game appearing in both lists, keeping the GM-list entry and order", () => {
+    const gmEntry = makeGame({ id: "g1", name: "From GM list", game_memberships: [{ count: 2 }] });
+    const memberEntry = makeGame({
+      id: "g1",
+      name: "From member list",
+      game_memberships: [{ count: 99 }],
+    });
+    const gmOnly = makeGame({ id: "g2", name: "GM only" });
+
+    const result = mergeDashboardGames({
+      gmGames: [gmEntry, gmOnly],
+      memberGames: [memberEntry],
+      memberships: [],
+    });
+
+    // GM games first, in order; the duplicate keeps its GM-list position (before g2).
+    expect(result.map((g) => g.id)).toEqual(["g1", "g2"]);
+    // The GM-list entry's content wins over the member-list entry for the same id.
+    expect(result[0].name).toBe("From GM list");
+    expect(result[0].member_count).toBe(3); // 2 + 1, not 99 + 1
+  });
+
+  it("computes member_count as the embedded count plus one for the GM", () => {
+    const game = makeGame({ id: "g1", game_memberships: [{ count: 4 }] });
+
+    const result = mergeDashboardGames({ gmGames: [game], memberGames: [], memberships: [] });
+
+    expect(result[0].member_count).toBe(5);
+  });
+
+  it("defaults member_count to 1 when the game_memberships embed is missing or empty", () => {
+    const missingEmbed = makeGame({ id: "g1" });
+    const emptyEmbed = makeGame({ id: "g2", game_memberships: [] });
+
+    const result = mergeDashboardGames({
+      gmGames: [missingEmbed, emptyEmbed],
+      memberGames: [],
+      memberships: [],
+    });
+
+    expect(result.find((g) => g.id === "g1")?.member_count).toBe(1);
+    expect(result.find((g) => g.id === "g2")?.member_count).toBe(1);
+  });
+
+  it("marks is_co_gm true only for games with a co-GM membership row", () => {
+    const coGmGame = makeGame({ id: "g1" });
+    const playerGame = makeGame({ id: "g2" });
+
+    const result = mergeDashboardGames({
+      gmGames: [],
+      memberGames: [coGmGame, playerGame],
+      memberships: [
+        { game_id: "g1", is_co_gm: true },
+        { game_id: "g2", is_co_gm: false },
+      ],
+    });
+
+    expect(result.find((g) => g.id === "g1")?.is_co_gm).toBe(true);
+    expect(result.find((g) => g.id === "g2")?.is_co_gm).toBe(false);
+  });
+
+  it("strips the game_memberships embed key from the returned rows", () => {
+    const game = makeGame({ id: "g1", game_memberships: [{ count: 1 }] });
+
+    const result = mergeDashboardGames({ gmGames: [game], memberGames: [], memberships: [] });
+
+    expect(result[0]).not.toHaveProperty("game_memberships");
+  });
+});

--- a/src/lib/dashboardData.test.ts
+++ b/src/lib/dashboardData.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect } from "vitest";
-import { mergeDashboardGames, type GameWithGMAndCounts } from "./dashboardData";
-import type { User } from "@/types";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mergeDashboardGames, fetchDashboardData, type GameWithGMAndCounts } from "./dashboardData";
+import type { User, GameSession } from "@/types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  fetchUserMemberships,
+  fetchUserGmGames,
+  fetchGamesWithGMByIds,
+  fetchUpcomingSessionsForGames,
+} from "@/lib/data";
+
+vi.mock("@/lib/data", () => ({
+  fetchUserMemberships: vi.fn(),
+  fetchUserGmGames: vi.fn(),
+  fetchGamesWithGMByIds: vi.fn(),
+  fetchUpcomingSessionsForGames: vi.fn(),
+}));
 
 const makeUser = (overrides: Partial<User> = {}): User => ({
   id: "gm-1",
@@ -108,5 +122,146 @@ describe("mergeDashboardGames", () => {
     const result = mergeDashboardGames({ gmGames: [game], memberGames: [], memberships: [] });
 
     expect(result[0]).not.toHaveProperty("game_memberships");
+  });
+});
+
+type MembershipsResult = Awaited<ReturnType<typeof fetchUserMemberships>>;
+type GmGamesResult = Awaited<ReturnType<typeof fetchUserGmGames>>;
+type MemberGamesResult = Awaited<ReturnType<typeof fetchGamesWithGMByIds>>;
+type SessionsResult = Awaited<ReturnType<typeof fetchUpcomingSessionsForGames>>;
+
+describe("fetchDashboardData", () => {
+  const supabase = {} as unknown as SupabaseClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges gm and member games (gm first), excludes already-gm-owned ids from the member-games fetch, and unions ids for the sessions fetch", async () => {
+    const gmGame = makeGame({ id: "g1", name: "GM Game", game_memberships: [{ count: 2 }] });
+    const memberGame = makeGame({ id: "m2", name: "Member Game", game_memberships: [{ count: 1 }] });
+    const session = { id: "s1", game_id: "g1" } as GameSession;
+
+    vi.mocked(fetchUserMemberships).mockResolvedValue({
+      data: [
+        { game_id: "g1", is_co_gm: false }, // already GM-owned; must be filtered out below
+        { game_id: "m2", is_co_gm: true },
+      ],
+      error: null,
+    } as unknown as MembershipsResult);
+    vi.mocked(fetchUserGmGames).mockResolvedValue({
+      data: [gmGame],
+      error: null,
+    } as unknown as GmGamesResult);
+    vi.mocked(fetchGamesWithGMByIds).mockResolvedValue({
+      data: [memberGame],
+      error: null,
+    } as unknown as MemberGamesResult);
+    vi.mocked(fetchUpcomingSessionsForGames).mockResolvedValue({
+      data: [session],
+      error: null,
+    } as unknown as SessionsResult);
+
+    const result = await fetchDashboardData(supabase, "user-1");
+
+    expect(result.games.map((g) => g.id)).toEqual(["g1", "m2"]);
+    expect(result.games[0].member_count).toBe(3); // 2 + 1
+    expect(result.games[0].is_co_gm).toBe(false);
+    expect(result.games[1].member_count).toBe(2); // 1 + 1
+    expect(result.games[1].is_co_gm).toBe(true);
+    expect(result.upcoming).toEqual([session]);
+
+    // Only the member id NOT already gm-owned ("g1" is filtered out) is resolved.
+    expect(fetchGamesWithGMByIds).toHaveBeenCalledTimes(1);
+    expect(fetchGamesWithGMByIds).toHaveBeenCalledWith(supabase, ["m2"]);
+    // Sessions are fetched across the full union of gm + member ids.
+    expect(fetchUpcomingSessionsForGames).toHaveBeenCalledWith(
+      supabase,
+      ["g1", "m2"],
+      expect.any(String),
+    );
+  });
+
+  it("does not call fetchGamesWithGMByIds when the user has no memberships, and still returns gm games plus upcoming sessions", async () => {
+    const gmGame = makeGame({ id: "g1", name: "GM Game" });
+    const session = { id: "s1", game_id: "g1" } as GameSession;
+
+    vi.mocked(fetchUserMemberships).mockResolvedValue({
+      data: [],
+      error: null,
+    } as unknown as MembershipsResult);
+    vi.mocked(fetchUserGmGames).mockResolvedValue({
+      data: [gmGame],
+      error: null,
+    } as unknown as GmGamesResult);
+    vi.mocked(fetchUpcomingSessionsForGames).mockResolvedValue({
+      data: [session],
+      error: null,
+    } as unknown as SessionsResult);
+
+    const result = await fetchDashboardData(supabase, "user-1");
+
+    expect(fetchGamesWithGMByIds).not.toHaveBeenCalled();
+    expect(result.games.map((g) => g.id)).toEqual(["g1"]);
+    expect(result.upcoming).toEqual([session]);
+    expect(fetchUpcomingSessionsForGames).toHaveBeenCalledWith(
+      supabase,
+      ["g1"],
+      expect.any(String),
+    );
+  });
+
+  it("logs the error and returns an empty upcoming list when the sessions fetch fails, while still returning games", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const gmGame = makeGame({ id: "g1", name: "GM Game" });
+    const sessionsError = { message: "boom" };
+
+    vi.mocked(fetchUserMemberships).mockResolvedValue({
+      data: [],
+      error: null,
+    } as unknown as MembershipsResult);
+    vi.mocked(fetchUserGmGames).mockResolvedValue({
+      data: [gmGame],
+      error: null,
+    } as unknown as GmGamesResult);
+    vi.mocked(fetchUpcomingSessionsForGames).mockResolvedValue({
+      data: null,
+      error: sessionsError,
+    } as unknown as SessionsResult);
+
+    const result = await fetchDashboardData(supabase, "user-1");
+
+    expect(result.upcoming).toEqual([]);
+    expect(result.games.map((g) => g.id)).toEqual(["g1"]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[UpcomingSessions] failed to fetch upcoming sessions:",
+      sessionsError,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns a plausible fetchedAtMs (number) and fetchedToday (YYYY-MM-DD string)", async () => {
+    vi.mocked(fetchUserMemberships).mockResolvedValue({
+      data: [],
+      error: null,
+    } as unknown as MembershipsResult);
+    vi.mocked(fetchUserGmGames).mockResolvedValue({
+      data: [],
+      error: null,
+    } as unknown as GmGamesResult);
+    vi.mocked(fetchUpcomingSessionsForGames).mockResolvedValue({
+      data: [],
+      error: null,
+    } as unknown as SessionsResult);
+
+    const before = Date.now();
+    const result = await fetchDashboardData(supabase, "user-1");
+    const after = Date.now();
+
+    expect(typeof result.fetchedAtMs).toBe("number");
+    expect(result.fetchedAtMs).toBeGreaterThanOrEqual(before);
+    expect(result.fetchedAtMs).toBeLessThanOrEqual(after);
+    expect(result.fetchedToday).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -33,9 +33,12 @@ export interface DashboardData {
 /**
  * Merge the GM-owned and member games lists into deduped dashboard rows.
  *
- * Pure function (no I/O), so it's directly unit-testable. GM games take
- * priority on id collisions, matching the pre-React-Query `new Map(...)`
- * dedupe (which put GM games first in the source array).
+ * Pure function (no I/O), so it's directly unit-testable. On an id collision
+ * the GM-list entry wins — a deliberate change from the pre-React-Query
+ * `new Map(...)` dedupe (where the later, member-list entry's content won):
+ * the user's own GM row is authoritative over a stray membership row for a
+ * game they host. fetchDashboardData also pre-filters overlapping ids, so
+ * collisions only arise from inconsistent data.
  */
 export function mergeDashboardGames({
   gmGames,

--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GameSession, GameWithGM } from '@/types';
+import {
+  fetchUserMemberships,
+  fetchUserGmGames,
+  fetchGamesWithGMByIds,
+  fetchUpcomingSessionsForGames,
+} from '@/lib/data';
+import { getTodayLocalDate, getUpcomingQueryFloor } from '@/lib/upcomingSessions';
+
+/** Row shape returned by the games queries with the embedded membership count. */
+export type GameWithGMAndCounts = GameWithGM & { game_memberships?: { count: number }[] };
+
+export interface DashboardGame extends GameWithGM {
+  member_count: number; // embedded count + 1 for the GM
+  is_co_gm: boolean; // current user is co-GM of this game
+}
+
+export interface DashboardData {
+  games: DashboardGame[];
+  upcoming: GameSession[];
+  /**
+   * Clock captured when the data was fetched. Render code derives the
+   * today/tomorrow highlighting from these instead of reading the clock during
+   * render (react-hooks/purity); staleTime plus refetch-on-focus bound how far
+   * they can drift, and a render-time read would be no fresher anyway since
+   * nothing re-renders on a timer.
+   */
+  fetchedAtMs: number;
+  fetchedToday: string;
+}
+
+/**
+ * Merge the GM-owned and member games lists into deduped dashboard rows.
+ *
+ * Pure function (no I/O), so it's directly unit-testable. GM games take
+ * priority on id collisions, matching the pre-React-Query `new Map(...)`
+ * dedupe (which put GM games first in the source array).
+ */
+export function mergeDashboardGames({
+  gmGames,
+  memberGames,
+  memberships,
+}: {
+  gmGames: GameWithGMAndCounts[];
+  memberGames: GameWithGMAndCounts[];
+  memberships: { game_id: string; is_co_gm: boolean }[];
+}): DashboardGame[] {
+  const coGmGameIds = new Set(
+    memberships.filter((m) => m.is_co_gm).map((m) => m.game_id)
+  );
+
+  // GM games first: on an id collision the GM-list entry wins (both content
+  // and position) since the user's own GM row is authoritative over any
+  // stale/edge-case membership row for that same game.
+  const merged = new Map<string, GameWithGMAndCounts>();
+  for (const game of [...gmGames, ...memberGames]) {
+    if (!merged.has(game.id)) merged.set(game.id, game);
+  }
+
+  return Array.from(merged.values()).map(({ game_memberships, ...game }) => ({
+    ...game,
+    member_count: (game_memberships?.[0]?.count ?? 0) + 1, // +1 for the GM
+    is_co_gm: coGmGameIds.has(game.id),
+  }));
+}
+
+/**
+ * Fetch everything the dashboard needs in two parallel round trips instead of
+ * a six-stage sequential waterfall with a per-game membership-count query:
+ *
+ *   Stage A: the user's memberships + GM-owned games (with embedded counts).
+ *   Stage B: the remaining member games (resolved by id) + upcoming sessions
+ *            across every game — both keyed off the ids resolved in Stage A.
+ */
+export async function fetchDashboardData(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<DashboardData> {
+  const fetchedAtMs = Date.now();
+  const fetchedToday = getTodayLocalDate();
+
+  const [{ data: memberships }, { data: gmGames }] = await Promise.all([
+    fetchUserMemberships(supabase, userId),
+    fetchUserGmGames(supabase, userId),
+  ]);
+
+  const gmGameIds = new Set((gmGames ?? []).map((g) => g.id));
+  const memberGameIds = (memberships ?? [])
+    .map((m) => m.game_id)
+    .filter((gameId) => !gmGameIds.has(gameId));
+  const allGameIds = [...gmGameIds, ...memberGameIds];
+
+  const [{ data: memberGames }, { data: upcoming, error: sessionsError }] = await Promise.all([
+    memberGameIds.length
+      ? fetchGamesWithGMByIds(supabase, memberGameIds)
+      : Promise.resolve({ data: [], error: null }),
+    fetchUpcomingSessionsForGames(supabase, allGameIds, getUpcomingQueryFloor(fetchedAtMs)),
+  ]);
+
+  if (sessionsError) {
+    // Games already resolved above; surface the failure rather than showing
+    // a silently-empty panel that looks like "no upcoming sessions".
+    console.error('[UpcomingSessions] failed to fetch upcoming sessions:', sessionsError);
+  }
+
+  return {
+    games: mergeDashboardGames({
+      gmGames: (gmGames ?? []) as GameWithGMAndCounts[],
+      memberGames: (memberGames ?? []) as GameWithGMAndCounts[],
+      memberships: (memberships ?? []) as { game_id: string; is_co_gm: boolean }[],
+    }),
+    upcoming: sessionsError ? [] : ((upcoming ?? []) as GameSession[]),
+    fetchedAtMs,
+    fetchedToday,
+  };
+}

--- a/src/lib/data/games.ts
+++ b/src/lib/data/games.ts
@@ -12,8 +12,20 @@ export async function fetchGameWithGM(supabase: SupabaseClient, gameId: string) 
 export async function fetchUserGmGames(supabase: SupabaseClient, userId: string) {
   return supabase
     .from('games')
-    .select('*, gm:users!games_gm_id_fkey(*)')
+    .select('*, gm:users!games_gm_id_fkey(*), game_memberships(count)')
     .eq('gm_id', userId);
+}
+
+/**
+ * Fetch a set of games (with GM profile and embedded membership count) by id.
+ * Used for the dashboard's "member" games — the ones the user belongs to but
+ * doesn't GM — resolved from the id list returned by fetchUserMemberships.
+ */
+export async function fetchGamesWithGMByIds(supabase: SupabaseClient, gameIds: string[]) {
+  return supabase
+    .from('games')
+    .select('*, gm:users!games_gm_id_fkey(*), game_memberships(count)')
+    .in('id', gameIds);
 }
 
 export async function fetchUserGameCount(supabase: SupabaseClient, userId: string) {

--- a/src/lib/data/memberships.ts
+++ b/src/lib/data/memberships.ts
@@ -35,28 +35,23 @@ export async function fetchMembershipCount(supabase: SupabaseClient, gameId: str
     .eq('game_id', gameId);
 }
 
-export async function fetchUserOtherGames(
-  supabase: SupabaseClient,
-  userId: string,
-  excludeGameId: string
-) {
-  const { data: memberGames } = await supabase
-    .from('game_memberships')
-    .select('game_id, games(id, name)')
-    .eq('user_id', userId);
-
-  const { data: gmGames } = await supabase
-    .from('games')
-    .select('id, name')
-    .eq('gm_id', userId);
+/**
+ * Every game the user participates in (as GM or member), as {id, name} pairs.
+ * Callers filter out the current game themselves so the result is cacheable
+ * per user rather than per (user, game) pair.
+ */
+export async function fetchMyGamesLite(supabase: SupabaseClient, userId: string) {
+  const [memberRes, gmRes] = await Promise.all([
+    supabase.from('game_memberships').select('game_id, games(id, name)').eq('user_id', userId),
+    supabase.from('games').select('id, name').eq('gm_id', userId),
+  ]);
 
   const gameMap = new Map<string, string>();
-  gmGames?.forEach((g) => gameMap.set(g.id, g.name));
-  memberGames?.forEach((m) => {
+  gmRes.data?.forEach((g) => gameMap.set(g.id, g.name));
+  memberRes.data?.forEach((m) => {
     const g = m.games as unknown as { id: string; name: string } | null;
     if (g) gameMap.set(g.id, g.name);
   });
-  gameMap.delete(excludeGameId);
 
   return Array.from(gameMap.entries()).map(([id, name]) => ({ id, name }));
 }

--- a/src/lib/data/memberships.ts
+++ b/src/lib/data/memberships.ts
@@ -28,13 +28,6 @@ export async function fetchUserMemberships(supabase: SupabaseClient, userId: str
     .eq('user_id', userId);
 }
 
-export async function fetchMembershipCount(supabase: SupabaseClient, gameId: string) {
-  return supabase
-    .from('game_memberships')
-    .select('*', { count: 'exact', head: true })
-    .eq('game_id', gameId);
-}
-
 /**
  * Every game the user participates in (as GM or member), as {id, name} pairs.
  * Callers filter out the current game themselves so the result is cacheable

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,15 +1,22 @@
+import type { QueryClient } from '@tanstack/react-query';
+
 /**
  * Central registry of React Query cache keys.
  *
  * Every useQuery/setQueryData/invalidateQueries call must build its key here so
  * that producers and invalidators can never drift apart. Keys are hierarchical:
- * invalidating a prefix (e.g. `['dashboard']`) invalidates every user's entry.
+ * invalidating a prefix (e.g. `queryKeys.dashboardAll`) invalidates every
+ * user's entry — prefixes are exported from here too, never written inline.
  */
 export const queryKeys = {
   /** Dashboard bundle: the user's games (with member counts) + upcoming sessions. */
   dashboard: (userId: string) => ['dashboard', userId] as const,
+  /** Prefix matching every user's dashboard entry (for invalidation). */
+  dashboardAll: ['dashboard'] as const,
   /** Lightweight {id, name} list of every game the user is in (GM or player). */
   myGamesLite: (userId: string) => ['myGamesLite', userId] as const,
+  /** Prefix matching every user's my-games list (for invalidation). */
+  myGamesLiteAll: ['myGamesLite'] as const,
   /** A single game with GM profile and member list. */
   game: (gameId: string) => ['game', gameId] as const,
   /** All availability rows for a game (every player). */
@@ -24,3 +31,14 @@ export const queryKeys = {
   otherGameSessions: (gameIds: string[]) =>
     ['otherGameSessions', [...gameIds].sort().join('|')] as const,
 } as const;
+
+/**
+ * Invalidate every cached view of "which games am I in" — the dashboard bundle
+ * and the my-games list. Call after any mutation that changes game membership
+ * or a game's existence/summary fields (create, join, leave, delete, edit,
+ * member removal, session changes shown on the dashboard).
+ */
+export function invalidateGamesLists(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.dashboardAll });
+  queryClient.invalidateQueries({ queryKey: queryKeys.myGamesLiteAll });
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,26 @@
+/**
+ * Central registry of React Query cache keys.
+ *
+ * Every useQuery/setQueryData/invalidateQueries call must build its key here so
+ * that producers and invalidators can never drift apart. Keys are hierarchical:
+ * invalidating a prefix (e.g. `['dashboard']`) invalidates every user's entry.
+ */
+export const queryKeys = {
+  /** Dashboard bundle: the user's games (with member counts) + upcoming sessions. */
+  dashboard: (userId: string) => ['dashboard', userId] as const,
+  /** Lightweight {id, name} list of every game the user is in (GM or player). */
+  myGamesLite: (userId: string) => ['myGamesLite', userId] as const,
+  /** A single game with GM profile and member list. */
+  game: (gameId: string) => ['game', gameId] as const,
+  /** All availability rows for a game (every player). */
+  availability: (gameId: string) => ['availability', gameId] as const,
+  /** All sessions for a game. */
+  sessions: (gameId: string) => ['sessions', gameId] as const,
+  /** Special play dates for a game. */
+  playDates: (gameId: string) => ['playDates', gameId] as const,
+  /** The user's weekly default availability rows. */
+  userDefaults: (userId: string) => ['userDefaults', userId] as const,
+  /** Upcoming sessions across a set of games (order-insensitive). */
+  otherGameSessions: (gameIds: string[]) =>
+    ['otherGameSessions', [...gameIds].sort().join('|')] as const,
+} as const;


### PR DESCRIPTION
## Summary

Client data fetching was a stack of sequential query waterfalls with no caching: the dashboard alone ran 6 serial round-trip stages including an N+1 membership-count query per game, the game page fetched the user's own availability twice and gated independent queries on each other, and bulk availability marking fired one HTTP upsert per date (~150 requests on a 12-month window). This PR restructures all of it around TanStack Query v5.

### Dashboard (`src/lib/dashboardData.ts`)
- 6 serial stages + N+1 count queries → **2 parallel stages, 4 requests** for a typical user
- Member counts come embedded via `game_memberships(count)` aggregates — no per-game count queries
- Fetch keys off `session.user.id` instead of waiting for the `profile` row (one round trip earlier, runs concurrently with the profile fetch)

### Game page hooks
- All hooks (`useGameMeta`, `useAvailability`, `useSessions`, `usePlayDates`) fire in parallel as soon as `gameId`/`userId` are known; the old `ready` gating and internal sequential awaits are gone
- The current user's availability map is **derived** from the all-players query instead of fetched separately (one query less, half the transfer for own rows)

### Bulk availability
- "Mark all remaining/[weekday]" now builds its rows via the previously-unused (but tested) `filterDatesForBulkSet` and issues **one** `batchUpsertAvailability` call through the new required `onBulkSet` prop — the per-date fallback loop is deleted so future callers can't silently regress

### Caching layer (TanStack Query v5)
- `QueryClientProvider` with 45s `staleTime`; dashboard ↔ game navigation inside the window is served from cache
- Central key registry (`src/lib/queryKeys.ts`) owns every key **and** every invalidation prefix; mutations write optimistically to the cache with surgical rollback and invalidate the other views their data appears in (join/create/edit/delete/session changes → games lists, etc.)
- Query cache is cleared on auth identity change (Supabase syncs sign-in/out across tabs), so a user switch can never serve the previous identity's cached data
- Failed availability writes revert **and refetch** so an interleaved earlier failure can't clobber a later successful write
- Dashboard result seeds the `myGamesLite` cache, so the hot dashboard → game navigation skips that fetch entirely

An 8-angle adversarial self-review ran over the diff before pushing; all 11 confirmed findings are fixed in `db05092`.

## Test plan

- [x] 584 unit tests pass (14 new: dashboard merge/orchestration, bulk entry building)
- [x] `next build` + `tsc` + ESLint clean
- [x] E2E suite (Playwright) green on CI — availability bulk actions, marking, dashboard, game detail, scheduling flows all have existing coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185yYxR2HNiUHRcSx7wwDyo

---
_Generated by [Claude Code](https://claude.ai/code/session_0185yYxR2HNiUHRcSx7wwDyo)_