### PR TITLE
Fix availability silently truncated by Supabase 1000-row cap

### DIFF
--- a/src/app/api/admin/games/[id]/route.ts
+++ b/src/app/api/admin/games/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   fetchGamePlayDates,
 } from '@/lib/data';
 import { serverError } from '@/lib/apiError';
+import { getTodayLocalDate } from '@/lib/date';
 
 /**
  * Read-only snapshot of a game for the admin peek view. Uses the service-role
@@ -33,7 +34,10 @@ export async function GET(
 
     const [membersRes, availabilityRes, sessionsRes, playDatesRes] = await Promise.all([
       fetchGameMembers(admin, id),
-      fetchAllAvailability(admin, id),
+      // Paginated + today-scoped, mirroring the player calendar (which only
+      // renders the scheduling window). Without paging the peek view silently
+      // truncated at 1000 rows on large games.
+      fetchAllAvailability(admin, id, getTodayLocalDate()),
       fetchGameSessions(admin, id),
       fetchGamePlayDates(admin, id),
     ]);

--- a/src/app/api/admin/games/route.ts
+++ b/src/app/api/admin/games/route.ts
@@ -13,14 +13,28 @@ export async function GET(): Promise<Response> {
     if (result instanceof NextResponse) return result;
     const { admin } = result;
 
-    const { data: games, error: gamesError } = await admin
-      .from('games')
-      .select('id, name, created_at, play_days, scheduling_window_months, campaign_start_date, campaign_end_date, gm_id, gm:users!games_gm_id_fkey(id, name, email)')
-      .order('created_at', { ascending: false });
+    type GmRef = { id: string; name: string | null; email: string };
+    type GameRow = {
+      id: string;
+      name: string;
+      created_at: string | null;
+      play_days: number[] | null;
+      scheduling_window_months: number | null;
+      campaign_start_date: string | null;
+      campaign_end_date: string | null;
+      gm_id: string;
+      gm: GmRef | GmRef[] | null;
+    };
 
-    if (gamesError) {
-      throw gamesError;
-    }
+    // Paginated: platform-wide games list grows unbounded, so a plain select
+    // would silently truncate at Supabase's 1000-row cap. Sort in JS since
+    // paginate() reads in primary-key order.
+    const games = await paginate<GameRow>(
+      admin,
+      'games',
+      'id, name, created_at, play_days, scheduling_window_months, campaign_start_date, campaign_end_date, gm_id, gm:users!games_gm_id_fkey(id, name, email)'
+    );
+    games.sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
 
     const [memberships, sessions, availabilityRecords, gamePlayDates] = await Promise.all([
       paginate<{ game_id: string; user_id: string }>(admin, 'game_memberships', 'game_id, user_id'),
@@ -73,7 +87,7 @@ export async function GET(): Promise<Response> {
     }
 
     // Build game list with engagement metrics
-    const gamesWithEngagement: GameWithEngagement[] = (games ?? []).map((game) => {
+    const gamesWithEngagement: GameWithEngagement[] = games.map((game) => {
       const members = membershipsByGame.get(game.id) ?? new Set();
       const totalPlayers = members.size + 1; // +1 for GM
       const sessionStats = sessionsByGame.get(game.id) ?? { total: 0, future: 0, lastActivity: null };

--- a/src/app/api/games/calendar/[code]/route.ts
+++ b/src/app/api/games/calendar/[code]/route.ts
@@ -1,6 +1,8 @@
 import { createAdminClient } from '@/lib/supabase/admin';
 import { generateICS, composeIcsDescription } from '@/lib/ics';
+import { fetchAllPages } from '@/lib/data';
 import type { Game, GameSession } from '@/types';
+import type { Database } from '@/types/database';
 import { serverError } from '@/lib/apiError';
 
 /**
@@ -44,13 +46,24 @@ export async function GET(
 
     const typedGame = game as Pick<Game, 'id' | 'name' | 'description' | 'default_start_time' | 'default_end_time' | 'timezone'>;
 
-    // Fetch confirmed sessions for this game
-    const { data: sessions, error: sessionsError } = await admin
-      .from('sessions')
-      .select('id, date, start_time, end_time, status, location, notes')
-      .eq('game_id', typedGame.id)
-      .eq('status', 'confirmed')
-      .order('date', { ascending: true });
+    // Fetch confirmed sessions for this game. Paginated because a long-lived
+    // campaign's confirmed sessions can exceed Supabase's 1000-row cap, which
+    // would silently drop events from the ICS feed.
+    type CalendarSession = Pick<
+      Database['public']['Tables']['sessions']['Row'],
+      'id' | 'date' | 'start_time' | 'end_time' | 'status' | 'location' | 'notes'
+    >;
+    const { data: sessions, error: sessionsError } = await fetchAllPages<CalendarSession>(
+      (from, to) =>
+        admin
+          .from('sessions')
+          .select('id, date, start_time, end_time, status, location, notes')
+          .eq('game_id', typedGame.id)
+          .eq('status', 'confirmed')
+          .order('date', { ascending: true })
+          .order('id', { ascending: true })
+          .range(from, to)
+    );
 
     if (sessionsError) {
       console.error('Error fetching sessions:', sessionsError);

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -32,6 +32,7 @@ import {
   type WeekdayDefault,
 } from '@/lib/availability';
 import { getSchedulingWindow } from '@/lib/schedule';
+import { getTodayLocalDate } from '@/lib/date';
 
 const supabase = getSupabaseClient();
 
@@ -82,7 +83,12 @@ export function useAvailability(
   const allQuery = useQuery({
     queryKey: queryKeys.availability(gameId),
     enabled: !!gameId && !!userId,
-    queryFn: async () => (await fetchAllAvailability(supabase, gameId)).data ?? [],
+    // Scope out stale past dates: the calendar only shows today-forward, and a
+    // long game's back-catalog of availability otherwise bloats the (paged)
+    // fetch. `getTodayLocalDate()` is always <= the scheduling-window start, so
+    // this never drops a date the UI can display.
+    queryFn: async () =>
+      (await fetchAllAvailability(supabase, gameId, getTodayLocalDate())).data ?? [],
   });
   const allAvailability = allQuery.data ?? EMPTY_AVAILABILITY;
 

--- a/src/lib/data/availability.test.ts
+++ b/src/lib/data/availability.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchAllAvailability } from "./availability";
+
+/** Chainable Supabase mock terminating at `.range()` (paginated read). */
+function makeChainMock(rangeResult: { data: unknown[]; error: unknown } = { data: [], error: null }) {
+  const range = vi.fn().mockResolvedValue(rangeResult);
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range,
+  };
+  const from = vi.fn().mockReturnValue(builder);
+  return { from, ...builder };
+}
+
+describe("fetchAllAvailability", () => {
+  it("reads every player's rows for the game in a stable paginated order", async () => {
+    const mock = makeChainMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fetchAllAvailability(mock as any, "game-1");
+    expect(mock.from).toHaveBeenCalledWith("availability");
+    expect(mock.eq).toHaveBeenCalledWith("game_id", "game-1");
+    // Stable total order so pages don't skip/duplicate.
+    expect(mock.order).toHaveBeenCalledWith("date", { ascending: true });
+    expect(mock.order).toHaveBeenCalledWith("user_id", { ascending: true });
+    expect(mock.range).toHaveBeenCalledWith(0, 999);
+  });
+
+  it("does NOT filter by date when no fromDate is given", async () => {
+    const mock = makeChainMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fetchAllAvailability(mock as any, "game-1");
+    expect(mock.gte).not.toHaveBeenCalled();
+  });
+
+  it("scopes to fromDate (drops stale past dates) when given", async () => {
+    const mock = makeChainMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fetchAllAvailability(mock as any, "game-1", "2026-07-28");
+    expect(mock.gte).toHaveBeenCalledWith("date", "2026-07-28");
+  });
+
+  it("stitches multiple pages together (survives the 1000-row cap)", async () => {
+    // First call returns a full page of 1000, second returns the tail — the
+    // exact scenario that silently truncated before pagination.
+    const page1 = Array.from({ length: 1000 }, (_, i) => ({ id: `a${i}` }));
+    const page2 = [{ id: "tail-row" }];
+    const range = vi
+      .fn()
+      .mockResolvedValueOnce({ data: page1, error: null })
+      .mockResolvedValueOnce({ data: page2, error: null });
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range,
+    };
+    const mock = { from: vi.fn().mockReturnValue(builder) };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await fetchAllAvailability(mock as any, "game-1", "2026-07-28");
+
+    expect(data).toHaveLength(1001);
+    expect(data?.at(-1)).toEqual({ id: "tail-row" });
+    expect(range).toHaveBeenNthCalledWith(1, 0, 999);
+    expect(range).toHaveBeenNthCalledWith(2, 1000, 1999);
+  });
+});

--- a/src/lib/data/availability.ts
+++ b/src/lib/data/availability.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
-import type { AvailabilityStatus } from '@/types';
+import type { Availability, AvailabilityStatus } from '@/types';
+import { fetchAllPages } from './paginate';
 
 export async function fetchUserAvailability(
   supabase: SupabaseClient<Database>,
@@ -14,8 +15,31 @@ export async function fetchUserAvailability(
     .eq('user_id', userId);
 }
 
-export async function fetchAllAvailability(supabase: SupabaseClient<Database>, gameId: string) {
-  return supabase.from('availability').select('*').eq('game_id', gameId);
+/**
+ * Every player's availability for a game. Paginated because a long-running
+ * game accumulates far more than Supabase's 1000-row cap (one row per player
+ * per date) — without paging, rows past the first 1000 silently vanish, and a
+ * player's marks appear to "revert" on reload. `fromDate` scopes out stale
+ * past dates (the calendar only ever shows the scheduling window); pass the
+ * local "today" so the payload stays small on top of the paging.
+ */
+export async function fetchAllAvailability(
+  supabase: SupabaseClient<Database>,
+  gameId: string,
+  fromDate?: string
+) {
+  return fetchAllPages<Availability>((from, to) => {
+    let query = supabase
+      .from('availability')
+      .select('*')
+      .eq('game_id', gameId)
+      // Stable total order so pages don't skip/duplicate; (date, user_id) is
+      // unique within a single game.
+      .order('date', { ascending: true })
+      .order('user_id', { ascending: true });
+    if (fromDate) query = query.gte('date', fromDate);
+    return query.range(from, to);
+  });
 }
 
 export async function upsertAvailability(

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,3 +1,4 @@
+export * from './paginate';
 export * from './games';
 export * from './memberships';
 export * from './availability';

--- a/src/lib/data/paginate.test.ts
+++ b/src/lib/data/paginate.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchAllPages, PAGE_SIZE } from "./paginate";
+import type { PostgrestError } from "@supabase/supabase-js";
+
+/** A buildPage backed by an in-memory array that honors the requested range. */
+function pagerOver(rows: number[]) {
+  const buildPage = vi.fn(async (from: number, to: number) => ({
+    data: rows.slice(from, to + 1),
+    error: null as PostgrestError | null,
+  }));
+  return buildPage;
+}
+
+describe("fetchAllPages", () => {
+  it("stitches every row together across multiple pages", async () => {
+    const rows = Array.from({ length: PAGE_SIZE * 2 + 37 }, (_, i) => i);
+    const buildPage = pagerOver(rows);
+
+    const { data, error } = await fetchAllPages<number>(buildPage);
+
+    expect(error).toBeNull();
+    expect(data).toEqual(rows); // all 2037 rows, not just the first 1000
+    // 3 full-or-short pages: [0..999], [1000..1999], [2000..2036]
+    expect(buildPage).toHaveBeenCalledTimes(3);
+    expect(buildPage).toHaveBeenNthCalledWith(1, 0, PAGE_SIZE - 1);
+    expect(buildPage).toHaveBeenNthCalledWith(2, PAGE_SIZE, PAGE_SIZE * 2 - 1);
+    expect(buildPage).toHaveBeenNthCalledWith(3, PAGE_SIZE * 2, PAGE_SIZE * 3 - 1);
+  });
+
+  it("stops after a single short page without asking for another", async () => {
+    const buildPage = pagerOver([1, 2, 3]);
+
+    const { data } = await fetchAllPages<number>(buildPage);
+
+    expect(data).toEqual([1, 2, 3]);
+    expect(buildPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes a second request when the first page is exactly full, then stops on the empty page", async () => {
+    const rows = Array.from({ length: PAGE_SIZE }, (_, i) => i);
+    const buildPage = pagerOver(rows);
+
+    const { data } = await fetchAllPages<number>(buildPage);
+
+    expect(data).toEqual(rows);
+    // Exactly-full first page is indistinguishable from "more remain", so we
+    // must fetch again; the second (empty) page ends the loop.
+    expect(buildPage).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty data (never null) when there are no rows", async () => {
+    const buildPage = pagerOver([]);
+
+    const { data, error } = await fetchAllPages<number>(buildPage);
+
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+
+  it("propagates an error and stops paging immediately", async () => {
+    const err = { message: "boom" } as PostgrestError;
+    const buildPage = vi.fn(async () => ({ data: null, error: err }));
+
+    const { data, error } = await fetchAllPages<number>(buildPage);
+
+    expect(data).toBeNull();
+    expect(error).toBe(err);
+    expect(buildPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/data/paginate.ts
+++ b/src/lib/data/paginate.ts
@@ -1,0 +1,34 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
+/**
+ * Supabase/PostgREST silently caps every `.select()` at `max_rows` (1000 in
+ * this project — see supabase/config.toml). A query with no `.range()` returns
+ * only the first page and drops the rest with NO error, which quietly loses
+ * data once a table exceeds the cap for a given filter.
+ *
+ * `fetchAllPages` reads every matching row by paging through `.range()` until a
+ * short page arrives. `buildPage(from, to)` MUST apply a stable, total ordering
+ * (e.g. `.order('date').order('id')`) so pages don't skip or duplicate rows.
+ */
+export const PAGE_SIZE = 1000;
+
+export async function fetchAllPages<T>(
+  buildPage: (
+    from: number,
+    to: number
+  ) => PromiseLike<{ data: T[] | null; error: PostgrestError | null }>
+): Promise<{ data: T[] | null; error: PostgrestError | null }> {
+  const all: T[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const { data, error } = await buildPage(offset, offset + PAGE_SIZE - 1);
+    if (error) return { data: null, error };
+    if (data && data.length > 0) all.push(...data);
+    // A short (or empty) page means we've read the last one.
+    if (!data || data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  return { data: all, error: null };
+}

--- a/src/lib/data/sessions.test.ts
+++ b/src/lib/data/sessions.test.ts
@@ -106,34 +106,60 @@ describe("updateSession", () => {
   });
 });
 
-describe("fetchUpcomingSessionsForGames", () => {
-  function makeSelectMock() {
-    const order = vi.fn().mockResolvedValue({ data: [], error: null });
-    const gte = vi.fn().mockReturnValue({ order });
-    const inFn = vi.fn().mockReturnValue({ gte });
-    const select = vi.fn().mockReturnValue({ in: inFn });
-    const from = vi.fn().mockReturnValue({ select });
-    return { from, select, inFn, gte, order };
-  }
+/**
+ * Chainable Supabase mock terminating at `.range()` (the paginated reads end in
+ * `.range(from, to)` rather than an awaited `.order()`). By default `.range()`
+ * resolves to an empty page, so `fetchAllPages` stops after one call.
+ */
+function makeChainMock(rangeResult: { data: unknown[]; error: unknown } = { data: [], error: null }) {
+  const range = vi.fn().mockResolvedValue(rangeResult);
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range,
+  };
+  const from = vi.fn().mockReturnValue(builder);
+  return { from, ...builder };
+}
 
-  it("queries sessions for the given game IDs from the given date, ordered by date asc", async () => {
+describe("fetchUpcomingSessionsForGames", () => {
+  it("queries sessions for the given game IDs from the given date, in a stable paginated order", async () => {
     const { fetchUpcomingSessionsForGames } = await import("./sessions");
-    const mock = makeSelectMock();
+    const mock = makeChainMock();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await fetchUpcomingSessionsForGames(mock as any, ["g1", "g2"], "2026-06-01");
     expect(mock.from).toHaveBeenCalledWith("sessions");
     expect(mock.select).toHaveBeenCalledWith("*");
-    expect(mock.inFn).toHaveBeenCalledWith("game_id", ["g1", "g2"]);
+    expect(mock.in).toHaveBeenCalledWith("game_id", ["g1", "g2"]);
     expect(mock.gte).toHaveBeenCalledWith("date", "2026-06-01");
     expect(mock.order).toHaveBeenCalledWith("date", { ascending: true });
+    expect(mock.order).toHaveBeenCalledWith("id", { ascending: true });
+    expect(mock.range).toHaveBeenCalledWith(0, 999);
   });
 
   it("returns an empty result without querying when there are no game IDs", async () => {
     const { fetchUpcomingSessionsForGames } = await import("./sessions");
-    const mock = makeSelectMock();
+    const mock = makeChainMock();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await fetchUpcomingSessionsForGames(mock as any, [], "2026-06-01");
     expect(mock.from).not.toHaveBeenCalled();
     expect(result).toEqual({ data: [], error: null });
+  });
+});
+
+describe("fetchGameSessions", () => {
+  it("reads all of a game's sessions in a stable paginated order", async () => {
+    const { fetchGameSessions } = await import("./sessions");
+    const mock = makeChainMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fetchGameSessions(mock as any, "g1");
+    expect(mock.from).toHaveBeenCalledWith("sessions");
+    expect(mock.eq).toHaveBeenCalledWith("game_id", "g1");
+    expect(mock.order).toHaveBeenCalledWith("date", { ascending: true });
+    expect(mock.order).toHaveBeenCalledWith("id", { ascending: true });
+    expect(mock.range).toHaveBeenCalledWith(0, 999);
   });
 });

--- a/src/lib/data/sessions.ts
+++ b/src/lib/data/sessions.ts
@@ -1,13 +1,21 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
 import type { GameSession } from '@/types';
+import { fetchAllPages } from './paginate';
 
 export async function fetchGameSessions(supabase: SupabaseClient<Database>, gameId: string) {
-  return supabase
-    .from('sessions')
-    .select('*')
-    .eq('game_id', gameId)
-    .order('date', { ascending: true });
+  // Paginated: `sessions` has no date filter here (past + future), so a
+  // long-lived campaign can exceed Supabase's 1000-row cap. `id` is the stable
+  // tiebreaker since multiple sessions can share a date.
+  return fetchAllPages<GameSession>((from, to) =>
+    supabase
+      .from('sessions')
+      .select('*')
+      .eq('game_id', gameId)
+      .order('date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(from, to)
+  );
 }
 
 export async function confirmSession(
@@ -60,12 +68,18 @@ export async function fetchUpcomingSessionsForGames(
   if (gameIds.length === 0) {
     return { data: [] as GameSession[], error: null };
   }
-  return supabase
-    .from('sessions')
-    .select('*')
-    .in('game_id', gameIds)
-    .gte('date', fromDate)
-    .order('date', { ascending: true });
+  // Paginated: up to (20 games/user × 100 future sessions/game) structurally
+  // exceeds the 1000-row cap for a heavy user. `id` is the stable tiebreaker.
+  return fetchAllPages<GameSession>((from, to) =>
+    supabase
+      .from('sessions')
+      .select('*')
+      .in('game_id', gameIds)
+      .gte('date', fromDate)
+      .order('date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(from, to)
+  );
 }
 
 export async function updateSession(


### PR DESCRIPTION
A user's availability for certain dates reverted on reload: the game had 1043 availability rows and `fetchAllAvailability` read them via an unpaginated `select()`, which Supabase silently caps at 1000 rows (`config.toml max_rows`), dropping the tail from both the player calendar and the admin peek view. This adds a shared `fetchAllPages()` pagination helper and rewrites `fetchAllAvailability` to paginate with a stable order and scope to a today-forward floor (past dates are never displayed), keeping the payload small. An audit surfaced other reads that can exceed 1000 rows, now paginated too: `fetchUpcomingSessionsForGames`, `fetchGameSessions`, the platform-wide admin games list, and the public ICS calendar feed. New unit tests cover the pagination helper and the availability/session query shapes; lint, typecheck, the full test suite (654 tests), and build all pass.