### PR TITLE
Harden schema-management CLIs per code review

### DIFF
--- a/scripts/check-schema-drift.sh
+++ b/scripts/check-schema-drift.sh
@@ -3,13 +3,19 @@
 # Compare supabase/schema.sql against a live database (default: PROD).
 #
 # Default mode builds a THROWAWAY reference database from schema.sql on the
-# local Supabase cluster — the reference is always exactly schema.sql, never a
+# local Supabase cluster (uniquely named per invocation; only that database is
+# dropped afterwards) — the reference is always exactly schema.sql, never a
 # possibly-stale dev database — then compares two things:
 #   1. Structure: pg_dump --schema-only --schema=public, normalized.
-#   2. Privileges: anon/authenticated EXECUTE on every public function and
-#      table-level rights on every public table (catalog queries), because the
-#      structural dump deliberately omits ACLs and this app's security posture
-#      depends on function grant lockdown.
+#   2. Privileges: for anon/authenticated/service_role — schema USAGE/CREATE,
+#      all seven table privileges (incl. TRUNCATE/REFERENCES/TRIGGER),
+#      sequence privileges, and function EXECUTE, via catalog queries (the
+#      structural dump deliberately omits ACLs, and this app's security
+#      posture depends on function grant lockdown).
+#      NOT covered: object ownership and default privileges (pg_default_acl) —
+#      owners legitimately differ between local and hosted Supabase, and
+#      default ACLs only affect future objects, whose actual privileges this
+#      check catches once they exist.
 #
 # Usage:
 #   npm run db:drift                        # schema.sql vs prod (DATABASE_URL)
@@ -22,10 +28,11 @@
 set -euo pipefail
 
 CLUSTER_URL="${DRIFT_CLUSTER_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
-TEMP_DB="_schema_drift_ref"
+TEMP_DB="_drift_ref_$$_${RANDOM}"
 
 cleanup() {
   if [ "${BUILT_REF:-}" = "1" ]; then
+    # Only ever drops the uniquely-named database THIS invocation created.
     psql "$CLUSTER_URL" -X -q -c "DROP DATABASE IF EXISTS $TEMP_DB WITH (FORCE);" >/dev/null 2>&1 || true
   fi
   rm -f "${TMP_A:-}" "${TMP_B:-}" "${PRIV_A:-}" "${PRIV_B:-}"
@@ -46,8 +53,7 @@ else
   LABEL_B="prod (DATABASE_URL)"
   LABEL_A="schema.sql (fresh reference)"
 
-  echo "Building reference database from supabase/schema.sql ..."
-  psql "$CLUSTER_URL" -X -q -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS $TEMP_DB WITH (FORCE);"
+  echo "Building reference database from supabase/schema.sql ($TEMP_DB) ..."
   psql "$CLUSTER_URL" -X -q -v ON_ERROR_STOP=1 -c "CREATE DATABASE $TEMP_DB;"
   BUILT_REF=1
   URL_A="${CLUSTER_URL%/*}/$TEMP_DB"
@@ -81,11 +87,18 @@ dump_structure() {
 
 dump_privileges() {
   psql "$1" -X -q -v ON_ERROR_STOP=1 -At <<'SQL'
-SELECT 'function ' || p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'
-       || ' anon=' || has_function_privilege('anon', p.oid, 'EXECUTE')::text
-       || ' authenticated=' || has_function_privilege('authenticated', p.oid, 'EXECUTE')::text
+WITH roles(role) AS (VALUES ('anon'), ('authenticated'), ('service_role'))
+SELECT 'schema public ' || role || '='
+       || concat_ws(',',
+            CASE WHEN has_schema_privilege(role, 'public', 'USAGE') THEN 'usage' END,
+            CASE WHEN has_schema_privilege(role, 'public', 'CREATE') THEN 'create' END)
+FROM roles
+UNION ALL
+SELECT 'function ' || p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ') ' || r.role
+       || '=' || CASE WHEN has_function_privilege(r.role, p.oid, 'EXECUTE') THEN 'execute' ELSE '-' END
 FROM pg_proc p
 JOIN pg_namespace n ON n.oid = p.pronamespace
+CROSS JOIN roles r
 WHERE n.nspname = 'public'
 UNION ALL
 SELECT 'table ' || c.relname || ' ' || r.role || '='
@@ -93,11 +106,24 @@ SELECT 'table ' || c.relname || ' ' || r.role || '='
             CASE WHEN has_table_privilege(r.role, c.oid, 'SELECT') THEN 'select' END,
             CASE WHEN has_table_privilege(r.role, c.oid, 'INSERT') THEN 'insert' END,
             CASE WHEN has_table_privilege(r.role, c.oid, 'UPDATE') THEN 'update' END,
-            CASE WHEN has_table_privilege(r.role, c.oid, 'DELETE') THEN 'delete' END)
+            CASE WHEN has_table_privilege(r.role, c.oid, 'DELETE') THEN 'delete' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'TRUNCATE') THEN 'truncate' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'REFERENCES') THEN 'references' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'TRIGGER') THEN 'trigger' END)
 FROM pg_class c
 JOIN pg_namespace n2 ON n2.oid = c.relnamespace
-CROSS JOIN (VALUES ('anon'), ('authenticated')) AS r(role)
+CROSS JOIN roles r
 WHERE n2.nspname = 'public' AND c.relkind = 'r' AND c.relname <> '_applied_migrations'
+UNION ALL
+SELECT 'sequence ' || c.relname || ' ' || r.role || '='
+       || concat_ws(',',
+            CASE WHEN has_sequence_privilege(r.role, c.oid, 'USAGE') THEN 'usage' END,
+            CASE WHEN has_sequence_privilege(r.role, c.oid, 'SELECT') THEN 'select' END,
+            CASE WHEN has_sequence_privilege(r.role, c.oid, 'UPDATE') THEN 'update' END)
+FROM pg_class c
+JOIN pg_namespace n3 ON n3.oid = c.relnamespace
+CROSS JOIN roles r
+WHERE n3.nspname = 'public' AND c.relkind = 'S'
 ORDER BY 1;
 SQL
 }
@@ -114,7 +140,7 @@ dump_privileges "$URL_B" > "$PRIV_B"
 
 drift=0
 echo ""
-echo "── Structure ──"
+echo "── Structure (public schema, ownership/ACLs excluded) ──"
 if diff -u --label "$LABEL_A" --label "$LABEL_B" "$TMP_A" "$TMP_B"; then
   echo "identical."
 else
@@ -122,7 +148,7 @@ else
 fi
 
 echo ""
-echo "── Privileges (anon/authenticated) ──"
+echo "── Privileges (anon/authenticated/service_role: schema, tables, sequences, functions) ──"
 if diff -u --label "$LABEL_A" --label "$LABEL_B" "$PRIV_A" "$PRIV_B"; then
   echo "identical."
 else
@@ -131,7 +157,8 @@ fi
 
 echo ""
 if [ "$drift" -eq 0 ]; then
-  echo "No drift: structure and privileges match."
+  echo "No drift within the compared surface (structure + role privileges above;"
+  echo "ownership and default ACLs are not compared — see header comment)."
 else
   echo "DRIFT DETECTED (see diffs above)."
   echo "If prod is behind, run: npm run db:migrate"

--- a/scripts/check-schema-drift.sh
+++ b/scripts/check-schema-drift.sh
@@ -1,65 +1,139 @@
 #!/bin/bash
 #
-# Diff the public schema of two databases to detect drift.
+# Compare supabase/schema.sql against a live database (default: PROD).
 #
-# Default comparison: LOCAL Supabase (a fresh `npm run db:reset` = pure
-# schema.sql) vs PRODUCTION (DATABASE_URL from .env.local). An empty diff
-# means prod matches schema.sql.
+# Default mode builds a THROWAWAY reference database from schema.sql on the
+# local Supabase cluster — the reference is always exactly schema.sql, never a
+# possibly-stale dev database — then compares two things:
+#   1. Structure: pg_dump --schema-only --schema=public, normalized.
+#   2. Privileges: anon/authenticated EXECUTE on every public function and
+#      table-level rights on every public table (catalog queries), because the
+#      structural dump deliberately omits ACLs and this app's security posture
+#      depends on function grant lockdown.
 #
 # Usage:
-#   npm run db:drift                          # local supabase vs prod
-#   ./scripts/check-schema-drift.sh <url-A> <url-B>   # any two databases
+#   npm run db:drift                        # schema.sql vs prod (DATABASE_URL)
+#   ./scripts/check-schema-drift.sh <A> <B> # any two live databases
 #
-# Both sides are dumped with the SAME local pg_dump binary (schema-only,
-# public schema, no owners/ACLs) and normalized before diffing.
+# Env:
+#   DRIFT_CLUSTER_URL  cluster on which the throwaway reference DB is built
+#                      (default: local Supabase; must be running: npm run db:start)
 
 set -euo pipefail
 
-LOCAL_DEFAULT="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+CLUSTER_URL="${DRIFT_CLUSTER_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
+TEMP_DB="_schema_drift_ref"
+
+cleanup() {
+  if [ "${BUILT_REF:-}" = "1" ]; then
+    psql "$CLUSTER_URL" -X -q -c "DROP DATABASE IF EXISTS $TEMP_DB WITH (FORCE);" >/dev/null 2>&1 || true
+  fi
+  rm -f "${TMP_A:-}" "${TMP_B:-}" "${PRIV_A:-}" "${PRIV_B:-}"
+}
+trap cleanup EXIT
 
 if [ $# -ge 2 ]; then
   URL_A="$1"; URL_B="$2"
   LABEL_A="database A"; LABEL_B="database B"
 else
-  URL_A="$LOCAL_DEFAULT"
-  LABEL_A="local supabase (schema.sql — run 'npm run db:reset' first!)"
   if [ -f .env.local ]; then
     URL_B=$(grep -E "^DATABASE_URL=" .env.local | cut -d '=' -f2- | tr -d '"' | tr -d "'")
   fi
-  LABEL_B="prod (DATABASE_URL)"
   if [ -z "${URL_B:-}" ]; then
     echo "Error: no DATABASE_URL in .env.local (or pass two URLs explicitly)" >&2
     exit 1
   fi
+  LABEL_B="prod (DATABASE_URL)"
+  LABEL_A="schema.sql (fresh reference)"
+
+  echo "Building reference database from supabase/schema.sql ..."
+  psql "$CLUSTER_URL" -X -q -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS $TEMP_DB WITH (FORCE);"
+  psql "$CLUSTER_URL" -X -q -v ON_ERROR_STOP=1 -c "CREATE DATABASE $TEMP_DB;"
+  BUILT_REF=1
+  URL_A="${CLUSTER_URL%/*}/$TEMP_DB"
+  # Stub the auth surface schema.sql references (roles exist cluster-wide on
+  # Supabase; the DO block covers plain-postgres clusters used in tests).
+  psql "$URL_A" -X -q -v ON_ERROR_STOP=1 <<'SQL'
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN; END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role NOLOGIN; END IF;
+END $$;
+CREATE SCHEMA IF NOT EXISTS auth;
+CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY, email text, raw_user_meta_data jsonb);
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS 'SELECT NULL::uuid';
+SQL
+  psql "$URL_A" -X -q -v ON_ERROR_STOP=1 -f supabase/schema.sql >/dev/null
 fi
 
-dump() {
-  # --schema=public only; strip comments/SET noise and the migration ledger,
-  # which exists only on prod by design.
+dump_structure() {
+  # public schema only; strip comments/SET noise, pg_dump's random
+  # \restrict tokens, and the migration ledger (prod-only by design).
   pg_dump "$1" \
     --schema-only --schema=public --no-owner --no-acl \
     2>/dev/null \
   | grep -vE '^(--|SET |SELECT pg_catalog\.set_config)' \
   | grep -vE '^\\(un)?restrict ' \
   | sed '/^$/d' \
-  | awk '/^CREATE TABLE public\._applied_migrations/,/^\);$/ {next} {print}' \
+  | awk '/^CREATE TABLE public\._applied_migrations/,/^\);$/ { next } { print }' \
   | grep -vE '_applied_migrations'
 }
 
-TMP_A=$(mktemp); TMP_B=$(mktemp)
-trap 'rm -f "$TMP_A" "$TMP_B"' EXIT
+dump_privileges() {
+  psql "$1" -X -q -v ON_ERROR_STOP=1 -At <<'SQL'
+SELECT 'function ' || p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'
+       || ' anon=' || has_function_privilege('anon', p.oid, 'EXECUTE')::text
+       || ' authenticated=' || has_function_privilege('authenticated', p.oid, 'EXECUTE')::text
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+UNION ALL
+SELECT 'table ' || c.relname || ' ' || r.role || '='
+       || concat_ws(',',
+            CASE WHEN has_table_privilege(r.role, c.oid, 'SELECT') THEN 'select' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'INSERT') THEN 'insert' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'UPDATE') THEN 'update' END,
+            CASE WHEN has_table_privilege(r.role, c.oid, 'DELETE') THEN 'delete' END)
+FROM pg_class c
+JOIN pg_namespace n2 ON n2.oid = c.relnamespace
+CROSS JOIN (VALUES ('anon'), ('authenticated')) AS r(role)
+WHERE n2.nspname = 'public' AND c.relkind = 'r' AND c.relname <> '_applied_migrations'
+ORDER BY 1;
+SQL
+}
 
-echo "Dumping $LABEL_A ..."
-dump "$URL_A" > "$TMP_A"
-echo "Dumping $LABEL_B ..."
-dump "$URL_B" > "$TMP_B"
+TMP_A=$(mktemp); TMP_B=$(mktemp); PRIV_A=$(mktemp); PRIV_B=$(mktemp)
 
+echo "Dumping structure: $LABEL_A ..."
+dump_structure "$URL_A" > "$TMP_A"
+echo "Dumping structure: $LABEL_B ..."
+dump_structure "$URL_B" > "$TMP_B"
+echo "Dumping privileges ..."
+dump_privileges "$URL_A" > "$PRIV_A"
+dump_privileges "$URL_B" > "$PRIV_B"
+
+drift=0
+echo ""
+echo "── Structure ──"
 if diff -u --label "$LABEL_A" --label "$LABEL_B" "$TMP_A" "$TMP_B"; then
-  echo ""
-  echo "No drift: public schemas are identical."
+  echo "identical."
 else
-  echo ""
-  echo "DRIFT DETECTED (see diff above)."
+  drift=1
+fi
+
+echo ""
+echo "── Privileges (anon/authenticated) ──"
+if diff -u --label "$LABEL_A" --label "$LABEL_B" "$PRIV_A" "$PRIV_B"; then
+  echo "identical."
+else
+  drift=1
+fi
+
+echo ""
+if [ "$drift" -eq 0 ]; then
+  echo "No drift: structure and privileges match."
+else
+  echo "DRIFT DETECTED (see diffs above)."
   echo "If prod is behind, run: npm run db:migrate"
   echo "If schema.sql is behind, someone hand-edited prod — reconcile and add a migration."
   exit 1

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -5,12 +5,20 @@
 # Guarantees:
 #   - Each migration file and its ledger record commit in ONE transaction
 #     (psql --single-transaction), so a crash can never leave an applied file
-#     unrecorded. Files must NOT contain their own BEGIN/COMMIT (enforced).
+#     unrecorded. Files must not contain transaction-control statements: a
+#     comment-aware keyword scan rejects the obvious ones (BEGIN;/COMMIT/
+#     ROLLBACK/SAVEPOINT/...), and a server-side check compares txid_current()
+#     before and after the file body, so anything that escapes the runner's
+#     transaction (e.g. a top-level END;, indistinguishable from plpgsql's by
+#     scanning) aborts the run loudly instead of passing silently.
 #   - A transaction-scoped advisory lock + the ledger's primary key serialize
 #     concurrent runners; a double-apply rolls back the whole file.
 #   - SHA-256 checksums are recorded and verified: editing an applied file is
-#     detected and blocks the run (applied files are immutable).
-#   - --status and --dry-run are strictly read-only (no ledger DDL).
+#     detected and blocks the run. Legacy ledger rows without checksums are
+#     backfilled (from current file content, announced) on the next apply.
+#   - Nothing is written to the target — not even ledger DDL — before the
+#     typed confirmation. --status and --dry-run never write at all, and
+#     tolerate a pre-checksum ledger created by an older runner.
 #
 # Usage:
 #   npm run db:migrate                 # apply pending (asks for confirmation)
@@ -19,7 +27,11 @@
 #   ./scripts/prod-migrate.sh <postgresql://url> [--status|--dry-run]
 #
 # DATABASE_URL is read from the first URL argument, else the environment,
-# else .env.local. PROD_MIGRATIONS_DIR overrides the source directory (tests).
+# else .env.local. Optional hard gate: set DB_MIGRATE_EXPECTED_IDENTITY (env
+# or .env.local) to a substring that must appear in the server-verified
+# identity or the connection URL (e.g. your Supabase project ref) — apply
+# refuses to run against any other database. PROD_MIGRATIONS_DIR overrides
+# the source directory (tests).
 
 set -euo pipefail
 
@@ -35,14 +47,16 @@ for arg in "$@"; do
   esac
 done
 
-if [ -z "${DATABASE_URL:-}" ] && [ -f .env.local ]; then
-  DATABASE_URL=$(grep -E "^DATABASE_URL=" .env.local | cut -d '=' -f2- | tr -d '"' | tr -d "'")
-fi
+env_local() { [ -f .env.local ] && grep -E "^$1=" .env.local | cut -d '=' -f2- | tr -d '"' | tr -d "'" || true; }
 
+if [ -z "${DATABASE_URL:-}" ]; then
+  DATABASE_URL=$(env_local DATABASE_URL)
+fi
 if [ -z "${DATABASE_URL:-}" ]; then
   echo "Error: no DATABASE_URL (argument, environment, or .env.local)" >&2
   exit 1
 fi
+EXPECTED_IDENTITY="${DB_MIGRATE_EXPECTED_IDENTITY:-$(env_local DB_MIGRATE_EXPECTED_IDENTITY)}"
 
 PSQL=(psql "$DATABASE_URL" -X -q -v ON_ERROR_STOP=1)
 
@@ -54,47 +68,45 @@ sha() {
   fi
 }
 
+# --- Read ledger state (tolerant of: no ledger, pre-checksum ledger) --------
+
 ledger_exists=$("${PSQL[@]}" -Atc "SELECT (to_regclass('public._applied_migrations') IS NOT NULL)::text;")
-
-# Ledger DDL runs ONLY in apply mode — status/dry-run never write anything.
-if [ "$MODE" = "apply" ]; then
-  "${PSQL[@]}" <<'SQL'
-SET client_min_messages = warning;
-CREATE TABLE IF NOT EXISTS public._applied_migrations (
-  name TEXT PRIMARY KEY,
-  checksum TEXT,
-  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-ALTER TABLE public._applied_migrations ADD COLUMN IF NOT EXISTS checksum TEXT;
-ALTER TABLE public._applied_migrations ENABLE ROW LEVEL SECURITY;
-REVOKE ALL ON public._applied_migrations FROM anon, authenticated;
-SQL
-  ledger_exists="true"
-fi
-
-# "name<space>checksum" per line (checksum may be empty on pre-checksum rows).
+has_checksum_col="false"
 applied_rows=""
 if [ "$ledger_exists" = "true" ]; then
-  applied_rows=$("${PSQL[@]}" -Atc "SELECT name || ' ' || COALESCE(checksum, '') FROM public._applied_migrations ORDER BY name;")
+  has_checksum_col=$("${PSQL[@]}" -Atc "SELECT (EXISTS (SELECT FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '_applied_migrations' AND column_name = 'checksum'))::text;")
+  if [ "$has_checksum_col" = "true" ]; then
+    applied_rows=$("${PSQL[@]}" -Atc "SELECT name || ' ' || COALESCE(checksum, '') FROM public._applied_migrations ORDER BY name;")
+  else
+    applied_rows=$("${PSQL[@]}" -Atc "SELECT name || ' ' FROM public._applied_migrations ORDER BY name;")
+  fi
 fi
 
 is_applied() { awk -v n="$1" '$1 == n { found = 1 } END { exit !found }' <<< "$applied_rows"; }
 recorded_sum() { awk -v n="$1" '$1 == n { print $2 }' <<< "$applied_rows"; }
 
+# --- Validate files; compute pending -----------------------------------------
+
 pending=()
+backfill=()
 problems=0
 for file in "$MIGRATIONS_DIR"/*.sql; do
   [ -e "$file" ] || continue
   name=$(basename "$file")
-  if grep -qiE '^[[:space:]]*(BEGIN|COMMIT)[[:space:]]*;' "$file"; then
-    echo "ERROR: $name contains its own BEGIN/COMMIT — the runner owns the transaction (see the README)." >&2
+  # Comment-aware scan for transaction control. Bare BEGIN (plpgsql block
+  # opener) and END; (plpgsql block terminator) are legitimate and allowed;
+  # everything the scan can't distinguish is caught server-side at apply time.
+  if sed 's/--.*//' "$file" | grep -qiE '\b(COMMIT|ROLLBACK|ABORT|SAVEPOINT|PREPARE[[:space:]]+TRANSACTION|START[[:space:]]+TRANSACTION)\b|\bBEGIN[[:space:]]*(TRANSACTION|WORK)?[[:space:]]*;|\bEND[[:space:]]+(TRANSACTION|WORK)\b'; then
+    echo "ERROR: $name contains transaction-control statements — the runner owns the transaction (see the README)." >&2
     problems=1
     continue
   fi
   if is_applied "$name"; then
     rec=$(recorded_sum "$name")
     cur=$(sha "$file")
-    if [ -n "$rec" ] && [ "$rec" != "$cur" ]; then
+    if [ -z "$rec" ]; then
+      backfill+=("$name $cur")
+    elif [ "$rec" != "$cur" ]; then
       echo "ERROR: applied migration $name has been EDITED (checksum mismatch)." >&2
       echo "       Applied files are immutable — restore it and add a new migration instead." >&2
       problems=1
@@ -107,10 +119,12 @@ if [ "$problems" -ne 0 ]; then
   exit 1
 fi
 
+# --- Read-only modes ----------------------------------------------------------
+
 if [ "$MODE" = "status" ]; then
   echo "Applied:"
   if [ -n "$applied_rows" ]; then
-    awk '{ print "  " $1 ($2 == "" ? "  (no checksum recorded)" : "") }' <<< "$applied_rows"
+    awk '{ print "  " $1 ($2 == "" ? "  (no checksum recorded — will backfill on next apply)" : "") }' <<< "$applied_rows"
   else
     echo "  (none — ledger absent or empty)"
   fi
@@ -119,44 +133,88 @@ if [ "$MODE" = "status" ]; then
   exit 0
 fi
 
-if [ ${#pending[@]} -eq 0 ]; then
+if [ ${#pending[@]} -eq 0 ] && [ ${#backfill[@]} -eq 0 ]; then
   echo "Nothing pending — database is at the chain head."
   exit 0
 fi
 
-echo "Pending migrations (in order):"
-for f in "${pending[@]}"; do echo "  $(basename "$f")"; done
+if [ ${#pending[@]} -gt 0 ]; then
+  echo "Pending migrations (in order):"
+  for f in "${pending[@]}"; do echo "  $(basename "$f")"; done
+fi
+if [ ${#backfill[@]} -gt 0 ]; then
+  echo "Checksum backfills for legacy ledger rows (recorded from current file content):"
+  for b in "${backfill[@]}"; do echo "  ${b%% *}"; done
+fi
 
 if [ "$MODE" = "dry-run" ]; then
   echo "(dry run — nothing applied)"
   exit 0
 fi
 
-# Server-verified identity (not the parsed URL): database, address, role, and
-# live row counts so prod is unmistakable at the prompt.
+# --- Confirmation (nothing has been written up to this point) -----------------
+
 identity=$("${PSQL[@]}" -Atc "SELECT current_database() || ' @ ' || COALESCE(inet_server_addr()::text || ':' || inet_server_port()::text, 'local socket') || ' as ' || current_user;")
 stats=$("${PSQL[@]}" -Atc "SELECT (SELECT count(*) FROM public.users)::text || ' users, ' || (SELECT count(*) FROM public.games)::text || ' games'" 2>/dev/null || echo "row counts unavailable")
+
+if [ -n "$EXPECTED_IDENTITY" ]; then
+  if [[ "$identity" != *"$EXPECTED_IDENTITY"* && "$DATABASE_URL" != *"$EXPECTED_IDENTITY"* ]]; then
+    echo "ERROR: DB_MIGRATE_EXPECTED_IDENTITY ('$EXPECTED_IDENTITY') matches neither the" >&2
+    echo "       server-verified identity ($identity) nor the connection URL. Refusing." >&2
+    exit 1
+  fi
+  gate_note="identity gate '$EXPECTED_IDENTITY' matched"
+else
+  gate_note="no identity gate — set DB_MIGRATE_EXPECTED_IDENTITY in .env.local to hard-gate this prompt"
+fi
 
 echo ""
 echo "Target database: $identity"
 echo "Contains:        $stats"
+echo "Gate:            $gate_note"
 read -r -p "Apply ${#pending[@]} migration(s) to THIS database? Type 'apply' to continue: " confirm
 if [ "$confirm" != "apply" ]; then
   echo "Aborted."
   exit 1
 fi
 
-for f in "${pending[@]}"; do
+# --- First writes happen here: ledger DDL, backfills, then migrations ---------
+
+"${PSQL[@]}" <<'SQL'
+SET client_min_messages = warning;
+CREATE TABLE IF NOT EXISTS public._applied_migrations (
+  name TEXT PRIMARY KEY,
+  checksum TEXT,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public._applied_migrations ADD COLUMN IF NOT EXISTS checksum TEXT;
+ALTER TABLE public._applied_migrations ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public._applied_migrations FROM anon, authenticated;
+SQL
+
+for b in "${backfill[@]:-}"; do
+  [ -n "$b" ] || continue
+  bname="${b%% *}"
+  bsum="${b##* }"
+  "${PSQL[@]}" -c "UPDATE public._applied_migrations SET checksum = '$bsum' WHERE name = '$bname' AND checksum IS NULL;"
+  echo "Backfilled checksum for $bname"
+done
+
+for f in "${pending[@]:-}"; do
+  [ -n "$f" ] || continue
   name=$(basename "$f")
   sum=$(sha "$f")
   echo "Applying $name ..."
-  # One transaction: advisory lock -> ledger insert -> migration body.
-  # Concurrent runners serialize on the lock; the second one's ledger insert
-  # then hits the primary key and rolls back the whole file.
+  # One transaction: advisory lock -> txid marker -> ledger insert -> file
+  # body -> txid assertion. Concurrent runners serialize on the lock (the
+  # loser rolls back on the ledger PK). The txid assertion proves the file
+  # did not escape the runner's transaction; if it did, this aborts loudly —
+  # inspect the ledger and database state before re-running.
   psql "$DATABASE_URL" -X -q -v ON_ERROR_STOP=1 --single-transaction \
-    -c "DO \$\$ BEGIN PERFORM pg_advisory_xact_lock(hashtext('supabase/prod-migrations')); END \$\$;" \
+    -c "DO \$runner\$ BEGIN PERFORM pg_advisory_xact_lock(hashtext('supabase/prod-migrations')); PERFORM set_config('migration.runner_txid', txid_current()::text, true); END \$runner\$;" \
     -c "INSERT INTO public._applied_migrations (name, checksum) VALUES ('$name', '$sum');" \
-    -f "$f"
+    -f "$f" \
+    -c "DO \$runner\$ BEGIN IF current_setting('migration.runner_txid', true) IS DISTINCT FROM txid_current()::text THEN RAISE EXCEPTION 'migration escaped the runner transaction (transaction-control statement in the file?) — inspect ledger and database state before re-running'; END IF; END \$runner\$;"
   echo "  applied + recorded atomically."
 done
 

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 #
 # Apply pending files from supabase/prod-migrations/ to the PRODUCTION database.
-# Applied files are recorded in public._applied_migrations on the target, so
-# re-runs only apply what's new.
+#
+# Guarantees:
+#   - Each migration file and its ledger record commit in ONE transaction
+#     (psql --single-transaction), so a crash can never leave an applied file
+#     unrecorded. Files must NOT contain their own BEGIN/COMMIT (enforced).
+#   - A transaction-scoped advisory lock + the ledger's primary key serialize
+#     concurrent runners; a double-apply rolls back the whole file.
+#   - SHA-256 checksums are recorded and verified: editing an applied file is
+#     detected and blocks the run (applied files are immutable).
+#   - --status and --dry-run are strictly read-only (no ledger DDL).
 #
 # Usage:
-#   npm run db:migrate                    # apply pending (asks for confirmation)
-#   npm run db:migrate -- --status        # list applied + pending, change nothing
-#   npm run db:migrate -- --dry-run       # show what WOULD be applied
+#   npm run db:migrate                 # apply pending (asks for confirmation)
+#   npm run db:migrate:status          # read-only: list applied + pending
+#   npm run db:migrate -- --dry-run    # read-only: show what WOULD be applied
 #   ./scripts/prod-migrate.sh <postgresql://url> [--status|--dry-run]
 #
-# DATABASE_URL is read from the first argument if it looks like a URL,
-# otherwise from the environment, otherwise from .env.local.
+# DATABASE_URL is read from the first URL argument, else the environment,
+# else .env.local. PROD_MIGRATIONS_DIR overrides the source directory (tests).
 
 set -euo pipefail
 
-MIGRATIONS_DIR="supabase/prod-migrations"
+MIGRATIONS_DIR="${PROD_MIGRATIONS_DIR:-supabase/prod-migrations}"
 MODE="apply"
 
 for arg in "$@"; do
@@ -36,40 +44,83 @@ if [ -z "${DATABASE_URL:-}" ]; then
   exit 1
 fi
 
-PSQL=(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q)
+PSQL=(psql "$DATABASE_URL" -X -q -v ON_ERROR_STOP=1)
 
-# Ensure the ledger table exists (hidden from app roles: RLS on with no
-# policies, and the blanket default-privilege grants revoked).
-"${PSQL[@]}" <<'SQL'
+sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+ledger_exists=$("${PSQL[@]}" -Atc "SELECT (to_regclass('public._applied_migrations') IS NOT NULL)::text;")
+
+# Ledger DDL runs ONLY in apply mode — status/dry-run never write anything.
+if [ "$MODE" = "apply" ]; then
+  "${PSQL[@]}" <<'SQL'
+SET client_min_messages = warning;
 CREATE TABLE IF NOT EXISTS public._applied_migrations (
   name TEXT PRIMARY KEY,
+  checksum TEXT,
   applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+ALTER TABLE public._applied_migrations ADD COLUMN IF NOT EXISTS checksum TEXT;
 ALTER TABLE public._applied_migrations ENABLE ROW LEVEL SECURITY;
 REVOKE ALL ON public._applied_migrations FROM anon, authenticated;
 SQL
+  ledger_exists="true"
+fi
 
-applied=$("${PSQL[@]}" -Atc "SELECT name FROM public._applied_migrations ORDER BY name;")
+# "name<space>checksum" per line (checksum may be empty on pre-checksum rows).
+applied_rows=""
+if [ "$ledger_exists" = "true" ]; then
+  applied_rows=$("${PSQL[@]}" -Atc "SELECT name || ' ' || COALESCE(checksum, '') FROM public._applied_migrations ORDER BY name;")
+fi
+
+is_applied() { awk -v n="$1" '$1 == n { found = 1 } END { exit !found }' <<< "$applied_rows"; }
+recorded_sum() { awk -v n="$1" '$1 == n { print $2 }' <<< "$applied_rows"; }
 
 pending=()
+problems=0
 for file in "$MIGRATIONS_DIR"/*.sql; do
   [ -e "$file" ] || continue
   name=$(basename "$file")
-  if ! grep -qx "$name" <<< "$applied"; then
+  if grep -qiE '^[[:space:]]*(BEGIN|COMMIT)[[:space:]]*;' "$file"; then
+    echo "ERROR: $name contains its own BEGIN/COMMIT — the runner owns the transaction (see the README)." >&2
+    problems=1
+    continue
+  fi
+  if is_applied "$name"; then
+    rec=$(recorded_sum "$name")
+    cur=$(sha "$file")
+    if [ -n "$rec" ] && [ "$rec" != "$cur" ]; then
+      echo "ERROR: applied migration $name has been EDITED (checksum mismatch)." >&2
+      echo "       Applied files are immutable — restore it and add a new migration instead." >&2
+      problems=1
+    fi
+  else
     pending+=("$file")
   fi
 done
+if [ "$problems" -ne 0 ]; then
+  exit 1
+fi
 
 if [ "$MODE" = "status" ]; then
-  echo "Applied ($(grep -c . <<< "$applied" || true)):"
-  sed 's/^/  /' <<< "$applied"
+  echo "Applied:"
+  if [ -n "$applied_rows" ]; then
+    awk '{ print "  " $1 ($2 == "" ? "  (no checksum recorded)" : "") }' <<< "$applied_rows"
+  else
+    echo "  (none — ledger absent or empty)"
+  fi
   echo "Pending (${#pending[@]}):"
   for f in "${pending[@]:-}"; do [ -n "$f" ] && echo "  $(basename "$f")"; done
   exit 0
 fi
 
 if [ ${#pending[@]} -eq 0 ]; then
-  echo "Nothing pending — prod is at the chain head."
+  echo "Nothing pending — database is at the chain head."
   exit 0
 fi
 
@@ -81,9 +132,15 @@ if [ "$MODE" = "dry-run" ]; then
   exit 0
 fi
 
-host=$(sed -E 's|.*@([^:/]+).*|\1|' <<< "$DATABASE_URL")
+# Server-verified identity (not the parsed URL): database, address, role, and
+# live row counts so prod is unmistakable at the prompt.
+identity=$("${PSQL[@]}" -Atc "SELECT current_database() || ' @ ' || COALESCE(inet_server_addr()::text || ':' || inet_server_port()::text, 'local socket') || ' as ' || current_user;")
+stats=$("${PSQL[@]}" -Atc "SELECT (SELECT count(*) FROM public.users)::text || ' users, ' || (SELECT count(*) FROM public.games)::text || ' games'" 2>/dev/null || echo "row counts unavailable")
+
 echo ""
-read -r -p "Apply ${#pending[@]} migration(s) to $host? Type 'apply' to continue: " confirm
+echo "Target database: $identity"
+echo "Contains:        $stats"
+read -r -p "Apply ${#pending[@]} migration(s) to THIS database? Type 'apply' to continue: " confirm
 if [ "$confirm" != "apply" ]; then
   echo "Aborted."
   exit 1
@@ -91,10 +148,16 @@ fi
 
 for f in "${pending[@]}"; do
   name=$(basename "$f")
+  sum=$(sha "$f")
   echo "Applying $name ..."
-  "${PSQL[@]}" -f "$f"
-  "${PSQL[@]}" -c "INSERT INTO public._applied_migrations (name) VALUES ('$name');"
-  echo "  recorded."
+  # One transaction: advisory lock -> ledger insert -> migration body.
+  # Concurrent runners serialize on the lock; the second one's ledger insert
+  # then hits the primary key and rolls back the whole file.
+  psql "$DATABASE_URL" -X -q -v ON_ERROR_STOP=1 --single-transaction \
+    -c "DO \$\$ BEGIN PERFORM pg_advisory_xact_lock(hashtext('supabase/prod-migrations')); END \$\$;" \
+    -c "INSERT INTO public._applied_migrations (name, checksum) VALUES ('$name', '$sum');" \
+    -f "$f"
+  echo "  applied + recorded atomically."
 done
 
 echo ""

--- a/supabase/prod-migrations/20260709T01_handle_new_user_resilience.sql
+++ b/supabase/prod-migrations/20260709T01_handle_new_user_resilience.sql
@@ -7,8 +7,6 @@
 --
 -- Pre-flight: none needed — the new CHECK is strictly weaker than the old one.
 
-BEGIN;
-
 ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_avatar_url_check;
 ALTER TABLE public.users ADD CONSTRAINT users_avatar_url_check CHECK (
   avatar_url IS NULL
@@ -47,4 +45,3 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
 
-COMMIT;

--- a/supabase/prod-migrations/20260709T02_game_today_cutoffs.sql
+++ b/supabase/prod-migrations/20260709T02_game_today_cutoffs.sql
@@ -7,8 +7,6 @@
 --
 -- Pre-flight: none needed.
 
-BEGIN;
-
 CREATE OR REPLACE FUNCTION public.game_today(game_id_param UUID)
 RETURNS DATE AS $$
 DECLARE
@@ -51,4 +49,3 @@ CREATE POLICY "GMs and co-GMs can insert sessions" ON public.sessions
     AND public.count_future_sessions(game_id) < 100
   );
 
-COMMIT;

--- a/supabase/prod-migrations/20260709T03_play_days_check.sql
+++ b/supabase/prod-migrations/20260709T03_play_days_check.sql
@@ -4,8 +4,6 @@
 -- Pre-flight is built in: the DO block raises with the offending rows before
 -- the ALTER would fail opaquely, and the transaction rolls back.
 
-BEGIN;
-
 DO $$
 DECLARE
   bad_count INTEGER;
@@ -22,4 +20,3 @@ $$;
 ALTER TABLE public.games ADD CONSTRAINT games_play_days_check
   CHECK (play_days <@ ARRAY[0, 1, 2, 3, 4, 5, 6]);
 
-COMMIT;

--- a/supabase/prod-migrations/README.md
+++ b/supabase/prod-migrations/README.md
@@ -18,10 +18,16 @@ e2e, `db:reset`) and must stay as-is.
   editing an applied one.
 - **Name format:** `YYYYMMDDTNN_short_description.sql` (lexicographic order is
   application order).
-- **Write transactionally and idempotently where cheap** (`BEGIN/COMMIT`,
-  `CREATE OR REPLACE`, `DROP ... IF EXISTS`): the runner records success AFTER
-  a file applies, so a crash between apply and record means the file may run
-  again.
+- **Do NOT include `BEGIN`/`COMMIT`** — the runner wraps each file, its
+  ledger record, and an advisory lock in ONE transaction, so apply-and-record
+  is atomic and concurrent runners serialize. The runner rejects files that
+  contain their own transaction statements. (If you ever apply a file by hand
+  in a SQL editor, wrap it in a transaction yourself.)
+- **Checksums are enforced.** The runner records each file's SHA-256 in the
+  ledger and refuses to proceed if an applied file has been edited —
+  immutability is checked, not just documented. Prefer `CREATE OR REPLACE` /
+  `DROP ... IF EXISTS` forms anyway so a file is cheap to re-apply if a run
+  is ever interrupted before it starts.
 - **Pre-flights live inside the file** as a `DO` block that raises a clear
   error (see `20260709T03_play_days_check.sql`), so a violating database
   fails loudly and rolls back rather than half-applying.

--- a/supabase/prod-migrations/README.md
+++ b/supabase/prod-migrations/README.md
@@ -18,16 +18,29 @@ e2e, `db:reset`) and must stay as-is.
   editing an applied one.
 - **Name format:** `YYYYMMDDTNN_short_description.sql` (lexicographic order is
   application order).
-- **Do NOT include `BEGIN`/`COMMIT`** — the runner wraps each file, its
-  ledger record, and an advisory lock in ONE transaction, so apply-and-record
-  is atomic and concurrent runners serialize. The runner rejects files that
-  contain their own transaction statements. (If you ever apply a file by hand
-  in a SQL editor, wrap it in a transaction yourself.)
+- **No transaction-control statements** (`BEGIN;`/`COMMIT`/`ROLLBACK`/
+  `SAVEPOINT`/...) — the runner wraps each file, its ledger record, and an
+  advisory lock in ONE transaction, so apply-and-record is atomic and
+  concurrent runners serialize. Enforcement is layered: a comment-aware
+  keyword scan rejects files up front (bare plpgsql `BEGIN`/`END;` are fine),
+  and a server-side `txid_current()` assertion after the file body catches
+  anything the scan cannot distinguish (e.g. a top-level `END;`). The
+  server-side check is detection, not prevention: if it fires, part of the
+  file may have applied and the ledger row may exist — inspect both before
+  re-running. (If you ever apply a file by hand in a SQL editor, wrap it in a
+  transaction yourself.)
 - **Checksums are enforced.** The runner records each file's SHA-256 in the
   ledger and refuses to proceed if an applied file has been edited —
-  immutability is checked, not just documented. Prefer `CREATE OR REPLACE` /
+  immutability is checked, not just documented. Ledger rows created by an
+  older runner (no checksum) are backfilled from current file content on the
+  next apply, with a printed notice. Prefer `CREATE OR REPLACE` /
   `DROP ... IF EXISTS` forms anyway so a file is cheap to re-apply if a run
   is ever interrupted before it starts.
+- **Nothing is written before the confirmation prompt** (not even ledger
+  DDL); `--status`/`--dry-run` never write at all. For a hard target gate,
+  set `DB_MIGRATE_EXPECTED_IDENTITY` in `.env.local` to a substring of your
+  prod identity (e.g. the Supabase project ref from the connection host) —
+  apply refuses any database that doesn't match it.
 - **Pre-flights live inside the file** as a `DO` block that raises a clear
   error (see `20260709T03_play_days_check.sql`), so a violating database
   fails loudly and rolls back rather than half-applying.


### PR DESCRIPTION
## Summary

Follow-up to #135, addressing all six findings from an external (Codex) review of the new schema-management CLI tools. Scripts, migration files, and README only — no app code.

### `scripts/prod-migrate.sh`
- **Atomic apply + record (High):** each migration file, its ledger insert, and a transaction-scoped advisory lock now run in ONE `psql --single-transaction`. A crash can no longer strand an applied-but-unrecorded file (which would have permanently wedged the `play_days` CHECK migration on re-run), and concurrent runners serialize — the loser rolls back on the ledger's primary key. Convention change: migration files must not contain their own `BEGIN/COMMIT` (the runner enforces this; the three committed files are updated).
- **Checksums (Medium):** SHA-256 recorded per applied file and verified on every run — editing an applied file now fails loudly. Portable across macOS (`shasum`) and Linux (`sha256sum`); no bash-4 features (macOS ships bash 3.2).
- **Read-only status/dry-run (Medium):** ledger DDL runs only in apply mode; `--status` works against a ledger-less database without creating anything.
- **Stronger confirmation (Medium):** the prompt shows server-verified identity (`current_database() @ address as role`, queried from the live connection rather than parsed from the URL) plus live user/game row counts.

### `scripts/check-schema-drift.sh`
- **No more false-clean (High):** default mode builds a throwaway reference database from `supabase/schema.sql` itself on the local cluster (dropped on exit), instead of trusting a possibly-stale dev database.
- **Privilege drift visible (Medium):** a second, catalog-query comparison checks `anon`/`authenticated` EXECUTE on every public function and table-level rights on every public table — the structural dump deliberately omits ACLs, and this app's security posture depends on function grant lockdown.

## Test plan

All verified end-to-end on throwaway Postgres clusters:
- [x] Atomicity: a migration that fails mid-file leaves neither its partial DDL nor a ledger row
- [x] Checksum tamper on an applied file → blocked with a clear error
- [x] File containing `BEGIN/COMMIT` → rejected
- [x] `--status` against a database with no ledger → read-only (table verifiably not created)
- [x] Full chain apply on a pre-#135-schema database → drift tool reports structure AND privileges identical to a fresh `schema.sql` install
- [x] Negative drift tests: an added column and a `GRANT EXECUTE ... TO anon` are both detected (exit 1)
- [x] Lint / typecheck / 644 unit tests unaffected (no app code touched)

## After merging

1. `npm run db:migrate` (type `apply`) — applies the three pending prod migrations with the hardened runner
2. `npm run db:drift` — confirm structure + privilege parity with schema.sql
3. Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qiu2YR47eaoXsSBtxgERLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qiu2YR47eaoXsSBtxgERLN)_