### PR TITLE
Explain OAuth sign-in failures and harden the signup trigger name fallback

### DIFF
--- a/e2e/tests/auth/login.spec.ts
+++ b/e2e/tests/auth/login.spec.ts
@@ -61,6 +61,46 @@ test.describe('Authentication', () => {
     await expect(page).toHaveURL('/settings');
   });
 
+  // Supabase Auth sends provider failures back to /auth/callback as query
+  // params rather than a code. Dropping them leaves the user bouncing off the
+  // login page with no explanation — the failure mode a Discord account with
+  // no email address hits every single time.
+  test('explains a provider sign-in failure instead of silently returning to login', async ({ page }) => {
+    await page.goto(
+      '/auth/callback?provider=discord&error=server_error&error_code=unexpected_failure' +
+        '&error_description=Error+getting+user+email+from+external+provider'
+    );
+
+    await expect(page).toHaveURL(/\/login\?error=provider_no_email&provider=discord/);
+    await expect(page.getByText(/your discord account has no email address/i)).toBeVisible();
+  });
+
+  // The provider tag rides along on the callback URL we hand Supabase. If it
+  // ever gets stripped, the message must stay neutral rather than blame a
+  // provider the user did not use.
+  test('stays provider-neutral when the callback is not tagged with a provider', async ({ page }) => {
+    await page.goto(
+      '/auth/callback?error=server_error' +
+        '&error_description=Error+getting+user+email+from+external+provider'
+    );
+
+    await expect(page.getByText(/no email address/i)).toBeVisible();
+    await expect(page.getByText(/your discord account/i)).toHaveCount(0);
+  });
+
+  test('keeps the intended destination when a provider sign-in fails', async ({ page }) => {
+    await page.goto('/auth/callback?next=%2Fsettings&error=access_denied&error_description=denied');
+
+    await expect(page).toHaveURL(/callbackUrl=%2Fsettings/);
+    await expect(page.getByText(/sign-in was cancelled/i)).toBeVisible();
+  });
+
+  test('shows a generic message for an unrecognized sign-in error', async ({ page }) => {
+    await page.goto('/login?error=auth_failed');
+
+    await expect(page.getByText(/something went wrong while signing you in/i)).toBeVisible();
+  });
+
   // Note: "Create New Game" button tests removed - all users are now GMs by default
 
   test('user can sign out and session is properly cleared', async ({ page }) => {

--- a/e2e/tests/auth/signup-trigger.spec.ts
+++ b/e2e/tests/auth/signup-trigger.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+// handle_new_user() runs inside the GoTrue signup transaction, so anything it
+// lets through to a public.users constraint aborts the whole signup — the user
+// simply cannot create an account. It must sanitize, never reject. These
+// exercise the trigger directly because the failure is invisible from the app:
+// the transaction rolls back and leaves no row to inspect.
+function sql(statement: string): string {
+  return execSync(`psql "${DB_URL}" -tA`, { encoding: 'utf8', input: statement }).trim();
+}
+
+const RUN = Date.now();
+
+test.describe('handle_new_user() name fallbacks', () => {
+  const created: string[] = [];
+
+  test.afterAll(() => {
+    for (const id of created) {
+      sql(`DELETE FROM auth.users WHERE id = '${id}';`);
+    }
+  });
+
+  /** Simulates a GoTrue signup and returns the name the trigger derived. */
+  function signUp(metadata: string, email: string): string {
+    const id = randomUUID();
+    created.push(id);
+    sql(
+      `INSERT INTO auth.users
+         (id, instance_id, aud, role, email, raw_user_meta_data, raw_app_meta_data, created_at, updated_at)
+       VALUES
+         ('${id}', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+          '${email}', '${metadata}'::jsonb, '{"provider":"discord"}'::jsonb, now(), now());`
+    );
+    return sql(`SELECT name FROM public.users WHERE id = '${id}';`);
+  }
+
+  test('uses the email local part when the provider sends an empty display name', () => {
+    expect(signUp('{"full_name": ""}', `noname-${RUN}@e2e.local`)).toBe(`noname-${RUN}`);
+  });
+
+  test('falls back to a placeholder when neither metadata nor email yields a name', () => {
+    expect(signUp('{}', `@e2e-${RUN}.local`)).toBe('Player');
+  });
+
+  test('still prefers the display name the provider supplied', () => {
+    expect(signUp('{"full_name": "Ada Lovelace"}', `ada-${RUN}@e2e.local`)).toBe('Ada Lovelace');
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,11 +1,27 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { classifyAuthCallbackError, isAuthProvider } from '@/lib/authCallback';
 import { safeCallbackUrl } from '@/lib/url';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-  const next = safeCallbackUrl(searchParams.get('next'));
+  const rawNext = searchParams.get('next');
+  const next = safeCallbackUrl(rawNext);
+
+  // Supabase Auth reports provider failures by redirecting here with
+  // error/error_description and no code. Classify before the generic fallback
+  // so /login can say what actually happened; forward the provider tag we set
+  // on the way out (there is no session to infer it from), and the intended
+  // destination so a retry with the other provider still lands there.
+  const providerError = classifyAuthCallbackError(searchParams);
+  if (providerError) {
+    const provider = searchParams.get('provider');
+    const params = new URLSearchParams({ error: providerError });
+    if (isAuthProvider(provider)) params.set('provider', provider);
+    if (rawNext) params.set('callbackUrl', next);
+    return NextResponse.redirect(`${origin}/login?${params}`);
+  }
 
   if (code) {
     const supabase = await createClient();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
 import { PageLoading } from '@/components/ui';
+import { getAuthErrorMessage } from '@/lib/authCallback';
 import { safeCallbackUrl } from '@/lib/url';
 
 function LoginContent() {
@@ -13,6 +14,7 @@ function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = safeCallbackUrl(searchParams.get('callbackUrl'));
+  const authError = getAuthErrorMessage(searchParams.get('error'), searchParams.get('provider'));
 
   useEffect(() => {
     // Redirect if user is already authenticated
@@ -36,6 +38,15 @@ function LoginContent() {
             <h1 className="text-2xl font-bold text-card-foreground mt-4">Can We Play?</h1>
             <p className="text-muted-foreground mt-2">Sign in to start scheduling your game nights</p>
           </div>
+
+          {authError && (
+            <div
+              role="alert"
+              className="mb-6 rounded-lg border border-danger/30 bg-danger/10 p-3 text-sm text-danger"
+            >
+              {authError}
+            </div>
+          )}
 
           <div className="space-y-4">
             <button

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import { getSupabaseClient, onSupabaseStatus } from '@/lib/supabase/client';
 import { fetchUserProfile } from '@/lib/data/users';
 import { User } from '@/types';
 import { TIMEOUTS } from '@/lib/constants';
+import { buildOAuthRedirectUrl, type AuthProvider } from '@/lib/authCallback';
 import { deriveAuthStatus, type AuthStatus } from './authStatus';
 
 interface AuthContextType {
@@ -229,30 +230,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [supabase, fetchProfile, queryClient]);
 
-  async function signInWithGoogle(redirectTo?: string) {
-    const redirectUrl = `${window.location.origin}/auth/callback${
-      redirectTo ? `?next=${encodeURIComponent(redirectTo)}` : ''
-    }`;
+  // The callback URL is tagged with the provider so a failed sign-in can name
+  // it: the error path has no session to read it from (see authCallback.ts).
+  async function signInWithProvider(provider: AuthProvider, redirectTo?: string) {
     const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
+      provider,
       options: {
-        redirectTo: redirectUrl,
+        redirectTo: buildOAuthRedirectUrl(window.location.origin, provider, redirectTo),
       },
     });
     if (error) reportBackendError(true);
   }
 
+  async function signInWithGoogle(redirectTo?: string) {
+    await signInWithProvider('google', redirectTo);
+  }
+
   async function signInWithDiscord(redirectTo?: string) {
-    const redirectUrl = `${window.location.origin}/auth/callback${
-      redirectTo ? `?next=${encodeURIComponent(redirectTo)}` : ''
-    }`;
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'discord',
-      options: {
-        redirectTo: redirectUrl,
-      },
-    });
-    if (error) reportBackendError(true);
+    await signInWithProvider('discord', redirectTo);
   }
 
   async function signOut() {

--- a/src/lib/authCallback.test.ts
+++ b/src/lib/authCallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOAuthRedirectUrl,
+  classifyAuthCallbackError,
+  getAuthErrorMessage,
+} from './authCallback';
+
+describe('buildOAuthRedirectUrl', () => {
+  it('tags the callback with the provider that started the flow', () => {
+    expect(buildOAuthRedirectUrl('https://app.test', 'discord')).toBe(
+      'https://app.test/auth/callback?provider=discord'
+    );
+  });
+
+  it('carries the intended destination alongside the provider', () => {
+    expect(buildOAuthRedirectUrl('https://app.test', 'google', '/games/join/ABC')).toBe(
+      'https://app.test/auth/callback?provider=google&next=%2Fgames%2Fjoin%2FABC'
+    );
+  });
+});
+
+describe('classifyAuthCallbackError', () => {
+  it('recognizes the provider-returned-no-email failure', () => {
+    // Verbatim shape of a Supabase Auth error redirect for an OAuth account
+    // with no email address (GoTrue redirectErrors -> query params).
+    const params = new URLSearchParams({
+      error: 'server_error',
+      error_code: 'unexpected_failure',
+      error_description: 'Error getting user email from external provider',
+    });
+
+    expect(classifyAuthCallbackError(params)).toBe('provider_no_email');
+  });
+
+  it('recognizes a declined consent screen', () => {
+    const params = new URLSearchParams({
+      error: 'access_denied',
+      error_description: 'The user denied the request',
+    });
+
+    expect(classifyAuthCallbackError(params)).toBe('access_denied');
+  });
+
+  it('falls back to auth_failed for an unrecognized provider error', () => {
+    const params = new URLSearchParams({
+      error: 'server_error',
+      error_description: 'Unable to exchange external code',
+    });
+
+    expect(classifyAuthCallbackError(params)).toBe('auth_failed');
+  });
+
+  it('returns null when the callback carries no error', () => {
+    expect(classifyAuthCallbackError(new URLSearchParams({ code: 'abc123' }))).toBeNull();
+  });
+});
+
+describe('getAuthErrorMessage', () => {
+  it('names the provider that failed and how to fix it', () => {
+    const message = getAuthErrorMessage('provider_no_email', 'discord');
+
+    expect(message).toMatch(/discord/i);
+    expect(message).toMatch(/no email address/i);
+  });
+
+  it('does not blame Discord when a different provider failed', () => {
+    const message = getAuthErrorMessage('provider_no_email', 'google');
+
+    expect(message).toMatch(/google/i);
+    expect(message).not.toMatch(/discord/i);
+  });
+
+  it('stays provider-neutral when the callback did not say which provider failed', () => {
+    const message = getAuthErrorMessage('provider_no_email', null);
+
+    expect(message).toMatch(/no email address/i);
+    expect(message).not.toMatch(/discord/i);
+    expect(message).not.toMatch(/google/i);
+  });
+
+  it('ignores a provider value it does not recognize', () => {
+    expect(getAuthErrorMessage('provider_no_email', 'evilcorp')).toBe(
+      getAuthErrorMessage('provider_no_email', null)
+    );
+  });
+
+  it('returns null when there is no error to show', () => {
+    expect(getAuthErrorMessage(null)).toBeNull();
+    expect(getAuthErrorMessage('')).toBeNull();
+  });
+
+  it('shows the generic message for a reason it does not know', () => {
+    expect(getAuthErrorMessage('not_a_real_reason')).toBe(getAuthErrorMessage('auth_failed'));
+  });
+});

--- a/src/lib/authCallback.ts
+++ b/src/lib/authCallback.ts
@@ -1,0 +1,92 @@
+/**
+ * Both directions of the OAuth callback contract.
+ *
+ * Outbound: we build the `redirectTo` URL handed to Supabase, tagging it with
+ * the provider that started the flow. Inbound: Supabase reports failures by
+ * redirecting back with `error` / `error_code` / `error_description` (GoTrue's
+ * `redirectErrors`) instead of a `code`, preserving whatever query params the
+ * redirect URL already carried — which is the only way to know which provider
+ * failed. There is no session to read on the error path: the sign-in never
+ * completed, so there is no user and no `app_metadata.provider`.
+ *
+ * Inbound errors are mapped onto a small set of stable reasons so `/login` can
+ * explain what happened without echoing provider prose, which is
+ * internal-facing and changes between GoTrue releases.
+ */
+export const AUTH_PROVIDERS = ['google', 'discord'] as const;
+
+export type AuthProvider = (typeof AUTH_PROVIDERS)[number];
+
+const PROVIDER_LABELS: Record<AuthProvider, string> = {
+  google: 'Google',
+  discord: 'Discord',
+};
+
+export const AUTH_ERROR_REASONS = ['provider_no_email', 'access_denied', 'auth_failed'] as const;
+
+export type AuthErrorReason = (typeof AUTH_ERROR_REASONS)[number];
+
+export function isAuthProvider(value: string | null | undefined): value is AuthProvider {
+  return !!value && value in PROVIDER_LABELS;
+}
+
+/**
+ * The `provider` tag survives the round trip only while Supabase's Redirect URL
+ * allowlist keeps query strings intact (the `/**` wildcard suffix — see
+ * CLAUDE.md). If it is ever stripped, the messages below degrade to
+ * provider-neutral copy rather than naming the wrong provider.
+ */
+export function buildOAuthRedirectUrl(
+  origin: string,
+  provider: AuthProvider,
+  next?: string
+): string {
+  const params = new URLSearchParams({ provider });
+  if (next) params.set('next', next);
+  return `${origin}/auth/callback?${params}`;
+}
+
+/**
+ * GoTrue raises this when the provider's profile response carried no email
+ * address. Discord is the only provider that can produce it today — its API
+ * types `email` as nullable even with the `email` scope granted, and unclaimed
+ * accounts (joined a server via invite, never set an email) have none — but the
+ * copy below reads the tagged provider instead of assuming.
+ */
+const NO_PROVIDER_EMAIL = /email from external provider/i;
+
+export function classifyAuthCallbackError(params: URLSearchParams): AuthErrorReason | null {
+  const error = params.get('error');
+  if (!error) return null;
+
+  if (NO_PROVIDER_EMAIL.test(params.get('error_description') ?? '')) return 'provider_no_email';
+  if (error === 'access_denied') return 'access_denied';
+  return 'auth_failed';
+}
+
+const STATIC_MESSAGES: Record<Exclude<AuthErrorReason, 'provider_no_email'>, string> = {
+  access_denied: 'Sign-in was cancelled. You can try again whenever you are ready.',
+  auth_failed: 'Something went wrong while signing you in. Please try again.',
+};
+
+function noEmailMessage(provider: string | null | undefined): string {
+  const label = isAuthProvider(provider) ? PROVIDER_LABELS[provider] : null;
+  const whose = label ? `Your ${label} account` : 'The account you signed in with';
+  // Discord buries this behind a specific settings path, so name it. Anything
+  // else gets generic guidance rather than a confidently wrong instruction.
+  const fix =
+    provider === 'discord'
+      ? 'Add an email in Discord under Settings → My Account, then try again'
+      : 'Add an email address to it, then try again';
+
+  return `${whose} has no email address, and we need one to create your account. ${fix} — or sign in with a different provider.`;
+}
+
+export function getAuthErrorMessage(
+  reason: string | null | undefined,
+  provider?: string | null
+): string | null {
+  if (!reason) return null;
+  if (reason === 'provider_no_email') return noEmailMessage(provider);
+  return STATIC_MESSAGES[reason as keyof typeof STATIC_MESSAGES] ?? STATIC_MESSAGES.auth_failed;
+}

--- a/supabase/prod-migrations/20260802T01_handle_new_user_name_fallback.sql
+++ b/supabase/prod-migrations/20260802T01_handle_new_user_name_fallback.sql
@@ -1,0 +1,54 @@
+-- handle_new_user(): never let a blank display name reach users.name.
+--
+-- Follow-up to 20260709T01. That migration made the trigger sanitize the
+-- avatar and truncate over-long names, but the name COALESCE chain still only
+-- skipped NULL candidates. A provider sending "full_name": "" — or an address
+-- with no local part — therefore produced an empty-string name, which NOT NULL
+-- accepts and every UI then renders as a nameless player. When the email was
+-- also absent the same chain produced NULL and aborted the entire GoTrue signup
+-- transaction (23502), which is how this surfaced: three failed sign-ups on
+-- 2026-08-02 from a Discord account with no email address.
+--
+-- NULLIF each candidate so blanks fall through, and add a last-resort literal
+-- so the chain cannot yield NULL regardless of what a provider sends.
+--
+-- email stays NOT NULL and undefended on purpose: Supabase Auth's Discord
+-- "allow users without email" setting is off, so GoTrue rejects an email-less
+-- OAuth account before this trigger runs.
+--
+-- Pre-flight: none — the new chain is strictly more permissive than the old one
+-- and existing rows are untouched.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_name TEXT := left(
+    COALESCE(
+      NULLIF(NEW.raw_user_meta_data->>'full_name', ''),
+      NULLIF(NEW.raw_user_meta_data->>'name', ''),
+      NULLIF(split_part(COALESCE(NEW.email, ''), '@', 1), ''),
+      'Player'
+    ),
+    50
+  );
+  v_avatar TEXT := COALESCE(
+    NEW.raw_user_meta_data->>'avatar_url',
+    NEW.raw_user_meta_data->>'picture'
+  );
+BEGIN
+  -- Must mirror the users.avatar_url CHECK; drop rather than reject.
+  IF v_avatar IS NOT NULL
+     AND v_avatar !~ '^https://(lh[0-9]+\.googleusercontent\.com|cdn\.discordapp\.com|avatars\.githubusercontent\.com)/' THEN
+    v_avatar := NULL;
+  END IF;
+
+  INSERT INTO public.users (id, email, name, avatar_url, is_gm, is_admin)
+  VALUES (NEW.id, NEW.email, v_name, v_avatar, true, false);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '';
+
+-- CREATE OR REPLACE preserves the existing ACL, but re-assert the lockdown so
+-- this file leaves the same grant state as schema.sql: the trigger fires via
+-- the table's trigger machinery, so no client role needs EXECUTE.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -161,15 +161,27 @@ $$ LANGUAGE plpgsql SET search_path = '';
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER AS $$
 DECLARE
-  -- Sanitize inputs instead of letting public.users CHECK constraints reject
-  -- the row: this trigger runs inside the auth signup transaction, so a
-  -- constraint violation here turns a validation rule into a signup outage
-  -- (OAuth name >50 chars, avatar from an unexpected host).
+  -- Sanitize inputs instead of letting public.users constraints reject the
+  -- row: this trigger runs inside the auth signup transaction, so a violation
+  -- here turns a validation rule into a signup outage (OAuth name >50 chars,
+  -- avatar from an unexpected host, provider sending a blank display name).
+  --
+  -- NULLIF on each candidate matters: COALESCE only skips NULL, so a provider
+  -- that sends "full_name": "" (or an address with no local part) otherwise
+  -- lands an empty string in users.name, which NOT NULL happily accepts.
+  --
+  -- email is deliberately NOT defended here. Supabase Auth guarantees it:
+  -- the Discord provider's "allow users without email" setting is off, so
+  -- GoTrue rejects an email-less OAuth account before this trigger runs. That
+  -- guarantee lives in dashboard config that neither this file nor db:drift
+  -- can see — if signups start failing on users_email_key or a NOT NULL
+  -- violation, check that setting before looking anywhere else.
   v_name TEXT := left(
     COALESCE(
-      NEW.raw_user_meta_data->>'full_name',
-      NEW.raw_user_meta_data->>'name',
-      split_part(NEW.email, '@', 1)
+      NULLIF(NEW.raw_user_meta_data->>'full_name', ''),
+      NULLIF(NEW.raw_user_meta_data->>'name', ''),
+      NULLIF(split_part(COALESCE(NEW.email, ''), '@', 1), ''),
+      'Player'
     ),
     50
   );


### PR DESCRIPTION
Production logged three `23502` signup aborts on 2026-08-02 from a Discord account with no email address — `handle_new_user()` runs inside the GoTrue signup transaction, so the constraint violation rolled back the whole sign-up and the user saw nothing explaining why (`/auth/callback` discarded Supabase's `error_description`, and `/login` never read the `error` param at all).

A new `src/lib/authCallback.ts` owns the callback contract in both directions: it tags the outbound `redirectTo` with the provider that started the flow — the error path has no session to infer it from — and classifies the inbound failure into a stable reason that `/login` renders with provider-specific remediation, staying neutral when the tag is absent rather than blaming a provider the user did not use. The intended destination now survives the error path too, so a retry with the other provider still lands on the original invite link.

`handle_new_user()` also gets its own latent defect fixed: `COALESCE` only skips `NULL`, so a provider sending `"full_name": ""` landed an empty string in `users.name` — each candidate is now `NULLIF`-guarded with a `'Player'` last resort, shipped with a matching `prod-migrations/` file. `email` stays `NOT NULL` and undefended by design, since Supabase Auth's Discord "allow users without email" setting has been turned off; a comment records that this guarantee lives in dashboard config neither `schema.sql` nor `db:drift` can see.

Covered by 12 unit tests for the callback contract, 4 e2e for the login error paths, and 3 driving the trigger directly through `psql` — the signup failure is invisible from the app because the transaction rolls back and leaves no row to inspect. Verified with lint, typecheck, 671 unit tests, build, and the full 315-test e2e suite; the migration is confirmed pending via `db:migrate --dry-run` and has not been applied.