### PR TITLE
Show your availability status in a graphical day tooltip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 Next.js 16 App Router app for scheduling game nights. Players mark availability on a calendar; the app ranks candidate dates. Supabase (Postgres + Auth + RLS) backend.
 
+## How the app works
+
+A GM creates a **game**: regular play days (weekdays), an optional scheduling window, session defaults, and `min_players_needed`. Players join via **invite code** and become members. The GM may add **extra dates** outside the regular play days, and may promote members to co-GM.
+
+Each player marks per-date **availability** — `available` / `maybe` / `unavailable`, with an optional comment and an `available_after`/`available_until` time range. A date with no row is *pending*, which is deliberately not the same as `unavailable`: **silence is not a no.** That distinction drives most of the scheduling logic.
+
+Every eligible date (`isEligiblePlayDate()` — regular play day or extra date, inside the window, not past) becomes a **suggestion** carrying counts of available/maybe/unavailable/pending. Ranking and calendar color are computed from the same numbers in `src/lib/schedule/`, so the list and the calendar can't contradict each other:
+
+- `effectiveThreshold(gmValue, totalPlayers)` — how many yeses "enough" needs. An explicit GM minimum is used verbatim and never capped (a game whose minimum exceeds its roster genuinely can't run); otherwise 60% of the group rounded up, floored at 3, capped at the roster.
+- `resolveDateState(suggestion, threshold)` — one of seven `DateState`s. **Positive claims read a ceiling that excludes pending players; the "can't happen" claim reads one that includes them.** So silence never counts as good news, and a date is only called dead when it can't be saved even if every silent player says yes. "We don't know yet" falls out of that asymmetry — there is no response-rate cutoff anywhere.
+
+The GM confirms a date into a **session** (date + start/end time), which draws the star on both calendars and can be exported to a personal calendar. A player belongs to many games, so the app also surfaces sessions from a user's *other* games when they mark availability here.
+
 ## Commands
 
 Full list in `package.json`. Non-obvious ones:
@@ -50,6 +63,8 @@ npx playwright test "e2e/tests/settings/profile.spec.ts:46" --project=chromium
 - Available: `primary`, `secondary`, `muted`, `accent`, `card`, `danger` (+ `danger-muted`), `foreground`, `border`, `ring`, each with a `-foreground` variant where applicable. There is no `destructive` token — use `danger`.
 - Info callouts: `bg-primary/10 border border-primary/30 rounded-lg` + `text-primary`. Badges: `bg-primary/10 text-primary`.
 - Use `public/logo.png` (via next/image) for branding, not emojis.
+- **Calendars have their own palette**, shared by the availability and schedule calendars: `cal-available-bg`/`-text`/`-ink`, `cal-empty-bg`/`-text`, `cal-unavailable-bg`/`-text`, `cal-disabled-bg`/`-text`, `cal-everyone` (gold), `cal-pending-on-fill`. Don't restyle a cell with `primary`/`danger` or a raw green, and don't reintroduce the retired `cal-maybe-*`, `cal-unset-*`, or `cal-scheduled-*` tokens — maybe is now the dashed `-ink` outline, unset is `cal-empty-*`, scheduled is a star.
+- **Cell appearance is data, not markup.** `src/components/games/schedule/calendarStyles.ts` maps each `DateState` to fill + pip and exports the matching `LEGEND` from the same constants, so a swatch can't drift from the cell it describes. Encoding: fill hue = outcome, solid vs dashed = whether confirmed yeses alone clear the threshold, gold badge = ceiling reaches everyone. Lightness encodes nothing — it inverts between light and dark mode, which is what broke the previous two-greens scheme across the 5 themes. `SCHEDULED_STAR_PATH` (`src/lib/constants.ts`) is the one star path.
 
 ## Database
 

--- a/e2e/tests/availability/day-tooltip.spec.ts
+++ b/e2e/tests/availability/day-tooltip.spec.ts
@@ -138,6 +138,16 @@ test.describe('availability day tooltip', () => {
     await expect(tip).toContainText('campaign');
   });
 
+  test('updates the band when you click the cell you are hovering', async ({ page }) => {
+    const cell = page.locator(`button[data-date="${unsetDate}"]`);
+    await cell.hover();
+    await expect(page.getByTestId('day-tooltip')).toContainText('Not set');
+    await cell.click();
+    await expect(cell).toHaveAttribute('data-status', 'available');
+    await expect(page.getByTestId('day-tooltip')).toContainText('Available');
+    await expect(page.getByTestId('day-tooltip')).not.toContainText('Not set');
+  });
+
   test('shows exactly one tooltip while moving between cells', async ({ page }) => {
     const tip = page.getByTestId('day-tooltip');
 

--- a/e2e/tests/availability/day-tooltip.spec.ts
+++ b/e2e/tests/availability/day-tooltip.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import {
+  createTestGame,
+  addPlayerToGame,
+  setAvailability,
+  getPlayDates,
+  getPastPlayDates,
+} from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+/**
+ * Returns an ISO date string N months from today, on a fixed day-of-month.
+ * Mirrors the helper in e2e/tests/games/campaign-dates.spec.ts.
+ */
+function futureDate(monthsAhead: number, day: number): string {
+  const date = new Date();
+  date.setMonth(date.getMonth() + monthsAhead);
+  date.setDate(day);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${d}`;
+}
+
+/** The next Sunday (day-of-week 0) starting tomorrow, as yyyy-MM-dd. */
+function nextNonPlayDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+  while (date.getDay() !== 0) {
+    date.setDate(date.getDate() + 1);
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${d}`;
+}
+
+test.describe('availability day tooltip', () => {
+  // Play days Mon-Sat (1-6); Sunday (0) is the deliberate non-play day.
+  const PLAY_DAYS = [1, 2, 3, 4, 5, 6];
+
+  let availableDate: string;
+  let unsetDate: string;
+  let pastDate: string;
+  let nonPlayDate: string;
+  let outOfRangeDate: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-tooltip-${Date.now()}@e2e.local`,
+      name: 'Tooltip GM',
+      is_gm: true,
+    });
+    const player = await createTestUser(request, {
+      email: `player-tooltip-${Date.now()}@e2e.local`,
+      name: 'Tooltip Player',
+      is_gm: false,
+    });
+
+    // Cap the campaign well inside the default 2-month window so the last
+    // rendered month has real, in-grid out-of-range days after the cutoff
+    // (a bare scheduling_window_months with no campaign_end_date ends
+    // exactly on a month boundary, which leaves nothing to hover past it).
+    const campaignEnd = futureDate(2, 10);
+    outOfRangeDate = futureDate(2, 20);
+
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: `Tooltip Game ${Date.now()}`,
+      play_days: PLAY_DAYS,
+      scheduling_window_months: 2,
+      campaign_end_date: campaignEnd,
+    });
+
+    await addPlayerToGame(game.id, player.id);
+
+    const upcomingPlayDates = getPlayDates(PLAY_DAYS, 1);
+    availableDate = upcomingPlayDates[0];
+    unsetDate = upcomingPlayDates[1];
+    pastDate = getPastPlayDates(PLAY_DAYS, 1)[0];
+    nonPlayDate = nextNonPlayDate();
+
+    await setAvailability(player.id, game.id, [
+      { date: availableDate, status: 'available' as const },
+    ]);
+    // unsetDate is deliberately left with no availability row (pending).
+
+    await loginTestUser(page, {
+      email: player.email,
+      name: player.name,
+      is_gm: false,
+    });
+
+    await page.goto(`/games/${game.id}`);
+    await expect(page.getByRole('button', { name: /availability/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.getByText(/mark your availability/i)).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+  });
+
+  test('names the status of an answered play day', async ({ page }) => {
+    await page.locator(`button[data-date="${availableDate}"]`).hover();
+    const tip = page.getByTestId('day-tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Available');
+    await expect(tip).toContainText('Click to mark Unavailable');
+  });
+
+  test('names the status of an unanswered play day', async ({ page }) => {
+    await page.locator(`button[data-date="${unsetDate}"]`).hover();
+    const tip = page.getByTestId('day-tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Not set');
+  });
+
+  test('explains a past cell, which used to say nothing', async ({ page }) => {
+    await page.locator(`button[data-date="${pastDate}"]`).hover();
+    const tip = page.getByTestId('day-tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Past');
+  });
+
+  test('explains a non-play day', async ({ page }) => {
+    await page.locator(`button[data-date="${nonPlayDate}"]`).hover();
+    const tip = page.getByTestId('day-tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Not a play day');
+  });
+
+  test('names the campaign bound on an out-of-range cell', async ({ page }) => {
+    await page.locator(`button[data-date="${outOfRangeDate}"]`).hover();
+    const tip = page.getByTestId('day-tooltip');
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('campaign');
+  });
+
+  test('shows exactly one tooltip while moving between cells', async ({ page }) => {
+    const tip = page.getByTestId('day-tooltip');
+
+    await page.locator(`button[data-date="${unsetDate}"]`).hover();
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Not set');
+
+    await page.locator(`button[data-date="${availableDate}"]`).hover();
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText('Available');
+
+    await expect(tip).toHaveCount(1);
+  });
+});

--- a/e2e/tests/availability/marking.spec.ts
+++ b/e2e/tests/availability/marking.spec.ts
@@ -275,7 +275,7 @@ test.describe('Availability Marking', () => {
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
     // Available date should show edit icon (pencil emoji) for adding notes
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await expect(editIcon).toBeVisible();
 
     // Click the edit icon to open note popover
@@ -290,7 +290,7 @@ test.describe('Availability Marking', () => {
     await page.getByRole('button', { name: 'Save' }).click();
 
     // Note icon should now show comment bubble instead of pencil
-    const commentIcon = dateButton.locator('span[title^="Edit note"]');
+    const commentIcon = dateButton.locator('span[aria-label^="Edit note"]');
     await expect(commentIcon).toBeVisible();
 
     // Verify note persists after reload
@@ -301,7 +301,7 @@ test.describe('Availability Marking', () => {
     await page.getByRole('button', { name: /availability/i }).click();
 
     const dateButtonAfterReload = page.locator(`button[data-date="${targetDate}"]`);
-    await expect(dateButtonAfterReload.locator('span[title^="Edit note"]')).toBeVisible();
+    await expect(dateButtonAfterReload.locator('span[aria-label^="Edit note"]')).toBeVisible();
   });
 
   test('notes persist when cycling through availability states', async ({ page, request }) => {
@@ -341,7 +341,7 @@ test.describe('Availability Marking', () => {
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await editIcon.click();
 
     const noteInput = page.locator('input[placeholder*="Depends on work"]');
@@ -349,25 +349,25 @@ test.describe('Availability Marking', () => {
     await page.getByRole('button', { name: 'Save' }).click();
 
     // Verify note icon shows
-    await expect(dateButton.locator('span[title^="Edit note"]')).toBeVisible();
+    await expect(dateButton.locator('span[aria-label^="Edit note"]')).toBeVisible();
 
     // Cycle to unavailable - note should persist
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'unavailable');
-    await expect(dateButton.locator('span[title^="Edit note"]')).toBeVisible();
+    await expect(dateButton.locator('span[aria-label^="Edit note"]')).toBeVisible();
 
     // Cycle to maybe - note should persist
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'maybe');
-    await expect(dateButton.locator('span[title^="Edit note"]')).toBeVisible();
+    await expect(dateButton.locator('span[aria-label^="Edit note"]')).toBeVisible();
 
     // Cycle back to available - note should still persist
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'available');
-    await expect(dateButton.locator('span[title^="Edit note"]')).toBeVisible();
+    await expect(dateButton.locator('span[aria-label^="Edit note"]')).toBeVisible();
 
     // Verify the note content is still there by clicking edit
-    const commentIcon = dateButton.locator('span[title^="Edit note"]');
+    const commentIcon = dateButton.locator('span[aria-label^="Edit note"]');
     await commentIcon.click();
 
     const noteInputAfterCycle = page.locator('input[placeholder*="Depends on work"]');

--- a/e2e/tests/availability/time-constraints.spec.ts
+++ b/e2e/tests/availability/time-constraints.spec.ts
@@ -47,7 +47,7 @@ test.describe('Time Availability Constraints', () => {
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
     // Open note editor via pencil icon
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await expect(editIcon).toBeVisible();
     await editIcon.click();
 
@@ -56,14 +56,14 @@ test.describe('Time Availability Constraints', () => {
     await expect(page.getByText('Available until')).toBeVisible();
 
     // Set "available after" time
-    const afterInput = page.getByLabel('Available after');
+    const afterInput = page.getByLabel('Available after', { exact: true });
     await afterInput.selectOption('19:00');
 
     // Save
     await page.getByRole('button', { name: 'Save' }).click();
 
     // Clock icon should appear on the date cell
-    await expect(dateButton.locator('span[title*="After"], span[title*="Until"]')).toBeVisible();
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
 
     // Verify persistence after reload
     await page.reload();
@@ -73,13 +73,13 @@ test.describe('Time Availability Constraints', () => {
     await page.getByRole('button', { name: /availability/i }).click();
 
     const dateButtonAfterReload = page.locator(`button[data-date="${targetDate}"]`);
-    await expect(dateButtonAfterReload.locator('span[title*="After"], span[title*="Until"]')).toBeVisible();
+    await expect(dateButtonAfterReload.getByTestId('time-indicator')).toBeVisible();
 
     // Open note editor again and verify the time is still there
-    const editIconAfterReload = dateButtonAfterReload.locator('span[title="Add note"], span[title^="Edit note"]');
+    const editIconAfterReload = dateButtonAfterReload.locator('span[aria-label="Add note"], span[aria-label^="Edit note"]');
     await editIconAfterReload.first().click();
 
-    const afterInputAfterReload = page.getByLabel('Available after');
+    const afterInputAfterReload = page.getByLabel('Available after', { exact: true });
     await expect(afterInputAfterReload).toHaveValue('19:00');
   });
 
@@ -122,7 +122,7 @@ test.describe('Time Availability Constraints', () => {
     await expect(dateButton).toHaveAttribute('data-status', 'unavailable');
 
     // Open note editor
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await expect(editIcon).toBeVisible();
     await editIcon.click();
 
@@ -280,9 +280,9 @@ test.describe('Time Availability Constraints', () => {
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await editIcon.click();
-    await page.getByLabel('Available after').selectOption('20:00');
+    await page.getByLabel('Available after', { exact: true }).selectOption('20:00');
     await page.getByRole('button', { name: 'Save' }).click();
 
     // Clock indicator visible while available
@@ -337,15 +337,15 @@ test.describe('Time Availability Constraints', () => {
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
-    const editIcon = dateButton.locator('span[title="Add note"]');
+    const editIcon = dateButton.locator('span[aria-label="Add note"]');
     await editIcon.click();
 
-    const afterInput = page.getByLabel('Available after');
+    const afterInput = page.getByLabel('Available after', { exact: true });
     await afterInput.selectOption('20:00');
     await page.getByRole('button', { name: 'Save' }).click();
 
     // Clock icon visible
-    await expect(dateButton.locator('span[title*="After"], span[title*="Until"]')).toBeVisible();
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
 
     // Cycle to unavailable
     await dateButton.click();
@@ -356,20 +356,20 @@ test.describe('Time Availability Constraints', () => {
     await expect(dateButton).toHaveAttribute('data-status', 'maybe');
 
     // Clock icon should still be visible on maybe
-    await expect(dateButton.locator('span[title*="After"], span[title*="Until"]')).toBeVisible();
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
 
     // Cycle back to available
     await dateButton.click();
     await expect(dateButton).toHaveAttribute('data-status', 'available');
 
     // Clock icon should persist
-    await expect(dateButton.locator('span[title*="After"], span[title*="Until"]')).toBeVisible();
+    await expect(dateButton.getByTestId('time-indicator')).toBeVisible();
 
     // Open note editor and verify time is still set
-    const commentIcon = dateButton.locator('span[title="Add note"], span[title^="Edit note"]');
+    const commentIcon = dateButton.locator('span[aria-label="Add note"], span[aria-label^="Edit note"]');
     await commentIcon.first().click();
 
-    const afterInputCheck = page.getByLabel('Available after');
+    const afterInputCheck = page.getByLabel('Available after', { exact: true });
     await expect(afterInputCheck).toHaveValue('20:00');
   });
 });

--- a/e2e/tests/games/ad-hoc-game.spec.ts
+++ b/e2e/tests/games/ad-hoc-game.spec.ts
@@ -200,7 +200,7 @@ test.describe('Ad-Hoc Games', () => {
       const dayButton = page.locator(`button[data-date="${futureDate}"]`);
       await dayButton.hover();
 
-      const addIcon = dayButton.locator('span[title="Add play date"]');
+      const addIcon = dayButton.locator('span[aria-label="Add play date"]');
       await expect(addIcon).toBeVisible();
     });
 
@@ -233,7 +233,7 @@ test.describe('Ad-Hoc Games', () => {
       const dayButton = page.locator(`button[data-date="${futureDate}"]`);
       await dayButton.hover();
 
-      const addIcon = dayButton.locator('span[title="Add play date"]');
+      const addIcon = dayButton.locator('span[aria-label="Add play date"]');
       await addIcon.click();
 
       // Should now be a play date

--- a/e2e/tests/games/play-date-notes.spec.ts
+++ b/e2e/tests/games/play-date-notes.spec.ts
@@ -63,7 +63,7 @@ test.describe('Play Date Notes', () => {
 
       // The date cell should have a tooltip containing the GM note
       const dayButton = page.locator(`button[data-date="${futureDate}"]`);
-      await expect(dayButton).toHaveAttribute('title', /GM note: Different location today/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Different location today/);
     });
 
     test('player can see note in tooltip on calendar', async ({ page, request }) => {
@@ -103,7 +103,7 @@ test.describe('Play Date Notes', () => {
 
       // Player should see the GM note in the tooltip
       const dayButton = page.locator(`button[data-date="${futureDate}"]`);
-      await expect(dayButton).toHaveAttribute('title', /GM note: Only after 2pm/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Only after 2pm/);
     });
   });
 
@@ -158,7 +158,7 @@ test.describe('Play Date Notes', () => {
       await page.getByRole('button', { name: /save/i }).click();
 
       // The tooltip on the date cell should now show the note
-      await expect(dayButton).toHaveAttribute('title', /GM note: Bring snacks!/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Bring snacks!/);
     });
 
     test('non-GM player sees existing note as read-only in popover', async ({ page, request }) => {
@@ -297,7 +297,7 @@ test.describe('Play Date Notes', () => {
       // The special date should have the note in its tooltip
       const dayButton = page.locator(`button[data-date="${thursdayStr}"]`);
       await expect(dayButton).toHaveAttribute('data-extra', 'true');
-      await expect(dayButton).toHaveAttribute('title', /GM note: Extra session this week/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Extra session this week/);
     });
   });
 
@@ -351,7 +351,7 @@ test.describe('Play Date Notes', () => {
       await page.getByRole('button', { name: /save/i }).click();
 
       // The GM note should appear in the tooltip
-      await expect(dayButton).toHaveAttribute('title', /GM note: Game at park/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Game at park/);
 
       // Availability should NOT have been set (no data-status change)
       await expect(dayButton).not.toHaveAttribute('data-status', 'available');
@@ -505,8 +505,8 @@ test.describe('Play Date Notes', () => {
       const dayButton = page.locator(`button[data-date="${futureDate}"]`);
 
       // Tooltip should contain both the time constraint and the GM note
-      await expect(dayButton).toHaveAttribute('title', /After/);
-      await expect(dayButton).toHaveAttribute('title', /GM note: Afternoon only/);
+      await expect(dayButton).toHaveAttribute('aria-label', /Your status: \w+ after \d/);
+      await expect(dayButton).toHaveAttribute('aria-label', /GM note: Afternoon only/);
 
       // Both icons should be in the bottom-left area
       const bottomLeftIcons = dayButton.locator('[data-testid="note-icons"] > span');

--- a/e2e/tests/games/special-play-dates.spec.ts
+++ b/e2e/tests/games/special-play-dates.spec.ts
@@ -55,7 +55,7 @@ test.describe('Special Play Dates', () => {
     await dayButton.hover();
 
     // Should see the add icon appear on hover
-    const addIcon = dayButton.locator('span[title="Add extra date"]');
+    const addIcon = dayButton.locator('span[aria-label="Add extra date"]');
     await expect(addIcon).toBeVisible();
   });
 
@@ -90,7 +90,7 @@ test.describe('Special Play Dates', () => {
     const dayButton = page.locator(`button[data-date="${nonPlayDate}"]`);
     await dayButton.hover();
 
-    const addIcon = dayButton.locator('span[title="Add extra date"]');
+    const addIcon = dayButton.locator('span[aria-label="Add extra date"]');
     await addIcon.click();
 
     // After clicking, the day should now be marked as an extra date
@@ -98,7 +98,7 @@ test.describe('Special Play Dates', () => {
 
     // Now hover again to verify the remove icon appears
     await dayButton.hover();
-    const removeIcon = dayButton.locator('span[title="Remove extra date"]');
+    const removeIcon = dayButton.locator('span[aria-label="Remove extra date"]');
     await expect(removeIcon).toBeVisible();
   });
 
@@ -137,7 +137,7 @@ test.describe('Special Play Dates', () => {
 
     // Hover and click the remove icon
     await dayButton.hover();
-    const removeIcon = dayButton.locator('span[title="Remove extra date"]');
+    const removeIcon = dayButton.locator('span[aria-label="Remove extra date"]');
     await removeIcon.click();
 
     // After removing, the day should go back to being a non-play day (disabled status)
@@ -270,7 +270,7 @@ test.describe('Special Play Dates', () => {
     await dayButton.hover();
 
     // Should NOT see any add/remove icons as player
-    const addIcon = dayButton.locator('span[title="Add extra date"]');
+    const addIcon = dayButton.locator('span[aria-label="Add extra date"]');
     await expect(addIcon).not.toBeVisible();
   });
 

--- a/e2e/tests/rls/policy-enforcement.spec.ts
+++ b/e2e/tests/rls/policy-enforcement.spec.ts
@@ -336,7 +336,7 @@ test.describe('Availability Record Isolation', () => {
     // The UI only shows the GM's own availability calendar for editing
 
     // Verify the calendar rendered with clickable date cells
-    const calendarCell = page.locator('button[data-date]:not([disabled])').first();
+    const calendarCell = page.locator('button[data-date]:not([aria-disabled="true"])').first();
     if (await calendarCell.isVisible()) {
       // Just verify the calendar is interactive for own dates
       await expect(calendarCell).toBeEnabled();

--- a/e2e/tests/scheduling/confirmed-availability.spec.ts
+++ b/e2e/tests/scheduling/confirmed-availability.spec.ts
@@ -230,9 +230,9 @@ test.describe('Confirmed Day Availability', () => {
     const dateButton = page.locator(`button[data-date="${confirmedDate}"]`);
     await expect(dateButton).toBeVisible();
 
-    // Check the title attribute contains both scheduled info and availability status
-    const title = await dateButton.getAttribute('title');
-    expect(title).toContain('Scheduled');
+    // Check the aria-label attribute contains both scheduled info and availability status
+    const title = await dateButton.getAttribute('aria-label');
+    expect(title).toContain('Session confirmed');
     expect(title).toContain('7pm');
     expect(title).toContain('11pm');
     expect(title).toContain('Your status: Maybe');

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -19,14 +19,12 @@ import {
   filterDatesForBulkSet,
 } from "@/lib/availability";
 import type { OtherGameSessionInfo } from "@/lib/schedule";
-import type { TooltipModel } from "@/lib/calendarCellTooltip";
 import { useNoteEditorState } from "@/hooks/useNoteEditorState";
 import { MonthCalendar } from "./MonthCalendar";
 import { CalendarLegend } from "./CalendarLegend";
 import { NoteEditorPopover } from "./NoteEditorPopover";
 import { DateActionMenu } from "./DateActionMenu";
 import { BulkActionsBar } from "./BulkActionsBar";
-import { DayTooltip } from "./DayTooltip";
 
 export type { AvailabilityEntry };
 
@@ -92,6 +90,15 @@ export function AvailabilityCalendar({
   readOnly = false,
   onBulkSet,
 }: AvailabilityCalendarProps) {
+  // Recomputed every render, unlike windowStart (memoized once in
+  // useGameDerivedState.ts via getSchedulingWindow, which clamps
+  // windowStart to max(today, campaign_start)). The past/out-of-range
+  // precedence in calendarCellTooltip.ts's resolveBand rests entirely on
+  // windowStart >= today always holding — which is only true because both
+  // read the same clock. Decoupling this from that clamp (e.g. by moving one
+  // but not the other off "the render's `new Date()`") can produce
+  // isPast && !isOutOfRange across a midnight rollover with the tab left
+  // open, a combination that branch treats as impossible.
   const today = startOfDay(new Date());
   const maxDate = windowEnd;
   const {
@@ -110,7 +117,12 @@ export function AvailabilityCalendar({
   } = useNoteEditorState({ readOnly, availability, playDateNotes, onToggle, onUpdatePlayDateNote });
   // Action menu for GM long-press on extra play dates
   const [actionMenuDate, setActionMenuDate] = useState<string | null>(null);
-  const [hover, setHover] = useState<{ date: string; model: TooltipModel } | null>(null);
+  // The hovered/tapped date only — NOT a snapshot of its tooltip model. A
+  // model captured at hover time goes stale the instant the cell's own state
+  // changes without a fresh mouse event (e.g. a click, which doesn't move the
+  // pointer so onMouseEnter never re-fires). MonthCalendar re-derives the
+  // model from this date on every render, so it can never lag behind the cell.
+  const [hoveredDate, setHoveredDate] = useState<string | null>(null);
   // Inert tap toast state (mobile feedback for non-interactive cells)
   const [inertTapToast, setInertTapToast] = useState<string | null>(null);
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -257,12 +269,11 @@ export function AvailabilityCalendar({
             onInertTap={showInertTapToast}
             otherGameSessionsByDate={otherGameSessionsByDate}
             readOnly={readOnly}
-            onHoverDate={setHover}
+            hoveredDate={hoveredDate}
+            onHoverDate={setHoveredDate}
           />
         ))}
       </div>
-
-      <DayTooltip hover={hover} />
 
       <CalendarLegend hasPlayDays={playDays.length > 0} hasCampaignDates={hasCampaignDates} />
 

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -19,12 +19,14 @@ import {
   filterDatesForBulkSet,
 } from "@/lib/availability";
 import type { OtherGameSessionInfo } from "@/lib/schedule";
+import type { TooltipModel } from "@/lib/calendarCellTooltip";
 import { useNoteEditorState } from "@/hooks/useNoteEditorState";
 import { MonthCalendar } from "./MonthCalendar";
 import { CalendarLegend } from "./CalendarLegend";
 import { NoteEditorPopover } from "./NoteEditorPopover";
 import { DateActionMenu } from "./DateActionMenu";
 import { BulkActionsBar } from "./BulkActionsBar";
+import { DayTooltip } from "./DayTooltip";
 
 export type { AvailabilityEntry };
 
@@ -108,6 +110,7 @@ export function AvailabilityCalendar({
   } = useNoteEditorState({ readOnly, availability, playDateNotes, onToggle, onUpdatePlayDateNote });
   // Action menu for GM long-press on extra play dates
   const [actionMenuDate, setActionMenuDate] = useState<string | null>(null);
+  const [hover, setHover] = useState<{ date: string; model: TooltipModel } | null>(null);
   // Out-of-range toast state (mobile feedback)
   const [outOfRangeToast, setOutOfRangeToast] = useState<string | null>(null);
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -254,9 +257,12 @@ export function AvailabilityCalendar({
             onOutOfRangeTap={showOutOfRangeToast}
             otherGameSessionsByDate={otherGameSessionsByDate}
             readOnly={readOnly}
+            onHoverDate={setHover}
           />
         ))}
       </div>
+
+      <DayTooltip hover={hover} />
 
       <CalendarLegend hasPlayDays={playDays.length > 0} hasCampaignDates={hasCampaignDates} />
 

--- a/src/components/calendar/AvailabilityCalendar.tsx
+++ b/src/components/calendar/AvailabilityCalendar.tsx
@@ -111,13 +111,13 @@ export function AvailabilityCalendar({
   // Action menu for GM long-press on extra play dates
   const [actionMenuDate, setActionMenuDate] = useState<string | null>(null);
   const [hover, setHover] = useState<{ date: string; model: TooltipModel } | null>(null);
-  // Out-of-range toast state (mobile feedback)
-  const [outOfRangeToast, setOutOfRangeToast] = useState<string | null>(null);
+  // Inert tap toast state (mobile feedback for non-interactive cells)
+  const [inertTapToast, setInertTapToast] = useState<string | null>(null);
   const toastTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const showOutOfRangeToast = useCallback((message: string) => {
+  const showInertTapToast = useCallback((message: string) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    setOutOfRangeToast(message);
-    toastTimerRef.current = setTimeout(() => setOutOfRangeToast(null), 2000);
+    setInertTapToast(message);
+    toastTimerRef.current = setTimeout(() => setInertTapToast(null), 2000);
   }, []);
   useEffect(() => {
     return () => {
@@ -254,7 +254,7 @@ export function AvailabilityCalendar({
             playDateNotes={playDateNotes}
             windowStart={windowStart}
             windowEnd={windowEnd}
-            onOutOfRangeTap={showOutOfRangeToast}
+            onInertTap={showInertTapToast}
             otherGameSessionsByDate={otherGameSessionsByDate}
             readOnly={readOnly}
             onHoverDate={setHover}
@@ -266,14 +266,14 @@ export function AvailabilityCalendar({
 
       <CalendarLegend hasPlayDays={playDays.length > 0} hasCampaignDates={hasCampaignDates} />
 
-      {/* Out-of-range toast (mobile feedback) */}
-      {outOfRangeToast && (
+      {/* Inert tap toast (mobile feedback for non-interactive cells) */}
+      {inertTapToast && (
         <div
           className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg bg-card border border-border shadow-lg text-sm text-foreground animate-in fade-in slide-in-from-bottom-2 duration-200"
           role="status"
           aria-live="polite"
         >
-          {outOfRangeToast}
+          {inertTapToast}
         </div>
       )}
 

--- a/src/components/calendar/DayTooltip.test.tsx
+++ b/src/components/calendar/DayTooltip.test.tsx
@@ -85,14 +85,16 @@ describe('DayTooltip', () => {
       .toContain('bg-cal-available-ink/15 text-cal-available-ink border-y-2 border-dashed border-cal-available-ink');
   });
 
-  it('paints past and non-play bands with the same muted stripe the cells use', async () => {
+  it('paints the past band with the same out-of-range utility the cell uses', async () => {
     mountCell('2026-09-04');
     const DayTooltip = await loadTooltip();
     render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
     const { BAND_STYLES } = await import('./DayTooltip');
-    expect(BAND_STYLES.past).toBe(BAND_STYLES['non-play']);
-    expect(BAND_STYLES.past).toContain('var(--muted)');
-    expect(BAND_STYLES.past).not.toContain('cal-out-of-range');
+    // A past cell is out-of-range by construction (windowStart is clamped to
+    // today), so calendarCellState paints it with cal-out-of-range.
+    expect(BAND_STYLES.past).toContain('cal-out-of-range');
+    expect(BAND_STYLES['non-play']).toContain('var(--muted)');
+    expect(BAND_STYLES.past).not.toBe(BAND_STYLES['non-play']);
   });
 
   it('paints the out-of-range band with the cell out-of-range utility', async () => {

--- a/src/components/calendar/DayTooltip.test.tsx
+++ b/src/components/calendar/DayTooltip.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { TooltipModel } from '@/lib/calendarCellTooltip';
+import { calendarCellState, type CalendarCellInputs } from '@/lib/calendarCellState';
 
 beforeAll(() => {
   Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
@@ -88,18 +89,25 @@ describe('DayTooltip', () => {
   it('paints the past band with the same out-of-range utility the cell uses', async () => {
     mountCell('2026-09-04');
     const DayTooltip = await loadTooltip();
-    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
-    const { BAND_STYLES } = await import('./DayTooltip');
+    const pastModel: TooltipModel = {
+      ...model,
+      band: { label: 'Past · you were Available', qualifier: null, tone: 'past' },
+    };
+    render(<DayTooltip hover={{ date: '2026-09-04', model: pastModel }} />);
     // A past cell is out-of-range by construction (windowStart is clamped to
     // today), so calendarCellState paints it with cal-out-of-range.
-    expect(BAND_STYLES.past).toContain('cal-out-of-range');
-    expect(BAND_STYLES['non-play']).toContain('var(--muted)');
-    expect(BAND_STYLES.past).not.toBe(BAND_STYLES['non-play']);
+    expect(screen.getByTestId('day-tooltip-band').className).toContain('cal-out-of-range');
   });
 
   it('paints the out-of-range band with the cell out-of-range utility', async () => {
-    const { BAND_STYLES } = await import('./DayTooltip');
-    expect(BAND_STYLES['out-of-range']).toContain('cal-out-of-range');
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    const outOfRangeModel: TooltipModel = {
+      ...model,
+      band: { label: 'Before campaign start', qualifier: null, tone: 'out-of-range' },
+    };
+    render(<DayTooltip hover={{ date: '2026-09-04', model: outOfRangeModel }} />);
+    expect(screen.getByTestId('day-tooltip-band').className).toContain('cal-out-of-range');
   });
 
   it('never intercepts the pointer', async () => {
@@ -107,5 +115,38 @@ describe('DayTooltip', () => {
     const DayTooltip = await loadTooltip();
     render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
     expect(screen.getByRole('tooltip').className).toContain('pointer-events-none');
+  });
+});
+
+// Extracts cal-* tokens and CSS custom properties from a class string.
+function tokensOf(classes: string): string[] {
+  return [
+    ...(classes.match(/cal-[a-z-]+/g) ?? []),
+    ...(classes.match(/var\(--[a-z-]+\)/g) ?? []),
+  ];
+}
+
+const CELL_INPUTS: Record<string, CalendarCellInputs> = {
+  available:     { isOutOfRange: false, isConfirmed: false, isPast: false, isPlayDay: true,  isToday: false, status: 'available' },
+  maybe:         { isOutOfRange: false, isConfirmed: false, isPast: false, isPlayDay: true,  isToday: false, status: 'maybe' },
+  unavailable:   { isOutOfRange: false, isConfirmed: false, isPast: false, isPlayDay: true,  isToday: false, status: 'unavailable' },
+  unset:         { isOutOfRange: false, isConfirmed: false, isPast: false, isPlayDay: true,  isToday: false, status: undefined },
+  'non-play':    { isOutOfRange: false, isConfirmed: false, isPast: false, isPlayDay: false, isToday: false, status: undefined },
+  // A past date is out-of-range by construction (getSchedulingWindow clamps
+  // windowStart to today), which is exactly why calendarCellState never sees
+  // isPast without isOutOfRange in the real app — but as a pure function it
+  // still needs isOutOfRange: true here to reach the cal-out-of-range branch,
+  // same as the tooltip model's own `past` tone does at the model layer.
+  past:          { isOutOfRange: true,  isConfirmed: false, isPast: true,  isPlayDay: false, isToday: false, status: undefined },
+  'out-of-range': { isOutOfRange: true,  isConfirmed: false, isPast: false, isPlayDay: false, isToday: false, status: undefined },
+};
+
+describe('BAND_STYLES stays bound to the cell it describes', () => {
+  it.each(Object.keys(CELL_INPUTS))('band %s reuses the cell fill tokens', async (tone) => {
+    const { BAND_STYLES } = await import('./DayTooltip');
+    const cellTokens = tokensOf(calendarCellState(CELL_INPUTS[tone]).bgColor);
+    const bandTokens = tokensOf(BAND_STYLES[tone as keyof typeof BAND_STYLES]);
+    expect(cellTokens.length).toBeGreaterThan(0);
+    for (const token of cellTokens) expect(bandTokens).toContain(token);
   });
 });

--- a/src/components/calendar/DayTooltip.test.tsx
+++ b/src/components/calendar/DayTooltip.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TooltipModel } from '@/lib/calendarCellTooltip';
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    get() { return this.parentNode; },
+    configurable: true,
+  });
+});
+
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+async function loadTooltip() {
+  vi.resetModules();
+  return (await import('./DayTooltip')).DayTooltip;
+}
+
+const model: TooltipModel = {
+  dateLabel: 'Friday, Sep 4',
+  badges: ['Extra date'],
+  isScheduled: false,
+  band: { label: 'Maybe', qualifier: '6pm–10pm', tone: 'maybe' },
+  rows: [
+    { label: 'Note', value: 'Might be late' },
+    { label: 'GM', value: 'Bring snacks!' },
+  ],
+  hints: ['Click to mark Available'],
+};
+
+function mountCell(date: string) {
+  const el = document.createElement('button');
+  el.setAttribute('data-date', date);
+  el.getBoundingClientRect = () =>
+    ({ left: 100, top: 500, width: 40, height: 40, bottom: 540, right: 140 }) as DOMRect;
+  document.body.appendChild(el);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  stubMatchMedia(true);
+});
+
+describe('DayTooltip', () => {
+  it('renders nothing when nothing is hovered', async () => {
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={null} />);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing on a touch device', async () => {
+    stubMatchMedia(false);
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows the date, badges, band, rows and hint', async () => {
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
+
+    const tip = screen.getByRole('tooltip');
+    expect(tip).toHaveTextContent('Friday, Sep 4');
+    expect(tip).toHaveTextContent('Extra date');
+    expect(tip).toHaveTextContent('Maybe');
+    expect(tip).toHaveTextContent('6pm–10pm');
+    expect(tip).toHaveTextContent('Might be late');
+    expect(tip).toHaveTextContent('Bring snacks!');
+    expect(tip).toHaveTextContent('Click to mark Available');
+  });
+
+  it('paints the maybe band with the dashed ink outline the cell uses', async () => {
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
+    expect(screen.getByTestId('day-tooltip-band').className)
+      .toContain('bg-cal-available-ink/15 text-cal-available-ink border-y-2 border-dashed border-cal-available-ink');
+  });
+
+  it('paints past and non-play bands with the same muted stripe the cells use', async () => {
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
+    const { BAND_STYLES } = await import('./DayTooltip');
+    expect(BAND_STYLES.past).toBe(BAND_STYLES['non-play']);
+    expect(BAND_STYLES.past).toContain('var(--muted)');
+    expect(BAND_STYLES.past).not.toContain('cal-out-of-range');
+  });
+
+  it('paints the out-of-range band with the cell out-of-range utility', async () => {
+    const { BAND_STYLES } = await import('./DayTooltip');
+    expect(BAND_STYLES['out-of-range']).toContain('cal-out-of-range');
+  });
+
+  it('never intercepts the pointer', async () => {
+    mountCell('2026-09-04');
+    const DayTooltip = await loadTooltip();
+    render(<DayTooltip hover={{ date: '2026-09-04', model }} />);
+    expect(screen.getByRole('tooltip').className).toContain('pointer-events-none');
+  });
+});

--- a/src/components/calendar/DayTooltip.tsx
+++ b/src/components/calendar/DayTooltip.tsx
@@ -6,10 +6,10 @@ import type { BandTone, TooltipModel } from '@/lib/calendarCellTooltip';
 import { useHoverPopover } from '@/hooks/useHoverPopover';
 
 /**
- * The 45° stripe from calendarCellState.ts:57-59. Past in-range cells keep this
- * fill too — their isPast branch only dims the text, it never repaints the
- * background — so `past` and `non-play` are deliberately identical here. The
- * band's label is what distinguishes them, exactly as it is on the calendar.
+ * The 45° stripe from calendarCellState.ts:57-59, used by non-play in-range
+ * cells. NOT used by `past` — a past date is out-of-range by construction
+ * (getSchedulingWindow clamps windowStart to today), so calendarCellState
+ * paints it with `cal-out-of-range`, not this stripe. See BAND_STYLES.past.
  */
 const MUTED_STRIPE =
   'bg-[repeating-linear-gradient(45deg,transparent,transparent_3px,var(--muted)_3px,var(--muted)_5px)]';
@@ -31,7 +31,7 @@ export const BAND_STYLES: Record<BandTone, string> = {
   unavailable: 'bg-cal-unavailable-bg text-cal-unavailable-text',
   unset: 'bg-cal-empty-bg text-cal-empty-text',
   'non-play': `${MUTED_STRIPE} text-muted-foreground`,
-  past: `${MUTED_STRIPE} text-muted-foreground`,
+  past: 'cal-out-of-range text-muted-foreground',
   'out-of-range': 'cal-out-of-range text-muted-foreground',
 };
 

--- a/src/components/calendar/DayTooltip.tsx
+++ b/src/components/calendar/DayTooltip.tsx
@@ -31,6 +31,10 @@ export const BAND_STYLES: Record<BandTone, string> = {
   unavailable: 'bg-cal-unavailable-bg text-cal-unavailable-text',
   unset: 'bg-cal-empty-bg text-cal-empty-text',
   'non-play': `${MUTED_STRIPE} text-muted-foreground`,
+  // past and out-of-range are intentionally identical strings, not a
+  // duplicate to merge: calendarCellState paints a past date with
+  // cal-out-of-range too (it's out-of-range by construction), so the two
+  // fills must match even though `tone` keeps them distinct for the label.
   past: 'cal-out-of-range text-muted-foreground',
   'out-of-range': 'cal-out-of-range text-muted-foreground',
 };

--- a/src/components/calendar/DayTooltip.tsx
+++ b/src/components/calendar/DayTooltip.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import { SCHEDULED_STAR_PATH } from '@/lib/constants';
+import type { BandTone, TooltipModel } from '@/lib/calendarCellTooltip';
+import { useHoverPopover } from '@/hooks/useHoverPopover';
+
+/**
+ * The 45° stripe from calendarCellState.ts:57-59. Past in-range cells keep this
+ * fill too — their isPast branch only dims the text, it never repaints the
+ * background — so `past` and `non-play` are deliberately identical here. The
+ * band's label is what distinguishes them, exactly as it is on the calendar.
+ */
+const MUTED_STRIPE =
+  'bg-[repeating-linear-gradient(45deg,transparent,transparent_3px,var(--muted)_3px,var(--muted)_5px)]';
+
+/**
+ * The band restates the hovered cell's own fill, enlarged and labeled — so it
+ * has to be painted from the same tokens calendarCellState() uses. Keep these
+ * in step with it: a band that disagrees with its cell is worse than no band.
+ *
+ * Text colour is `text-muted-foreground`, not the cell's `text-cal-disabled-text`,
+ * because band text sits on the white card background where `--cal-disabled-text`
+ * (~1.6:1 contrast) is illegible. The fill is the contract; the text just needs
+ * to stay readable.
+ */
+export const BAND_STYLES: Record<BandTone, string> = {
+  available: 'bg-cal-available-bg text-cal-available-text',
+  maybe:
+    'bg-cal-available-ink/15 text-cal-available-ink border-y-2 border-dashed border-cal-available-ink',
+  unavailable: 'bg-cal-unavailable-bg text-cal-unavailable-text',
+  unset: 'bg-cal-empty-bg text-cal-empty-text',
+  'non-play': `${MUTED_STRIPE} text-muted-foreground`,
+  past: `${MUTED_STRIPE} text-muted-foreground`,
+  'out-of-range': 'cal-out-of-range text-muted-foreground',
+};
+
+interface DayTooltipProps {
+  hover: { date: string; model: TooltipModel } | null;
+}
+
+export function DayTooltip({ hover }: DayTooltipProps) {
+  const { coords, hoverCapable } = useHoverPopover(hover?.date ?? null, {
+    selector: (date) => `button[data-date="${date}"]`,
+  });
+
+  if (!hoverCapable || !hover || !coords) return null;
+  const { model } = hover;
+
+  return createPortal(
+    <div
+      role="tooltip"
+      data-testid="day-tooltip"
+      className={`pointer-events-none fixed z-50 w-56 rounded-lg border border-border bg-card p-3 shadow-lg ${
+        coords.placeBelow ? '' : '-translate-y-full'
+      } -translate-x-1/2`}
+      style={{ left: coords.x, top: coords.y }}
+    >
+      <p className="flex flex-wrap items-center gap-1.5 text-xs font-semibold text-card-foreground">
+        {model.isScheduled && (
+          <svg aria-hidden viewBox="0 0 24 24" className="size-3.5 shrink-0 fill-primary">
+            <path d={SCHEDULED_STAR_PATH} />
+          </svg>
+        )}
+        {model.dateLabel}
+        {model.badges.map((badge) => (
+          <span
+            key={badge}
+            className="rounded-sm bg-primary/10 px-1.5 py-px text-[9.5px] font-bold uppercase tracking-wide text-primary"
+          >
+            {badge}
+          </span>
+        ))}
+      </p>
+
+      {/* -mx-3 cancels the container padding so the band spans edge to edge. */}
+      <div
+        data-testid="day-tooltip-band"
+        className={`-mx-3 mt-2 flex items-center justify-between gap-2 px-3 py-1 text-xs font-bold ${
+          BAND_STYLES[model.band.tone]
+        }`}
+      >
+        <span>{model.band.label}</span>
+        {model.band.qualifier && (
+          <span className="text-[10.5px] font-semibold opacity-85">{model.band.qualifier}</span>
+        )}
+      </div>
+
+      {model.rows.length > 0 && (
+        <ul className="mt-1.5 space-y-0.5">
+          {model.rows.map((row, i) => (
+            <li key={`${row.label}-${i}`} className="flex gap-1.5 text-[11px]">
+              <span className="shrink-0 text-muted-foreground">{row.label}</span>
+              <span className="text-card-foreground">{row.value}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {model.hints.map((hint) => (
+        <p key={hint} className="mt-2 text-[10.5px] italic text-muted-foreground">
+          {hint}
+        </p>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/calendar/DayTooltip.tsx
+++ b/src/components/calendar/DayTooltip.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { createPortal } from 'react-dom';
-import { SCHEDULED_STAR_PATH } from '@/lib/constants';
 import type { BandTone, TooltipModel } from '@/lib/calendarCellTooltip';
 import { useHoverPopover } from '@/hooks/useHoverPopover';
 
@@ -60,12 +59,15 @@ export function DayTooltip({ hover }: DayTooltipProps) {
       } -translate-x-1/2`}
       style={{ left: coords.x, top: coords.y }}
     >
+      {/*
+        No star here: the cell's own star is coloured by the player's answer
+        (calendarCellState.ts's starFill ladder), and duplicating that ladder
+        just to match it would be a third copy of the same decision. A
+        fill-primary (blue) star above a green cell star taught the wrong
+        colour mapping. The SCHEDULED badge below already says this
+        unambiguously.
+      */}
       <p className="flex flex-wrap items-center gap-1.5 text-xs font-semibold text-card-foreground">
-        {model.isScheduled && (
-          <svg aria-hidden viewBox="0 0 24 24" className="size-3.5 shrink-0 fill-primary">
-            <path d={SCHEDULED_STAR_PATH} />
-          </svg>
-        )}
         {model.dateLabel}
         {model.badges.map((badge) => (
           <span

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -39,7 +39,7 @@ interface MonthCalendarProps {
   playDateNotes?: Map<string, string>;
   windowStart: Date;
   windowEnd: Date;
-  onOutOfRangeTap?: (message: string) => void;
+  onInertTap?: (message: string) => void;
   otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   readOnly?: boolean;
   onHoverDate?: (hover: { date: string; model: TooltipModel } | null) => void;
@@ -64,7 +64,7 @@ export function MonthCalendar({
   playDateNotes,
   windowStart,
   windowEnd,
-  onOutOfRangeTap,
+  onInertTap,
   otherGameSessionsByDate = new Map(),
   readOnly = false,
   onHoverDate,
@@ -205,15 +205,23 @@ export function MonthCalendar({
               onMouseEnter={() => onHoverDate?.({ date: dateStr, model: tooltipModel })}
               onMouseLeave={() => onHoverDate?.(null)}
               onTouchStart={() => {
-                if (isOutOfRange && !isPast && onOutOfRangeTap) {
-                  onOutOfRangeTap(
+                if (isOutOfRange) {
+                  onInertTap?.(
                     isBefore(date, windowStart) ? "Before campaign start" : "After campaign end"
                   );
                   return;
                 }
-                if (!isPast && !isOutOfRange) {
-                  handleTouchStart(dateStr, isRegularPlayDay, isExtraPlayDate);
+                if (isPast) {
+                  onInertTap?.("Past date");
+                  return;
                 }
+                // A GM can long-press a non-play day to add it, so only the
+                // members who genuinely can't act get the toast.
+                if (!isPlayDay && !canAddAsExtra) {
+                  onInertTap?.("Not a play day");
+                  return;
+                }
+                handleTouchStart(dateStr, isRegularPlayDay, isExtraPlayDate);
               }}
               onTouchEnd={handleTouchEnd}
               onTouchMove={handleTouchEnd}

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -14,12 +14,9 @@ import { CalendarDays, Clock, FileText, MessageSquare, Pencil, Plus, X } from 'l
 import type { GameSession } from '@/types';
 import { AvailabilityEntry } from '@/lib/availability';
 import { SCHEDULED_STAR_PATH } from '@/lib/constants';
-import { formatTimeShort } from '@/lib/formatting';
 import { calendarCellState } from '@/lib/calendarCellState';
-import {
-  formatSessionTimeWindow,
-  type OtherGameSessionInfo,
-} from '@/lib/schedule';
+import { type OtherGameSessionInfo } from '@/lib/schedule';
+import { describeCalendarCell, tooltipModelToText, type TooltipModel } from '@/lib/calendarCellTooltip';
 import { useLongPress } from '@/hooks/useLongPress';
 
 // Separate component for individual month to keep things clean
@@ -45,6 +42,7 @@ interface MonthCalendarProps {
   onOutOfRangeTap?: (message: string) => void;
   otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   readOnly?: boolean;
+  onHoverDate?: (hover: { date: string; model: TooltipModel } | null) => void;
 }
 
 export function MonthCalendar({
@@ -69,6 +67,7 @@ export function MonthCalendar({
   onOutOfRangeTap,
   otherGameSessionsByDate = new Map(),
   readOnly = false,
+  onHoverDate,
 }: MonthCalendarProps) {
   const days = eachDayOfInterval({
     start: startOfMonth(month),
@@ -150,6 +149,7 @@ export function MonthCalendar({
             isGmOrCoGm && !isRegularPlayDay && !isExtraPlayDate && !isPast && !isOutOfRange;
           // Can GM remove this extra play date?
           const canRemoveExtra = isGmOrCoGm && isExtraPlayDate && !isPast;
+          const isInert = (!isPlayDay && !canAddAsExtra) || isPast || isOutOfRange;
 
           const isTodayDate = isToday(date);
           const { bgColor, textColor, cursor, todayStyles, starFill, dataStatus } =
@@ -173,57 +173,37 @@ export function MonthCalendar({
             (avail?.status === "available" || avail?.status === "maybe");
           const hasAvailability = !!avail;
 
-          // Build tooltip
-          const tooltipParts = [format(date, "EEEE, MMM d")];
-          if (isConfirmed) {
-            const session = confirmedSessionsByDate.get(dateStr);
-            const startStr = formatTimeShort(session?.start_time ?? null, use24h);
-            const endStr = formatTimeShort(session?.end_time ?? null, use24h);
-            if (startStr && endStr) {
-              tooltipParts.push(`Scheduled: ${startStr}–${endStr}`);
-            } else if (startStr) {
-              tooltipParts.push(`Scheduled: starts ${startStr}`);
-            } else if (endStr) {
-              tooltipParts.push(`Scheduled: ends ${endStr}`);
-            } else {
-              tooltipParts.push("Scheduled");
-            }
-            if (!isPast) {
-              const statusLabel = avail?.status === "available" ? "Available" : avail?.status === "maybe" ? "Maybe" : avail?.status === "unavailable" ? "Unavailable" : "Not set";
-              tooltipParts.push(`Your status: ${statusLabel}`);
-            }
-          }
-          if (showTimeConstraint) {
-            const after = formatTimeShort(avail?.available_after ?? null, use24h);
-            const until = formatTimeShort(avail?.available_until ?? null, use24h);
-            if (after && until) {
-              tooltipParts.push(`Available ${after}–${until}`);
-            } else if (after) {
-              tooltipParts.push(`Available after ${after}`);
-            } else if (until) {
-              tooltipParts.push(`Available until ${until}`);
-            }
-          }
-          if (hasComment) {
-            tooltipParts.push(`Note: ${avail!.comment}`);
-          }
-          if (otherSessions?.length) {
-            for (const os of otherSessions) {
-              const when = formatSessionTimeWindow(os.startTime, os.endTime, use24h);
-              tooltipParts.push(`Scheduled: ${os.gameName}${when ? ` ${when}` : ""}`);
-            }
-          }
-          const gmNote = playDateNotes?.get(dateStr);
-          if (gmNote) {
-            tooltipParts.push(`GM note: ${gmNote}`);
-          }
-          const cellTooltip = tooltipParts.join("\n");
-
+          const tooltipModel = describeCalendarCell({
+            date: dateStr,
+            isOutOfRange,
+            isConfirmed,
+            isPast,
+            isPlayDay,
+            isToday: isTodayDate,
+            status: avail?.status,
+            entry: avail,
+            session: confirmedSessionsByDate.get(dateStr),
+            gmNote: playDateNotes?.get(dateStr),
+            otherSessions: otherSessions ?? [],
+            isExtraDate: isExtraPlayDate,
+            isGmOrCoGm,
+            readOnly,
+            canAddAsExtra,
+            windowStart,
+            windowEnd,
+            use24h,
+          });
+          const cellAriaLabel = tooltipModelToText(tooltipModel);
 
           return (
             <button
               key={dateStr}
-              onClick={() => handleDayClickWithLongPressCheck(date)}
+              onClick={() => {
+                if (isInert) return;
+                handleDayClickWithLongPressCheck(date);
+              }}
+              onMouseEnter={() => onHoverDate?.({ date: dateStr, model: tooltipModel })}
+              onMouseLeave={() => onHoverDate?.(null)}
               onTouchStart={() => {
                 if (isOutOfRange && !isPast && onOutOfRangeTap) {
                   onOutOfRangeTap(
@@ -237,7 +217,11 @@ export function MonthCalendar({
               }}
               onTouchEnd={handleTouchEnd}
               onTouchMove={handleTouchEnd}
-              disabled={(!isPlayDay && !canAddAsExtra) || isPast || isOutOfRange}
+              aria-disabled={isInert || undefined}
+              // aria-disabled keeps the cell in the a11y tree so its label can
+              // explain why it's dead, but a hover-only popover gives a keyboard
+              // user nothing to reach — so inert cells stay out of the tab order.
+              tabIndex={isInert ? -1 : 0}
               className={`group relative w-full aspect-square min-h-9 rounded-sm flex items-center justify-center font-mono text-xl transition-all select-none ${bgColor} ${textColor} ${cursor} ${todayStyles}`}
               style={{ WebkitTouchCallout: "none" }}
               data-date={dateStr}
@@ -245,7 +229,7 @@ export function MonthCalendar({
               data-availability={isConfirmed && !isPast ? (avail?.status ?? "unset") : undefined}
               data-extra={isExtraPlayDate ? "true" : undefined}
               data-other-game={showOtherGameBadge ? "true" : undefined}
-              title={cellTooltip}
+              aria-label={cellAriaLabel}
             >
               {/* Scheduled game star decoration */}
               {isConfirmed && (
@@ -266,9 +250,6 @@ export function MonthCalendar({
                 <span
                   className="absolute top-0.5 right-0.5 z-10 flex items-center rounded-sm bg-accent text-accent-foreground p-px leading-none"
                   data-testid="other-game-indicator"
-                  title={otherSessions!
-                    .map((os) => `Scheduled: ${os.gameName}`)
-                    .join("\n")}
                 >
                   <CalendarDays className="size-2.5" />
                 </span>
@@ -289,7 +270,7 @@ export function MonthCalendar({
                     if (consumeLongPress()) return;
                     onToggleExtraDate(dateStr);
                   }}
-                  title={playDays.length > 0 ? "Add extra date" : "Add play date"}
+                  aria-label={playDays.length > 0 ? "Add extra date" : "Add play date"}
                 >
                   <Plus className="size-2.5" />
                 </span>
@@ -304,7 +285,7 @@ export function MonthCalendar({
                     if (consumeLongPress()) return;
                     onToggleExtraDate(dateStr);
                   }}
-                  title={playDays.length > 0 ? "Remove extra date" : "Remove play date"}
+                  aria-label={playDays.length > 0 ? "Remove extra date" : "Remove play date"}
                 >
                   <X className="size-2.5" />
                 </span>
@@ -321,21 +302,12 @@ export function MonthCalendar({
                   }}
                 >
                   {showTimeConstraint && (
-                    <span
-                      data-testid="time-indicator"
-                      title={(() => {
-                        const after = formatTimeShort(avail?.available_after ?? null, use24h);
-                        const until = formatTimeShort(avail?.available_until ?? null, use24h);
-                        if (after && until) return `${after}–${until}`;
-                        if (after) return `After ${after}`;
-                        return `Until ${until}`;
-                      })()}
-                    >
+                    <span data-testid="time-indicator">
                       <Clock className="size-2.5" />
                     </span>
                   )}
                   {playDateNotes?.has(dateStr) && (
-                    <span data-testid="note-indicator" title={`GM note: ${playDateNotes.get(dateStr)}`}>
+                    <span data-testid="note-indicator">
                       <FileText className="size-2.5" />
                     </span>
                   )}
@@ -355,7 +327,7 @@ export function MonthCalendar({
                     if (consumeLongPress()) return;
                     onEditComment(dateStr);
                   }}
-                  title={
+                  aria-label={
                     hasComment
                       ? readOnly
                         ? `Note: ${avail!.comment}`

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -205,20 +205,14 @@ export function MonthCalendar({
               onMouseEnter={() => onHoverDate?.({ date: dateStr, model: tooltipModel })}
               onMouseLeave={() => onHoverDate?.(null)}
               onTouchStart={() => {
-                if (isOutOfRange) {
-                  onInertTap?.(
-                    isBefore(date, windowStart) ? "Before campaign start" : "After campaign end"
-                  );
-                  return;
-                }
-                if (isPast) {
-                  onInertTap?.("Past date");
-                  return;
-                }
-                // A GM can long-press a non-play day to add it, so only the
-                // members who genuinely can't act get the toast.
-                if (!isPlayDay && !canAddAsExtra) {
-                  onInertTap?.("Not a play day");
+                // The band label already encodes the corrected precedence (past
+                // before out-of-range) and is the same string the hover popover
+                // shows, so the toast can't drift from the tooltip. isInert is
+                // exactly "the user cannot act on this cell" — a GM who can add
+                // this non-play day as an extra date is NOT inert, so their
+                // long-press still reaches handleTouchStart.
+                if (isInert) {
+                  onInertTap?.(tooltipModel.band.label);
                   return;
                 }
                 handleTouchStart(dateStr, isRegularPlayDay, isExtraPlayDate);

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Fragment } from 'react';
 import {
   format,
   startOfMonth,
@@ -16,8 +17,12 @@ import { AvailabilityEntry } from '@/lib/availability';
 import { SCHEDULED_STAR_PATH } from '@/lib/constants';
 import { calendarCellState } from '@/lib/calendarCellState';
 import { type OtherGameSessionInfo } from '@/lib/schedule';
-import { describeCalendarCell, tooltipModelToText, type TooltipModel } from '@/lib/calendarCellTooltip';
+import { describeCalendarCell, tooltipModelToText } from '@/lib/calendarCellTooltip';
 import { useLongPress } from '@/hooks/useLongPress';
+// Imported directly, not via the './index' barrel: the barrel re-exports
+// AvailabilityCalendar, which imports this file — going through the barrel
+// would create a circular import.
+import { DayTooltip } from './DayTooltip';
 
 // Separate component for individual month to keep things clean
 interface MonthCalendarProps {
@@ -42,7 +47,9 @@ interface MonthCalendarProps {
   onInertTap?: (message: string) => void;
   otherGameSessionsByDate?: Map<string, OtherGameSessionInfo[]>;
   readOnly?: boolean;
-  onHoverDate?: (hover: { date: string; model: TooltipModel } | null) => void;
+  /** The single hovered/tapped date across the whole multi-month grid, or null. */
+  hoveredDate?: string | null;
+  onHoverDate?: (date: string | null) => void;
 }
 
 export function MonthCalendar({
@@ -67,6 +74,7 @@ export function MonthCalendar({
   onInertTap,
   otherGameSessionsByDate = new Map(),
   readOnly = false,
+  hoveredDate,
   onHoverDate,
 }: MonthCalendarProps) {
   const days = eachDayOfInterval({
@@ -196,13 +204,13 @@ export function MonthCalendar({
           const cellAriaLabel = tooltipModelToText(tooltipModel);
 
           return (
+            <Fragment key={dateStr}>
             <button
-              key={dateStr}
               onClick={() => {
                 if (isInert) return;
                 handleDayClickWithLongPressCheck(date);
               }}
-              onMouseEnter={() => onHoverDate?.({ date: dateStr, model: tooltipModel })}
+              onMouseEnter={() => onHoverDate?.(dateStr)}
               onMouseLeave={() => onHoverDate?.(null)}
               onTouchStart={() => {
                 // The band label already encodes the corrected precedence (past
@@ -341,6 +349,18 @@ export function MonthCalendar({
                 </span>
               )}
             </button>
+            {/*
+              Exactly one date can match hoveredDate across the whole
+              multi-month grid (dates don't repeat), so this renders at most
+              once total, not once per month. DayTooltip portals to
+              document.body, so its position in the tree doesn't matter, and
+              tooltipModel is computed above in this same render pass, so it
+              can never lag behind the cell it describes.
+            */}
+            {dateStr === hoveredDate && (
+              <DayTooltip hover={{ date: dateStr, model: tooltipModel }} />
+            )}
+            </Fragment>
           );
         })}
       </div>

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -1,1 +1,2 @@
 export { AvailabilityCalendar } from './AvailabilityCalendar';
+export * from './DayTooltip';

--- a/src/components/games/schedule/CalendarHoverPopover.tsx
+++ b/src/components/games/schedule/CalendarHoverPopover.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useLayoutEffect, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { format, parseISO } from 'date-fns';
 import type { DateSuggestion } from '@/types';
 import { describeDateState } from '@/lib/schedule';
+import { useHoverPopover } from '@/hooks/useHoverPopover';
 import { useHoverSync } from './HoverSyncContext';
 
 interface CalendarHoverPopoverProps {
@@ -12,78 +12,12 @@ interface CalendarHoverPopoverProps {
   scheduledDates: Set<string>;
 }
 
-// Lazily created so it's only constructed in browser environments (and once
-// per module load, not per component instance).
-let hoverCapableMql: MediaQueryList | null | undefined;
-
-function getHoverCapableMql(): MediaQueryList | null {
-  if (hoverCapableMql === undefined) {
-    hoverCapableMql =
-      typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-        ? window.matchMedia('(hover: hover) and (pointer: fine)')
-        : null;
-  }
-  return hoverCapableMql;
-}
-
-function subscribeHoverCapable(onChange: () => void): () => void {
-  const mql = getHoverCapableMql();
-  if (!mql) return () => {};
-  mql.addEventListener('change', onChange);
-  return () => mql.removeEventListener('change', onChange);
-}
-
-function getHoverCapableSnapshot(): boolean {
-  return getHoverCapableMql()?.matches ?? false;
-}
-
-function getHoverCapableServerSnapshot(): boolean {
-  return false;
-}
-
-function useHoverCapable(): boolean {
-  return useSyncExternalStore(
-    subscribeHoverCapable,
-    getHoverCapableSnapshot,
-    getHoverCapableServerSnapshot
-  );
-}
-
-const POPOVER_HEIGHT_HINT = 140;
-
 export function CalendarHoverPopover({ suggestions, scheduledDates }: CalendarHoverPopoverProps) {
   const { hoveredDate, hoveredFrom } = useHoverSync();
-  const hoverCapable = useHoverCapable();
-  const [coords, setCoords] = useState<{ x: number; y: number; placeBelow: boolean } | null>(null);
-
   const activeDate = hoveredFrom === 'cell' ? hoveredDate : null;
-
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useLayoutEffect(() => {
-    if (!activeDate) {
-      setCoords(null);
-      return;
-    }
-    // Both the mobile <details> block and the desktop <aside> render a calendar,
-    // so multiple cells can share the same data-date. Find the first one that
-    // is actually visible in the current viewport.
-    const candidates = document.querySelectorAll<HTMLElement>(
-      `[data-testid="calendar-cell"][data-date="${activeDate}"]`
-    );
-    const el = Array.from(candidates).find((node) => node.offsetParent !== null);
-    if (!el) {
-      setCoords(null);
-      return;
-    }
-    const rect = el.getBoundingClientRect();
-    const placeBelow = rect.top < POPOVER_HEIGHT_HINT;
-    setCoords({
-      x: rect.left + rect.width / 2,
-      y: placeBelow ? rect.bottom + 6 : rect.top - 6,
-      placeBelow,
-    });
-  }, [activeDate]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  const { coords, hoverCapable } = useHoverPopover(activeDate, {
+    selector: (date) => `[data-testid="calendar-cell"][data-date="${date}"]`,
+  });
 
   if (!hoverCapable || !activeDate || !coords) return null;
 

--- a/src/hooks/useHoverPopover.test.ts
+++ b/src/hooks/useHoverPopover.test.ts
@@ -87,4 +87,27 @@ describe('useHoverPopover', () => {
       useHoverPopover('2026-09-04', { selector: (d) => `button[data-date="${d}"]` }));
     expect(result.current.coords?.x).toBe(210);
   });
+
+  it('clamps x so the popover stays on-screen near the left edge', async () => {
+    // Cell centre at x=20, well inside the HALF_WIDTH (116) margin.
+    mountCell('2026-09-04', { left: 0, width: 40 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-09-04'));
+    expect(result.current.coords?.x).toBe(116);
+    // The popover (w-56, translated -50%) never extends left of the viewport.
+    expect((result.current.coords?.x ?? 0) - 116).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps x so the popover stays on-screen near the right edge', async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    // Cell centre at x=1020, well past innerWidth - HALF_WIDTH (908).
+    mountCell('2026-09-04', { left: 1000, width: 40 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-09-04'));
+    expect(result.current.coords?.x).toBe(908);
+    // The popover (w-56, translated -50%) never extends past the viewport.
+    expect((result.current.coords?.x ?? 0) + 116).toBeLessThanOrEqual(1024);
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+  });
 });

--- a/src/hooks/useHoverPopover.test.ts
+++ b/src/hooks/useHoverPopover.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+beforeAll(() => {
+  // jsdom never lays out, so offsetParent is always null. The hook uses it to
+  // pick the visible node among duplicate responsive renders.
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    get() { return this.parentNode; },
+    configurable: true,
+  });
+});
+
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+async function loadHook() {
+  vi.resetModules();
+  return (await import('./useHoverPopover')).useHoverPopover;
+}
+
+function mountCell(date: string, rect: Partial<DOMRect>, visible = true) {
+  const host = document.createElement('div');
+  const el = document.createElement('button');
+  el.setAttribute('data-date', date);
+  el.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, width: 40, height: 40, bottom: 40, right: 40, ...rect }) as DOMRect;
+  if (visible) host.appendChild(el);
+  document.body.appendChild(host);
+  // An unattached parent yields offsetParent === null via the stub above.
+  if (!visible) el.remove();
+  return el;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+beforeEach(() => { stubMatchMedia(true); });
+
+describe('useHoverPopover', () => {
+  it('reports hoverCapable false on a touch device', async () => {
+    stubMatchMedia(false);
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover(null));
+    expect(result.current.hoverCapable).toBe(false);
+  });
+
+  it('returns null coords when nothing is hovered', async () => {
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover(null));
+    expect(result.current.coords).toBeNull();
+  });
+
+  it('anchors to the horizontal centre of the cell', async () => {
+    mountCell('2026-09-04', { left: 100, width: 40, top: 500, bottom: 540 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-09-04'));
+    expect(result.current.coords?.x).toBe(120);
+  });
+
+  it('places above a cell with room overhead', async () => {
+    mountCell('2026-09-04', { top: 500, bottom: 540 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-09-04'));
+    expect(result.current.coords).toMatchObject({ placeBelow: false, y: 494 });
+  });
+
+  it('flips below a cell near the viewport top', async () => {
+    mountCell('2026-09-04', { top: 10, bottom: 50 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-09-04'));
+    expect(result.current.coords).toMatchObject({ placeBelow: true, y: 56 });
+  });
+
+  it('returns null coords when no cell matches', async () => {
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() => useHoverPopover('2026-01-01'));
+    expect(result.current.coords).toBeNull();
+  });
+
+  it('honours a custom selector', async () => {
+    mountCell('2026-09-04', { left: 200, width: 20 });
+    const useHoverPopover = await loadHook();
+    const { result } = renderHook(() =>
+      useHoverPopover('2026-09-04', { selector: (d) => `button[data-date="${d}"]` }));
+    expect(result.current.coords?.x).toBe(210);
+  });
+});

--- a/src/hooks/useHoverPopover.ts
+++ b/src/hooks/useHoverPopover.ts
@@ -82,8 +82,15 @@ export function useHoverPopover(
     }
     const rect = el.getBoundingClientRect();
     const placeBelow = rect.top < heightHint;
+    // Clamp horizontally so a cell near a viewport edge (400% zoom, a narrow
+    // desktop window) doesn't push the w-56 popover half off-screen. It's
+    // position: fixed and pointer-events: none, so a clipped edge is
+    // unrecoverable — there's no scrolling or dismissing it into view.
+    const HALF_WIDTH = 116; // half of w-56 (224px) plus a small margin
+    const rawX = rect.left + rect.width / 2;
+    const x = Math.min(Math.max(rawX, HALF_WIDTH), window.innerWidth - HALF_WIDTH);
     setCoords({
-      x: rect.left + rect.width / 2,
+      x,
       y: placeBelow ? rect.bottom + 6 : rect.top - 6,
       placeBelow,
     });

--- a/src/hooks/useHoverPopover.ts
+++ b/src/hooks/useHoverPopover.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useLayoutEffect, useState, useSyncExternalStore } from 'react';
+
+export interface HoverPopoverCoords {
+  x: number;
+  y: number;
+  /** True when the cell sits too near the viewport top to place the popover above it. */
+  placeBelow: boolean;
+}
+
+// Lazily created so it's only constructed in browser environments (and once
+// per module load, not per component instance).
+let hoverCapableMql: MediaQueryList | null | undefined;
+
+function getHoverCapableMql(): MediaQueryList | null {
+  if (hoverCapableMql === undefined) {
+    hoverCapableMql =
+      typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+        ? window.matchMedia('(hover: hover) and (pointer: fine)')
+        : null;
+  }
+  return hoverCapableMql;
+}
+
+function subscribeHoverCapable(onChange: () => void): () => void {
+  const mql = getHoverCapableMql();
+  if (!mql) return () => {};
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+function getHoverCapableSnapshot(): boolean {
+  return getHoverCapableMql()?.matches ?? false;
+}
+
+function getHoverCapableServerSnapshot(): boolean {
+  return false;
+}
+
+const DEFAULT_HEIGHT_HINT = 140;
+const defaultSelector = (date: string) => `[data-date="${date}"]`;
+
+/**
+ * Anchors a hover popover to a calendar cell.
+ *
+ * Returns `hoverCapable: false` on touch devices, where a hover popover has no
+ * dismissal gesture and would sit stuck under a thumb.
+ */
+export function useHoverPopover(
+  activeDate: string | null,
+  opts: { heightHint?: number; selector?: (date: string) => string } = {},
+): { coords: HoverPopoverCoords | null; hoverCapable: boolean } {
+  const { heightHint = DEFAULT_HEIGHT_HINT, selector = defaultSelector } = opts;
+  const hoverCapable = useSyncExternalStore(
+    subscribeHoverCapable,
+    getHoverCapableSnapshot,
+    getHoverCapableServerSnapshot,
+  );
+  const [coords, setCoords] = useState<HoverPopoverCoords | null>(null);
+
+  // A selector passed inline gets a fresh identity every render, so depending
+  // on the function itself would re-fire this effect forever (it setStates a
+  // new object each run). The resolved string is a primitive and compares by
+  // value, so the effect settles after one pass.
+  const query = activeDate ? selector(activeDate) : null;
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useLayoutEffect(() => {
+    if (!activeDate || !query) {
+      setCoords(null);
+      return;
+    }
+    // Responsive layouts render the same date more than once (a mobile
+    // <details> block and a desktop <aside>, say), so several nodes can share
+    // one data-date. Take the first that's actually laid out.
+    const candidates = document.querySelectorAll<HTMLElement>(query);
+    const el = Array.from(candidates).find((node) => node.offsetParent !== null);
+    if (!el) {
+      setCoords(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const placeBelow = rect.top < heightHint;
+    setCoords({
+      x: rect.left + rect.width / 2,
+      y: placeBelow ? rect.bottom + 6 : rect.top - 6,
+      placeBelow,
+    });
+  }, [activeDate, query, heightHint]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  return { coords, hoverCapable };
+}

--- a/src/lib/calendarCellTooltip.test.ts
+++ b/src/lib/calendarCellTooltip.test.ts
@@ -116,6 +116,84 @@ describe('describeCalendarCell — time qualifier', () => {
   });
 });
 
+describe('describeCalendarCell — rows', () => {
+  it('lists the confirmed session time', () => {
+    const m = describeCalendarCell({
+      ...base,
+      isConfirmed: true,
+      session: { date: '2026-09-04', start_time: '19:00', end_time: '23:00' } as never,
+    });
+    expect(m.rows).toContainEqual({ label: 'Session', value: '7pm–11pm' });
+  });
+
+  it('lists your own note and the GM note separately', () => {
+    const m = describeCalendarCell({
+      ...withEntry('maybe', { comment: 'Might be late' }),
+      gmNote: 'Bring snacks!',
+    });
+    expect(m.rows).toContainEqual({ label: 'Note', value: 'Might be late' });
+    expect(m.rows).toContainEqual({ label: 'GM', value: 'Bring snacks!' });
+  });
+
+  it('lists one row per conflicting game', () => {
+    const m = describeCalendarCell({
+      ...base,
+      otherSessions: [
+        { gameId: 'a', gameName: 'Curse of Strahd', startTime: '19:00', endTime: null },
+        { gameId: 'b', gameName: 'Blades', startTime: null, endTime: null },
+      ],
+    });
+    expect(m.rows).toContainEqual({ label: 'Also', value: 'Curse of Strahd, from 7pm' });
+    expect(m.rows).toContainEqual({ label: 'Also', value: 'Blades' });
+  });
+
+  it('gives the campaign bound that was crossed, not both', () => {
+    const after = describeCalendarCell({ ...base, isOutOfRange: true, date: '2026-12-04' });
+    expect(after.rows).toContainEqual({ label: 'Campaign ends', value: 'Nov 20' });
+    expect(after.rows.some((r) => r.label === 'Campaign starts')).toBe(false);
+  });
+
+  it('emits no rows when there is nothing to say', () => {
+    expect(describeCalendarCell(base).rows).toEqual([]);
+  });
+});
+
+describe('describeCalendarCell — hints', () => {
+  it.each([
+    [undefined, 'Click to mark Available'],
+    ['available', 'Click to mark Unavailable'],
+    ['unavailable', 'Click to mark Maybe'],
+    ['maybe', 'Click to mark Available'],
+  ] as const)('states the next status after %s', (status, hint) => {
+    const input = status ? withEntry(status) : base;
+    expect(describeCalendarCell(input).hints).toContain(hint);
+  });
+
+  it('offers the GM the add-extra affordance on a non-play day', () => {
+    const m = describeCalendarCell({ ...base, isPlayDay: false, isGmOrCoGm: true, canAddAsExtra: true });
+    expect(m.hints).toContain('GM · click + to add as an extra date');
+    expect(m.hints.some((h) => h.startsWith('Click to mark'))).toBe(false);
+  });
+
+  it('offers the GM the remove affordance on an extra date', () => {
+    const m = describeCalendarCell({ ...base, isExtraDate: true, isGmOrCoGm: true });
+    expect(m.hints).toContain('GM · click ✕ to remove this extra date');
+  });
+
+  it('gives a plain member no GM hints', () => {
+    const m = describeCalendarCell({ ...base, isPlayDay: false, canAddAsExtra: false });
+    expect(m.hints).toEqual([]);
+  });
+
+  it.each([
+    ['readOnly', { readOnly: true }],
+    ['past', { isPast: true }],
+    ['out-of-range', { isOutOfRange: true }],
+  ])('suppresses all hints when %s', (_name, patch) => {
+    expect(describeCalendarCell({ ...withEntry('available'), ...patch }).hints).toEqual([]);
+  });
+});
+
 describe('tooltipModelToText', () => {
   it('folds the qualifier into the status line', () => {
     const text = tooltipModelToText(describeCalendarCell(withEntry('available', { available_after: '14:00' })));
@@ -126,5 +204,17 @@ describe('tooltipModelToText', () => {
     const text = tooltipModelToText(describeCalendarCell({ ...base, isPlayDay: false }));
     expect(text).toContain('Not a play day');
     expect(text).not.toContain('Your status');
+  });
+
+  it('preserves the phrasings the confirmed-availability E2E asserts', () => {
+    const text = tooltipModelToText(describeCalendarCell({
+      ...withEntry('maybe'),
+      isConfirmed: true,
+      session: { date: '2026-09-04', start_time: '19:00', end_time: '23:00' } as never,
+    }));
+    expect(text).toContain('Scheduled');
+    expect(text).toContain('7pm');
+    expect(text).toContain('11pm');
+    expect(text).toContain('Your status: Maybe');
   });
 });

--- a/src/lib/calendarCellTooltip.test.ts
+++ b/src/lib/calendarCellTooltip.test.ts
@@ -177,6 +177,24 @@ describe('describeCalendarCell — hints', () => {
     expect(describeCalendarCell(input).hints).toContain(hint);
   });
 
+  it('names the note pencil affordance when there is no note yet', () => {
+    expect(describeCalendarCell(base).hints).toContain('Click the note icon to add a note or time window');
+  });
+
+  it('names the note pencil affordance as "edit" once a note exists', () => {
+    const m = describeCalendarCell(withEntry('available', { comment: 'Might be late' }));
+    expect(m.hints).toContain('Click the note icon to edit your note');
+  });
+
+  it.each([
+    ['readOnly', { readOnly: true }],
+    ['past', { isPast: true }],
+    ['out-of-range', { isOutOfRange: true }],
+  ])('suppresses the note pencil hint when %s', (_name, patch) => {
+    const m = describeCalendarCell({ ...withEntry('available'), ...patch });
+    expect(m.hints.some((h) => h.startsWith('Click the note icon'))).toBe(false);
+  });
+
   it('offers the GM the add-extra affordance on a non-play day', () => {
     const m = describeCalendarCell({ ...base, isPlayDay: false, isGmOrCoGm: true, canAddAsExtra: true });
     expect(m.hints).toContain('GM · click + to add as an extra date');

--- a/src/lib/calendarCellTooltip.test.ts
+++ b/src/lib/calendarCellTooltip.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { describeCalendarCell, tooltipModelToText, type TooltipInputs } from './calendarCellTooltip';
+
+const base: TooltipInputs = {
+  date: '2026-09-04',
+  isOutOfRange: false,
+  isConfirmed: false,
+  isPast: false,
+  isPlayDay: true,
+  isToday: false,
+  status: undefined,
+  entry: undefined,
+  session: undefined,
+  gmNote: undefined,
+  otherSessions: [],
+  isExtraDate: false,
+  isGmOrCoGm: false,
+  readOnly: false,
+  canAddAsExtra: false,
+  windowStart: new Date(2026, 7, 1),
+  windowEnd: new Date(2026, 10, 20),
+  use24h: false,
+};
+
+const withEntry = (
+  status: 'available' | 'maybe' | 'unavailable',
+  extra: Partial<TooltipInputs['entry'] & object> = {},
+): TooltipInputs => ({
+  ...base,
+  status,
+  entry: { status, comment: null, available_after: null, available_until: null, ...extra },
+});
+
+describe('describeCalendarCell — header and badges', () => {
+  it('formats the date as a full weekday label', () => {
+    expect(describeCalendarCell(base).dateLabel).toBe('Friday, Sep 4');
+  });
+
+  it('badges a scheduled, extra, today cell', () => {
+    const m = describeCalendarCell({ ...base, isConfirmed: true, isExtraDate: true, isToday: true });
+    expect(m.badges).toEqual(['Scheduled', 'Extra date', 'Today']);
+    expect(m.isScheduled).toBe(true);
+  });
+
+  it('drops the extra-date badge on past cells', () => {
+    const m = describeCalendarCell({ ...base, isExtraDate: true, isPast: true });
+    expect(m.badges).not.toContain('Extra date');
+  });
+});
+
+describe('describeCalendarCell — band', () => {
+  it.each([
+    ['available', 'Available'],
+    ['maybe', 'Maybe'],
+    ['unavailable', 'Unavailable'],
+  ] as const)('labels a %s play day', (status, label) => {
+    const m = describeCalendarCell(withEntry(status));
+    expect(m.band).toMatchObject({ label, tone: status, qualifier: null });
+  });
+
+  it('labels an unanswered play day', () => {
+    expect(describeCalendarCell(base).band).toMatchObject({ label: 'Not set', tone: 'unset' });
+  });
+
+  it('labels a non-play day', () => {
+    expect(describeCalendarCell({ ...base, isPlayDay: false }).band)
+      .toMatchObject({ label: 'Not a play day', tone: 'non-play' });
+  });
+
+  it('recalls your answer on a past cell', () => {
+    const m = describeCalendarCell({ ...withEntry('available'), isPast: true });
+    expect(m.band).toMatchObject({ label: 'Past · you were Available', tone: 'past' });
+  });
+
+  it('says only "Past date" when you never answered', () => {
+    expect(describeCalendarCell({ ...base, isPast: true }).band.label).toBe('Past date');
+  });
+
+  it('names which campaign bound was crossed', () => {
+    const before = describeCalendarCell({ ...base, isOutOfRange: true, date: '2026-07-01' });
+    expect(before.band).toMatchObject({ label: 'Before campaign start', tone: 'out-of-range' });
+    const after = describeCalendarCell({ ...base, isOutOfRange: true, date: '2026-12-04' });
+    expect(after.band.label).toBe('After campaign end');
+  });
+
+  it('prefers past over non-play, matching calendarCellState precedence', () => {
+    const m = describeCalendarCell({ ...base, isPast: true, isPlayDay: false });
+    expect(m.band.tone).toBe('past');
+  });
+});
+
+describe('describeCalendarCell — time qualifier', () => {
+  it('renders a two-sided window as a range', () => {
+    const m = describeCalendarCell(withEntry('available', { available_after: '18:00', available_until: '22:00' }));
+    expect(m.band.qualifier).toBe('6pm–10pm');
+  });
+
+  it('renders an open-ended start', () => {
+    expect(describeCalendarCell(withEntry('maybe', { available_after: '18:00' })).band.qualifier)
+      .toBe('after 6pm');
+  });
+
+  it('renders an open-ended end', () => {
+    expect(describeCalendarCell(withEntry('available', { available_until: '22:00' })).band.qualifier)
+      .toBe('until 10pm');
+  });
+
+  it('suppresses the window on unavailable — the editor hides those fields', () => {
+    expect(describeCalendarCell(withEntry('unavailable', { available_after: '18:00' })).band.qualifier)
+      .toBeNull();
+  });
+
+  it('honours the 24h preference', () => {
+    const m = describeCalendarCell({ ...withEntry('available', { available_after: '18:00' }), use24h: true });
+    expect(m.band.qualifier).toBe('after 18:00');
+  });
+});
+
+describe('tooltipModelToText', () => {
+  it('folds the qualifier into the status line', () => {
+    const text = tooltipModelToText(describeCalendarCell(withEntry('available', { available_after: '14:00' })));
+    expect(text).toContain('Your status: Available after 2pm');
+  });
+
+  it('omits "Your status" for states you cannot answer', () => {
+    const text = tooltipModelToText(describeCalendarCell({ ...base, isPlayDay: false }));
+    expect(text).toContain('Not a play day');
+    expect(text).not.toContain('Your status');
+  });
+});

--- a/src/lib/calendarCellTooltip.test.ts
+++ b/src/lib/calendarCellTooltip.test.ts
@@ -83,9 +83,17 @@ describe('describeCalendarCell — band', () => {
     expect(after.band.label).toBe('After campaign end');
   });
 
-  it('prefers past over non-play, matching calendarCellState precedence', () => {
+  it('prefers past over non-play', () => {
     const m = describeCalendarCell({ ...base, isPast: true, isPlayDay: false });
     expect(m.band.tone).toBe('past');
+  });
+
+  it('calls a past date past, even though it is also before the clamped window', () => {
+    // getSchedulingWindow clamps windowStart to today, so every past date is
+    // also out-of-range. Saying "Before campaign start" about last week is wrong.
+    const m = describeCalendarCell({ ...base, isPast: true, isOutOfRange: true, date: '2026-07-01' });
+    expect(m.band).toMatchObject({ label: 'Past date', tone: 'past' });
+    expect(m.rows.some((r) => r.label.startsWith('Campaign'))).toBe(false);
   });
 });
 

--- a/src/lib/calendarCellTooltip.test.ts
+++ b/src/lib/calendarCellTooltip.test.ts
@@ -212,7 +212,7 @@ describe('tooltipModelToText', () => {
       isConfirmed: true,
       session: { date: '2026-09-04', start_time: '19:00', end_time: '23:00' } as never,
     }));
-    expect(text).toContain('Scheduled');
+    expect(text).toContain('Session confirmed');
     expect(text).toContain('7pm');
     expect(text).toContain('11pm');
     expect(text).toContain('Your status: Maybe');

--- a/src/lib/calendarCellTooltip.ts
+++ b/src/lib/calendarCellTooltip.ts
@@ -78,21 +78,26 @@ function timeQualifier(entry: AvailabilityEntry | undefined, use24h: boolean): s
 }
 
 function resolveBand(i: TooltipInputs): TooltipModel['band'] {
-  // Precedence matches calendarCellState()'s dataStatus ladder.
-  if (i.isOutOfRange) {
-    const beforeStart = isBefore(parseISO(i.date), i.windowStart);
-    return {
-      label: beforeStart ? 'Before campaign start' : 'After campaign end',
-      qualifier: null,
-      tone: 'out-of-range',
-    };
-  }
+  // isPast is checked before isOutOfRange, which inverts calendarCellState's
+  // ladder deliberately. getSchedulingWindow clamps windowStart to >= today,
+  // so every past date is also "before the window" — checking out-of-range
+  // first would make a past date claim "Before campaign start", which is
+  // false about last Thursday. "Before campaign start" is only ever true of a
+  // future date waiting on a campaign that hasn't begun.
   if (i.isPast) {
     const answered = i.status ? STATUS_LABEL[i.status] : null;
     return {
       label: answered ? `Past · you were ${answered}` : 'Past date',
       qualifier: null,
       tone: 'past',
+    };
+  }
+  if (i.isOutOfRange) {
+    const beforeStart = isBefore(parseISO(i.date), i.windowStart);
+    return {
+      label: beforeStart ? 'Before campaign start' : 'After campaign end',
+      qualifier: null,
+      tone: 'out-of-range',
     };
   }
   if (!i.isPlayDay) {
@@ -119,7 +124,9 @@ function buildRows(i: TooltipInputs): TooltipRow[] {
   }
 
   // Only the bound that was actually crossed — naming both is noise.
-  if (i.isOutOfRange) {
+  // Past dates are out-of-range by construction (windowStart is clamped to
+  // today), so gate on !isPast or every past cell gains a bogus campaign row.
+  if (i.isOutOfRange && !i.isPast) {
     rows.push(
       isBefore(parseISO(i.date), i.windowStart)
         ? { label: 'Campaign starts', value: format(i.windowStart, 'MMM d') }

--- a/src/lib/calendarCellTooltip.ts
+++ b/src/lib/calendarCellTooltip.ts
@@ -168,7 +168,11 @@ export function tooltipModelToText(model: TooltipModel): string {
 
   if (model.isScheduled) {
     const session = model.rows.find((r) => r.label === 'Session');
-    lines.push(session ? `Scheduled: ${session.value}` : 'Scheduled');
+    // Deliberately NOT the word "Scheduled": this string becomes the day cell's
+    // accessible name, and ~94 E2E assertions use getByRole('button', { name:
+    // /schedule/i }), which substring-matches. "Scheduled" would make every
+    // confirmed cell collide with the Schedule tab button.
+    lines.push(session ? `Session confirmed: ${session.value}` : 'Session confirmed');
   }
 
   const { label, qualifier, tone } = model.band;

--- a/src/lib/calendarCellTooltip.ts
+++ b/src/lib/calendarCellTooltip.ts
@@ -1,0 +1,142 @@
+import { format, isBefore, parseISO } from 'date-fns';
+import type { AvailabilityStatus, GameSession } from '@/types';
+import type { AvailabilityEntry } from '@/lib/availability';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { formatSessionTimeWindow, type OtherGameSessionInfo } from '@/lib/schedule';
+import { formatTimeShort } from '@/lib/formatting';
+import type { CalendarCellInputs } from './calendarCellState';
+
+// One day cell's tooltip, derived once and rendered twice: visually by
+// DayTooltip, and as text for the cell's aria-label. Deriving both from a
+// single model is the point — the same reason calendarStyles.ts exports
+// CELL_STYLES and LEGEND from shared constants.
+
+export const STATUS_LABEL: Record<AvailabilityStatus, string> = {
+  available: 'Available',
+  maybe: 'Maybe',
+  unavailable: 'Unavailable',
+};
+
+export interface TooltipInputs extends CalendarCellInputs {
+  /** `yyyy-MM-dd`. */
+  date: string;
+  /**
+   * The current user's row for this date, if any. `status` (inherited from
+   * CalendarCellInputs, where calendarCellState() also consumes it) must be
+   * `entry?.status` — they are one fact carried in two places.
+   */
+  entry: AvailabilityEntry | undefined;
+  session: GameSession | undefined;
+  gmNote: string | undefined;
+  otherSessions: OtherGameSessionInfo[];
+  isExtraDate: boolean;
+  isGmOrCoGm: boolean;
+  /** Admin peek view: nothing here is clickable, so no hints. */
+  readOnly: boolean;
+  canAddAsExtra: boolean;
+  windowStart: Date;
+  windowEnd: Date;
+  use24h: boolean;
+}
+
+export type BandTone =
+  | 'available' | 'maybe' | 'unavailable' | 'unset'
+  | 'non-play' | 'past' | 'out-of-range';
+
+export interface TooltipRow {
+  label: string;
+  value: string;
+}
+
+export interface TooltipModel {
+  dateLabel: string;
+  badges: string[];
+  isScheduled: boolean;
+  band: { label: string; qualifier: string | null; tone: BandTone };
+  rows: TooltipRow[];
+  hints: string[];
+}
+
+/** Tones where the band states an answer the user gave (or didn't). */
+const ANSWER_TONES: ReadonlySet<BandTone> = new Set<BandTone>([
+  'available', 'maybe', 'unavailable', 'unset',
+]);
+
+/**
+ * A time window qualifies "Available"/"Maybe" only. The data round-trips
+ * through an unavailable toggle so it isn't lost, but the note editor hides
+ * the time fields for unavailable — surfacing it would advertise a value the
+ * user can't reach. Mirrors MonthCalendar's showTimeConstraint rule.
+ */
+function timeQualifier(entry: AvailabilityEntry | undefined, use24h: boolean): string | null {
+  if (!entry || (entry.status !== 'available' && entry.status !== 'maybe')) return null;
+  const after = formatTimeShort(entry.available_after, use24h);
+  const until = formatTimeShort(entry.available_until, use24h);
+  if (after && until) return `${after}–${until}`;
+  if (after) return `after ${after}`;
+  if (until) return `until ${until}`;
+  return null;
+}
+
+function resolveBand(i: TooltipInputs): TooltipModel['band'] {
+  // Precedence matches calendarCellState()'s dataStatus ladder.
+  if (i.isOutOfRange) {
+    const beforeStart = isBefore(parseISO(i.date), i.windowStart);
+    return {
+      label: beforeStart ? 'Before campaign start' : 'After campaign end',
+      qualifier: null,
+      tone: 'out-of-range',
+    };
+  }
+  if (i.isPast) {
+    const answered = i.status ? STATUS_LABEL[i.status] : null;
+    return {
+      label: answered ? `Past · you were ${answered}` : 'Past date',
+      qualifier: null,
+      tone: 'past',
+    };
+  }
+  if (!i.isPlayDay) {
+    return { label: 'Not a play day', qualifier: null, tone: 'non-play' };
+  }
+  const qualifier = timeQualifier(i.entry, i.use24h);
+  if (!i.status) return { label: 'Not set', qualifier, tone: 'unset' };
+  return { label: STATUS_LABEL[i.status], qualifier, tone: i.status };
+}
+
+export function describeCalendarCell(i: TooltipInputs): TooltipModel {
+  const badges: string[] = [];
+  if (i.isConfirmed) badges.push('Scheduled');
+  if (i.isExtraDate && !i.isPast) badges.push('Extra date');
+  if (i.isToday) badges.push('Today');
+
+  return {
+    dateLabel: format(parseISO(i.date), 'EEEE, MMM d'),
+    badges,
+    isScheduled: i.isConfirmed,
+    band: resolveBand(i),
+    rows: [],
+    hints: [],
+  };
+}
+
+export function tooltipModelToText(model: TooltipModel): string {
+  const lines = [model.dateLabel];
+
+  if (model.isScheduled) {
+    const session = model.rows.find((r) => r.label === 'Session');
+    lines.push(session ? `Scheduled: ${session.value}` : 'Scheduled');
+  }
+
+  const { label, qualifier, tone } = model.band;
+  const stated = qualifier ? `${label} ${qualifier}` : label;
+  lines.push(ANSWER_TONES.has(tone) ? `Your status: ${stated}` : stated);
+
+  for (const row of model.rows) {
+    if (row.label === 'Session') continue;
+    // "GM note:" verbatim — several E2E assertions match that exact prefix.
+    lines.push(row.label === 'GM' ? `GM note: ${row.value}` : `${row.label}: ${row.value}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/lib/calendarCellTooltip.ts
+++ b/src/lib/calendarCellTooltip.ts
@@ -144,6 +144,10 @@ function buildHints(i: TooltipInputs): string[] {
   const hints: string[] = [];
   if (i.isPlayDay) {
     hints.push(`Click to mark ${STATUS_LABEL[getNextStatus(i.entry)]}`);
+    // The pencil is a click target inside the cell button, so it can't be a
+    // real <button> and its aria-label isn't exposed on a generic span.
+    // The hint is the only place this affordance is named.
+    hints.push(i.entry?.comment ? 'Click the note icon to edit your note' : 'Click the note icon to add a note or time window');
   }
   if (i.isGmOrCoGm && i.canAddAsExtra) {
     hints.push('GM · click + to add as an extra date');

--- a/src/lib/calendarCellTooltip.ts
+++ b/src/lib/calendarCellTooltip.ts
@@ -1,7 +1,6 @@
 import { format, isBefore, parseISO } from 'date-fns';
 import type { AvailabilityStatus, GameSession } from '@/types';
-import type { AvailabilityEntry } from '@/lib/availability';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { getNextStatus, type AvailabilityEntry } from '@/lib/availability';
 import { formatSessionTimeWindow, type OtherGameSessionInfo } from '@/lib/schedule';
 import { formatTimeShort } from '@/lib/formatting';
 import type { CalendarCellInputs } from './calendarCellState';
@@ -104,6 +103,50 @@ function resolveBand(i: TooltipInputs): TooltipModel['band'] {
   return { label: STATUS_LABEL[i.status], qualifier, tone: i.status };
 }
 
+function buildRows(i: TooltipInputs): TooltipRow[] {
+  const rows: TooltipRow[] = [];
+
+  if (i.isConfirmed && i.session) {
+    const when = formatSessionTimeWindow(i.session.start_time, i.session.end_time, i.use24h);
+    rows.push({ label: 'Session', value: when || 'Time TBD' });
+  }
+  if (i.entry?.comment) rows.push({ label: 'Note', value: i.entry.comment });
+  if (i.gmNote) rows.push({ label: 'GM', value: i.gmNote });
+
+  for (const other of i.otherSessions) {
+    const when = formatSessionTimeWindow(other.startTime, other.endTime, i.use24h);
+    rows.push({ label: 'Also', value: when ? `${other.gameName}, ${when}` : other.gameName });
+  }
+
+  // Only the bound that was actually crossed — naming both is noise.
+  if (i.isOutOfRange) {
+    rows.push(
+      isBefore(parseISO(i.date), i.windowStart)
+        ? { label: 'Campaign starts', value: format(i.windowStart, 'MMM d') }
+        : { label: 'Campaign ends', value: format(i.windowEnd, 'MMM d') },
+    );
+  }
+
+  return rows;
+}
+
+function buildHints(i: TooltipInputs): string[] {
+  // Nothing here responds to a click, so promising one would be a lie.
+  if (i.readOnly || i.isPast || i.isOutOfRange) return [];
+
+  const hints: string[] = [];
+  if (i.isPlayDay) {
+    hints.push(`Click to mark ${STATUS_LABEL[getNextStatus(i.entry)]}`);
+  }
+  if (i.isGmOrCoGm && i.canAddAsExtra) {
+    hints.push('GM · click + to add as an extra date');
+  }
+  if (i.isGmOrCoGm && i.isExtraDate) {
+    hints.push('GM · click ✕ to remove this extra date');
+  }
+  return hints;
+}
+
 export function describeCalendarCell(i: TooltipInputs): TooltipModel {
   const badges: string[] = [];
   if (i.isConfirmed) badges.push('Scheduled');
@@ -115,8 +158,8 @@ export function describeCalendarCell(i: TooltipInputs): TooltipModel {
     badges,
     isScheduled: i.isConfirmed,
     band: resolveBand(i),
-    rows: [],
-    hints: [],
+    rows: buildRows(i),
+    hints: buildHints(i),
   };
 }
 


### PR DESCRIPTION
The availability calendar's day cells used a native `title` tooltip that never showed your own availability status — the fact most worth restating while the new colour encoding from #145 is still unfamiliar — so this replaces it with a styled hover popover whose dominant element is a colour band reusing the cell's own fill, matching the schedule tab's visual language.

A single pure `describeCalendarCell()` produces the model rendered three ways — the popover, each cell's `aria-label`, and the touch toast — so they cannot drift, and day cells move from native `disabled` to `aria-disabled` + `tabIndex={-1}` so past, non-play and out-of-range days become hoverable and can finally explain why they're inert.

This also fixes a real bug found while writing the E2E coverage: `getSchedulingWindow` clamps `windowStart` to today, so every past date is also out-of-range and a past cell was claiming "Before campaign start" — `resolveBand` now checks `isPast` first.

Supporting changes: a shared `useHoverPopover` hook (positioning mechanics extracted from the schedule tab's existing popover, now used by both, with horizontal viewport clamping added), the widened touch toast for cells a tap can't act on, and the E2E migration off `title` across three distinct locator-coupling classes.

Verification: full Playwright suite 324/324, 771 unit tests, lint/typecheck/build clean; the last commit also documents the app's scheduling model and calendar palette in CLAUDE.md.