### PR TITLE
Fix trapped sidebar calendar scrolling and add a back-to-top button

### DIFF
--- a/e2e/tests/games/scroll-to-top.spec.ts
+++ b/e2e/tests/games/scroll-to-top.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { loginTestUser, createTestUser } from '../../helpers/test-auth';
+import { createTestGame } from '../../helpers/seed';
+import { TEST_TIMEOUTS } from '../../constants';
+
+test.describe('Back to top', () => {
+  test('appears deep in a long page and returns to the top', async ({ page, request }) => {
+    await page.setViewportSize({ width: 380, height: 800 });
+
+    const gm = await createTestUser(request, {
+      email: `gm-scrolltop-${Date.now()}@e2e.local`,
+      name: 'Scroll Top GM',
+      is_gm: true,
+    });
+
+    // 12 months is the longest window the app offers, and AvailabilityCalendar
+    // renders every month of it uncapped — so this page is reliably far taller
+    // than the two-viewport threshold.
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Scroll Top Campaign',
+      play_days: [5, 6],
+      scheduling_window_months: 12,
+    });
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.getByRole('button', { name: /availability/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /availability/i }).click();
+    await expect(page.locator('[data-testid="availability-tab-content"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    const backToTop = page.getByRole('button', { name: 'Back to top' });
+
+    // Precondition: without a genuinely tall page the rest of this passes vacuously.
+    const tallEnough = await page.evaluate(
+      () => document.documentElement.scrollHeight > 3 * window.innerHeight
+    );
+    expect(tallEnough).toBe(true);
+
+    await expect(backToTop).toBeHidden();
+
+    await page.evaluate(() => window.scrollTo(0, 3 * window.innerHeight));
+    await expect(backToTop).toBeVisible();
+
+    await backToTop.click();
+
+    // Smooth scrolling animates, so poll rather than reading once.
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+    await expect(backToTop).toBeHidden();
+  });
+});

--- a/e2e/tests/games/scroll-to-top.spec.ts
+++ b/e2e/tests/games/scroll-to-top.spec.ts
@@ -37,15 +37,19 @@ test.describe('Back to top', () => {
     const backToTop = page.getByRole('button', { name: 'Back to top' });
 
     // Precondition: without a genuinely tall page the rest of this passes vacuously.
-    const tallEnough = await page.evaluate(
-      () => document.documentElement.scrollHeight > 3 * window.innerHeight
-    );
-    expect(tallEnough).toBe(true);
+    // Polled rather than read once — 13 full-size calendar months are still
+    // painting immediately after the visibility wait above.
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.documentElement.scrollHeight > 3 * window.innerHeight)
+      )
+      .toBe(true);
 
     await expect(backToTop).toBeHidden();
 
     await page.evaluate(() => window.scrollTo(0, 3 * window.innerHeight));
     await expect(backToTop).toBeVisible();
+    await expect(backToTop).toHaveAttribute('data-testid', 'scroll-to-top');
 
     await backToTop.click();
 

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -364,4 +364,67 @@ test.describe('Schedule Tab Redesign', () => {
       .filter({ visible: true });
     await expect(cell).toHaveAttribute('data-state', 'unknown');
   });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 6: long scheduling windows page three months at a time
+  // ────────────────────────────────────────────────────────────────────────────
+  test('long scheduling windows page the calendar three months at a time', async ({
+    page,
+    request,
+  }) => {
+    const gm = await createTestUser(request, {
+      email: `gm-redesign-pager-${Date.now()}@e2e.local`,
+      name: 'Redesign Pager GM',
+      is_gm: true,
+    });
+
+    // 12 months is the longest window the app offers; it spans 13 calendar
+    // months, which is what used to overflow the sticky sidebar.
+    const game = await createTestGame({
+      gm_id: gm.id,
+      name: 'Redesign Pager Campaign',
+      play_days: [5, 6],
+      scheduling_window_months: 12,
+    });
+
+    const playDates = getPlayDates([5, 6], 4);
+    await setAvailability(gm.id, game.id, [{ date: playDates[0], is_available: true }]);
+
+    await loginTestUser(page, { email: gm.email, name: gm.name, is_gm: true });
+    await page.goto(`/games/${game.id}`);
+
+    await expect(page.getByRole('button', { name: /schedule/i })).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+    await page.getByRole('button', { name: /schedule/i }).click();
+
+    await expect(page.locator('[data-testid="schedule-tab-content"]')).toBeVisible({
+      timeout: TEST_TIMEOUTS.LONG,
+    });
+
+    // The sidebar renders once, so a 13-month window shows exactly one page.
+    const months = page.locator('[data-testid="calendar-month"]');
+    await expect(months).toHaveCount(3);
+
+    const firstPage = await months.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('data-month'))
+    );
+
+    await page.getByRole('button', { name: 'Show later months' }).click();
+
+    await expect(months).toHaveCount(3);
+    const secondPage = await months.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('data-month'))
+    );
+
+    // A full-page step: no month carries over from the previous page.
+    expect(secondPage.filter((m) => firstPage.includes(m))).toEqual([]);
+
+    // And stepping back returns to exactly where we started.
+    await page.getByRole('button', { name: 'Show earlier months' }).click();
+    const backAgain = await months.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('data-month'))
+    );
+    expect(backAgain).toEqual(firstPage);
+  });
 });

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -240,7 +240,7 @@ test.describe('Schedule Tab Redesign', () => {
     });
 
     // Calendar + response panels are visible inline — no tap-to-expand gate.
-    const panels = page.locator('[data-testid="mobile-sidebar-panels"]');
+    const panels = page.locator('[data-testid="sidebar-panels"]');
     await expect(panels).toBeVisible();
 
     // Subscribe is a discoverable webcal:// link, no expansion needed.

--- a/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
+++ b/e2e/tests/scheduling/schedule-tab-redesign.spec.ts
@@ -121,9 +121,9 @@ test.describe('Schedule Tab Redesign', () => {
     const rowDate = await firstRow.getAttribute('data-date');
     expect(rowDate).toBeTruthy();
 
-    // Find the matching calendar cell by data-date. Both mobile <details> and
-    // desktop <aside> render a MiniCalendar, so the selector resolves to two
-    // cells; filter to the visible one for the current viewport.
+    // Find the matching calendar cell by data-date. The sidebar renders once,
+    // so this resolves to a single cell; filter({ visible: true }) is kept as
+    // belt-and-braces.
     const matchingCell = page
       .locator(`[data-testid="calendar-cell"][data-date="${rowDate}"]`)
       .filter({ visible: true });
@@ -366,7 +366,7 @@ test.describe('Schedule Tab Redesign', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────────
-  // Test 6: long scheduling windows page three months at a time
+  // Test 7: long scheduling windows page three months at a time
   // ────────────────────────────────────────────────────────────────────────────
   test('long scheduling windows page the calendar three months at a time', async ({
     page,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { Geist, Geist_Mono } from 'next/font/google';
-import { Providers, Navbar, StatusBanner } from '@/components/layout';
+import { Providers, Navbar, ScrollToTopButton, StatusBanner } from '@/components/layout';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import './globals.css';
@@ -72,6 +72,7 @@ export default function RootLayout({
           <Navbar />
           <StatusBanner />
           <main>{children}</main>
+          <ScrollToTopButton />
         </Providers>
         <Analytics />
         <SpeedInsights />

--- a/src/components/games/schedule/CalendarMonth.tsx
+++ b/src/components/games/schedule/CalendarMonth.tsx
@@ -42,7 +42,11 @@ export function CalendarMonth({
       : ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
   return (
-    <div className="rounded-md bg-background/40 p-2">
+    <div
+      className="rounded-md bg-background/40 p-2"
+      data-testid="calendar-month"
+      data-month={format(first, 'yyyy-MM')}
+    >
       <p className="mb-1 text-xs font-semibold text-card-foreground">{format(first, 'MMMM yyyy')}</p>
       <div className="grid grid-cols-7 gap-0.75 mb-1">
         {dowLabels.map((d, i) => (

--- a/src/components/games/schedule/MiniCalendar.test.tsx
+++ b/src/components/games/schedule/MiniCalendar.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MiniCalendar } from './MiniCalendar';
+
+// A 12-month game setting spans 13 calendar months (the window ends on the last
+// day of the month 12 months out), which is the longest window the app allows.
+const LONG_START = new Date(2026, 0, 15); // 15 Jan 2026
+const LONG_END = new Date(2027, 0, 31); // 31 Jan 2027 -> Jan 2026 .. Jan 2027
+const SHORT_START = new Date(2026, 0, 1);
+const SHORT_END = new Date(2026, 2, 31); // exactly 3 months
+
+const renderCalendar = (windowStart: Date, windowEnd: Date) =>
+  render(
+    <MiniCalendar
+      windowStart={windowStart}
+      windowEnd={windowEnd}
+      suggestions={[]}
+      sessions={[]}
+      playDayWeekdays={new Set([5, 6])}
+      specialPlayDates={new Set()}
+      weekStartDay={0}
+      onCellActivate={() => {}}
+    />
+  );
+
+const visibleMonths = () =>
+  screen.getAllByTestId('calendar-month').map((el) => el.getAttribute('data-month'));
+
+const laterButton = () => screen.getByRole('button', { name: 'Show later months' });
+const earlierButton = () => screen.getByRole('button', { name: 'Show earlier months' });
+
+describe('MiniCalendar month paging', () => {
+  it('shows only the first three months of a long window', () => {
+    renderCalendar(LONG_START, LONG_END);
+    expect(visibleMonths()).toEqual(['2026-01', '2026-02', '2026-03']);
+  });
+
+  it('hides the pager when the whole window fits on one page', () => {
+    renderCalendar(SHORT_START, SHORT_END);
+    expect(visibleMonths()).toEqual(['2026-01', '2026-02', '2026-03']);
+    expect(
+      screen.queryByRole('button', { name: 'Show earlier months' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Show later months' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('advances a full page of three months at a time', async () => {
+    const user = userEvent.setup();
+    renderCalendar(LONG_START, LONG_END);
+
+    await user.click(laterButton());
+    expect(visibleMonths()).toEqual(['2026-04', '2026-05', '2026-06']);
+
+    await user.click(laterButton());
+    expect(visibleMonths()).toEqual(['2026-07', '2026-08', '2026-09']);
+  });
+
+  it('steps back a full page of three months', async () => {
+    const user = userEvent.setup();
+    renderCalendar(LONG_START, LONG_END);
+
+    await user.click(laterButton());
+    await user.click(laterButton());
+    expect(visibleMonths()).toEqual(['2026-07', '2026-08', '2026-09']);
+
+    await user.click(earlierButton());
+    expect(visibleMonths()).toEqual(['2026-04', '2026-05', '2026-06']);
+  });
+
+  it('clamps the final page to the window end rather than showing a short page', async () => {
+    const user = userEvent.setup();
+    renderCalendar(LONG_START, LONG_END);
+
+    await user.click(laterButton()); // Apr-Jun
+    await user.click(laterButton()); // Jul-Sep
+    await user.click(laterButton()); // Oct-Dec
+    expect(visibleMonths()).toEqual(['2026-10', '2026-11', '2026-12']);
+
+    // The 13th month would otherwise sit alone on a page of its own; instead the
+    // cursor stops at the last full page, so this step advances by one month.
+    await user.click(laterButton());
+    expect(visibleMonths()).toEqual(['2026-11', '2026-12', '2027-01']);
+  });
+
+  it('disables each arrow at its bound', async () => {
+    const user = userEvent.setup();
+    renderCalendar(LONG_START, LONG_END);
+
+    expect(earlierButton()).toBeDisabled();
+    expect(laterButton()).toBeEnabled();
+
+    for (let i = 0; i < 4; i += 1) {
+      await user.click(laterButton());
+    }
+
+    expect(visibleMonths()).toEqual(['2026-11', '2026-12', '2027-01']);
+    expect(laterButton()).toBeDisabled();
+    expect(earlierButton()).toBeEnabled();
+  });
+});

--- a/src/components/games/schedule/MiniCalendar.test.tsx
+++ b/src/components/games/schedule/MiniCalendar.test.tsx
@@ -83,6 +83,12 @@ describe('MiniCalendar month paging', () => {
     // cursor stops at the last full page, so this step advances by one month.
     await user.click(laterButton());
     expect(visibleMonths()).toEqual(['2026-11', '2026-12', '2027-01']);
+
+    // Stepping back from the clamped page is deliberately asymmetric: the
+    // clamp only shifted the cursor forward by one month (not a full page),
+    // so a full page-back lands one month earlier than the page we came from.
+    await user.click(earlierButton());
+    expect(visibleMonths()).toEqual(['2026-08', '2026-09', '2026-10']);
   });
 
   it('disables each arrow at its bound', async () => {

--- a/src/components/games/schedule/MiniCalendar.tsx
+++ b/src/components/games/schedule/MiniCalendar.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { addMonths, startOfMonth, differenceInCalendarMonths, startOfDay } from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { DateSuggestion, GameSession } from '@/types';
 import { CalendarMonth } from './CalendarMonth';
 import { EyebrowLabel, Panel } from '@/components/ui';
 import { resolveDateState, showsPendingMark, describeDateState, type DateState } from '@/lib/schedule';
 import { SCHEDULED_STAR_PATH } from '@/lib/constants';
 import { LEGEND } from './calendarStyles';
+
+/**
+ * Months shown at once. The panel lives in a 340px sticky sidebar, so rendering
+ * a full 13-month window made it taller than the viewport — and a sticky element
+ * taller than the viewport hides its own overflow until the page bottom.
+ */
+const MONTHS_PER_PAGE = 3;
 
 interface MiniCalendarProps {
   windowStart: Date;
@@ -39,6 +47,17 @@ export function MiniCalendar({
     );
   }, [windowStart, windowEnd]);
 
+  const [pageStart, setPageStart] = useState(0);
+
+  const maxStart = Math.max(0, months.length - MONTHS_PER_PAGE);
+  // Derived, not stored. The window shrinks on its own as time passes
+  // (windowStart is max(campaign_start, today)) and when a GM edits
+  // campaign_end_date, so a stored cursor would need an effect to re-clamp it
+  // and would render one wrong frame first.
+  const safeStart = Math.min(pageStart, maxStart);
+  const visibleMonths = months.slice(safeStart, safeStart + MONTHS_PER_PAGE);
+  const showPager = months.length > MONTHS_PER_PAGE;
+
   const suggestionsByDate = useMemo(() => {
     const m = new Map<string, { state: DateState; showPending: boolean; title: string }>();
     suggestions.forEach((s) => {
@@ -62,12 +81,38 @@ export function MiniCalendar({
   const body = (
     <>
       <div className="flex items-center justify-between mb-3">
-        <EyebrowLabel>Calendar</EyebrowLabel>
+        <div className="flex items-center gap-2">
+          <EyebrowLabel>Calendar</EyebrowLabel>
+          {showPager && (
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                data-testid="mini-calendar-prev"
+                aria-label="Show earlier months"
+                disabled={safeStart === 0}
+                onClick={() => setPageStart(Math.max(0, safeStart - MONTHS_PER_PAGE))}
+                className="inline-flex size-6 items-center justify-center rounded-sm border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              >
+                <ChevronLeft className="size-3.5" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                data-testid="mini-calendar-next"
+                aria-label="Show later months"
+                disabled={safeStart >= maxStart}
+                onClick={() => setPageStart(Math.min(maxStart, safeStart + MONTHS_PER_PAGE))}
+                className="inline-flex size-6 items-center justify-center rounded-sm border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              >
+                <ChevronRight className="size-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          )}
+        </div>
         {subscribeLink}
       </div>
       <div className="@container">
         <div className="grid grid-cols-1 @lg:grid-cols-2 gap-2">
-          {months.map((m) => (
+          {visibleMonths.map((m) => (
             <CalendarMonth
               key={m.toISOString()}
               monthStart={m}

--- a/src/components/games/schedule/ScheduleTabContent.tsx
+++ b/src/components/games/schedule/ScheduleTabContent.tsx
@@ -88,6 +88,10 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
     [suggestions, scheduledDates]
   );
 
+  // ScheduledList renders null with no confirmed sessions, so its grid cell has
+  // to disappear too — otherwise desktop column 1 opens with an empty gap row.
+  const hasScheduled = scheduledDates.size > 0;
+
   const playDayWeekdays = useMemo(() => new Set(playDays), [playDays]);
 
   const handleCellActivate = (date: string) => {
@@ -198,32 +202,60 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
           candidateCount={unscheduledSuggestions.length}
         />
 
-        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_340px]">
-          <div className="space-y-5 min-w-0">
-            <ScheduledList
-              sessions={sessions}
-              suggestions={suggestions}
-              timezone={timezone}
-              userTimezone={userTimezone ?? null}
-              use24h={use24h}
-              isGm={isGm}
-              gmId={gmId}
-              coGmIds={coGmIds}
-              playDateNotes={playDateNotes}
-              celebrateDate={celebrateDate}
-              onCelebrationDone={() => setCelebrateDate(null)}
-              onDownloadIcs={handleDownloadIcs}
-              onDownloadAllIcs={handleDownloadAllIcs}
-              onRequestCancel={(s) => setCancelFor(s)}
-              onEditDetails={(s) => setEditFor(s)}
-            />
-
-            {/* Mobile: calendar + response status, visible above the long ranked list */}
-            <div className="space-y-5 lg:hidden" data-testid="mobile-sidebar-panels">
-              {calendarPanel}
-              {responsePanel}
+        {/*
+          Flat grid so the sidebar renders ONCE and is repositioned per
+          breakpoint, rather than being rendered twice behind lg:hidden.
+          Mobile (1 column): scheduled -> calendar + response -> ranked list, so
+          the calendar sits above the long ranked list.
+          Desktop (2 columns): scheduled + ranked stack in column 1; the sidebar
+          is sticky in column 2 and scrolls independently. Duplicating it would
+          put two month-pagers in the DOM with cursors that desync on resize,
+          and duplicate DOM text breaks unscoped getByText() assertions.
+        */}
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
+          {hasScheduled && (
+            <div className="min-w-0 lg:col-start-1 lg:row-start-1">
+              <ScheduledList
+                sessions={sessions}
+                suggestions={suggestions}
+                timezone={timezone}
+                userTimezone={userTimezone ?? null}
+                use24h={use24h}
+                isGm={isGm}
+                gmId={gmId}
+                coGmIds={coGmIds}
+                playDateNotes={playDateNotes}
+                celebrateDate={celebrateDate}
+                onCelebrationDone={() => setCelebrateDate(null)}
+                onDownloadIcs={handleDownloadIcs}
+                onDownloadAllIcs={handleDownloadAllIcs}
+                onRequestCancel={(s) => setCancelFor(s)}
+                onEditDetails={(s) => setEditFor(s)}
+              />
             </div>
+          )}
 
+          {/*
+            top-20 is 5rem, so capping at 100vh-6rem leaves a 1rem gap below the
+            panel. The cap is what makes trapped content structurally impossible:
+            three months usually fits, but ResponseStatus renders a row per
+            player and games allow 50.
+          */}
+          <aside
+            data-testid="sidebar-panels"
+            className={`space-y-5 lg:col-start-2 lg:row-start-1 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto ${
+              hasScheduled ? 'lg:row-span-2' : ''
+            }`}
+          >
+            {calendarPanel}
+            {responsePanel}
+          </aside>
+
+          <div
+            className={`min-w-0 lg:col-start-1 ${
+              hasScheduled ? 'lg:row-start-2' : 'lg:row-start-1'
+            }`}
+          >
             <RankedList
               suggestions={unscheduledSuggestions}
               isGm={isGm}
@@ -236,12 +268,6 @@ export function ScheduleTabContent(props: ScheduleTabContentProps) {
               autoExpandDate={autoExpandDate}
             />
           </div>
-
-          {/* Desktop sidebar (unchanged behavior) */}
-          <aside className="hidden lg:block space-y-5 lg:sticky lg:top-20 lg:self-start">
-            {calendarPanel}
-            {responsePanel}
-          </aside>
         </div>
 
         {scheduleFor !== null && (

--- a/src/components/layout/ScrollToTopButton.test.tsx
+++ b/src/components/layout/ScrollToTopButton.test.tsx
@@ -39,20 +39,39 @@ function scrollTo(y: number) {
   window.requestAnimationFrame = realRaf;
 }
 
+// Same rAF-synchronising trick as scrollTo(), but for a 'resize' event: sets
+// window.innerHeight then dispatches 'resize' so the component's throttled
+// handler runs synchronously inside the act() block.
+function resizeTo(height: number) {
+  Object.defineProperty(window, 'innerHeight', { value: height, configurable: true });
+  const realRaf = window.requestAnimationFrame;
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return ++rafHandle;
+  }) as typeof window.requestAnimationFrame;
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+  window.requestAnimationFrame = realRaf;
+}
+
 const button = () => screen.queryByRole('button', { name: 'Back to top' });
 
 describe('ScrollToTopButton', () => {
   let realScrollTo: typeof window.scrollTo;
+  let realInnerHeight: number;
 
   beforeEach(() => {
     realScrollTo = window.scrollTo;
     window.scrollTo = vi.fn();
+    realInnerHeight = window.innerHeight;
     Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
     stubMatchMedia(false);
   });
 
   afterEach(() => {
     window.scrollTo = realScrollTo;
+    Object.defineProperty(window, 'innerHeight', { value: realInnerHeight, configurable: true });
     vi.restoreAllMocks();
   });
 
@@ -79,6 +98,20 @@ describe('ScrollToTopButton', () => {
     expect(button()).toBeInTheDocument();
 
     scrollTo(window.innerHeight);
+    expect(button()).not.toBeInTheDocument();
+  });
+
+  it('re-evaluates the threshold on resize without a new scroll event', () => {
+    Object.defineProperty(window, 'innerHeight', { value: 400, configurable: true });
+    render(<ScrollToTopButton />);
+    scrollTo(1000);
+    expect(button()).toBeInTheDocument();
+
+    // scrollY stays at 1000; only the viewport grows, so the threshold
+    // (2 * innerHeight) rises from 800 to 1800, putting the unchanged
+    // scroll position back under it. Without a 'resize' listener, no scroll
+    // event fires here and the button would incorrectly stay visible.
+    resizeTo(900);
     expect(button()).not.toBeInTheDocument();
   });
 

--- a/src/components/layout/ScrollToTopButton.test.tsx
+++ b/src/components/layout/ScrollToTopButton.test.tsx
@@ -101,6 +101,26 @@ describe('ScrollToTopButton', () => {
     expect(button()).not.toBeInTheDocument();
   });
 
+  it('stays mounted while hidden, so showing and hiding can be a transition', () => {
+    render(<ScrollToTopButton />);
+
+    // Present in the DOM (queried by testid, which ignores the a11y tree)...
+    const el = screen.getByTestId('scroll-to-top');
+    expect(el).toBeInTheDocument();
+
+    // ...but out of the accessibility tree and out of the tab order, which is
+    // what keeps the faded-out button from being reachable. `button()` above
+    // queries by role, so it is aria-hidden that makes every other test's
+    // "not in the document" assertion mean "not available to the user".
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+    expect(el).toHaveAttribute('tabindex', '-1');
+
+    scrollTo(3 * window.innerHeight);
+
+    expect(el).toHaveAttribute('aria-hidden', 'false');
+    expect(el).not.toHaveAttribute('tabindex');
+  });
+
   it('re-evaluates the threshold on resize without a new scroll event', () => {
     Object.defineProperty(window, 'innerHeight', { value: 400, configurable: true });
     render(<ScrollToTopButton />);

--- a/src/components/layout/ScrollToTopButton.test.tsx
+++ b/src/components/layout/ScrollToTopButton.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScrollToTopButton } from './ScrollToTopButton';
+
+// jsdom does not implement window.matchMedia; the component reads it on click
+// to honour prefers-reduced-motion.
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+// jsdom never actually scrolls, so set scrollY directly and fire the event the
+// component listens for. requestAnimationFrame is made synchronous for just
+// this dispatch so the state update settles inside the act() block — userEvent
+// keeps the real one for its own internal scheduling.
+function scrollTo(y: number) {
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true });
+  const realRaf = window.requestAnimationFrame;
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof window.requestAnimationFrame;
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
+  });
+  window.requestAnimationFrame = realRaf;
+}
+
+const button = () => screen.queryByRole('button', { name: 'Back to top' });
+
+describe('ScrollToTopButton', () => {
+  let realScrollTo: typeof window.scrollTo;
+
+  beforeEach(() => {
+    realScrollTo = window.scrollTo;
+    window.scrollTo = vi.fn();
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true });
+    stubMatchMedia(false);
+  });
+
+  afterEach(() => {
+    window.scrollTo = realScrollTo;
+    vi.restoreAllMocks();
+  });
+
+  it('is hidden at the top of the page', () => {
+    render(<ScrollToTopButton />);
+    expect(button()).not.toBeInTheDocument();
+  });
+
+  it('stays hidden at exactly two viewport heights', () => {
+    render(<ScrollToTopButton />);
+    scrollTo(2 * window.innerHeight);
+    expect(button()).not.toBeInTheDocument();
+  });
+
+  it('appears past two viewport heights', () => {
+    render(<ScrollToTopButton />);
+    scrollTo(2 * window.innerHeight + 1);
+    expect(button()).toBeInTheDocument();
+  });
+
+  it('hides again when scrolled back below the threshold', () => {
+    render(<ScrollToTopButton />);
+    scrollTo(3 * window.innerHeight);
+    expect(button()).toBeInTheDocument();
+
+    scrollTo(window.innerHeight);
+    expect(button()).not.toBeInTheDocument();
+  });
+
+  it('scrolls smoothly to the top when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ScrollToTopButton />);
+    scrollTo(3 * window.innerHeight);
+
+    await user.click(screen.getByRole('button', { name: 'Back to top' }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('jumps without animation when the user prefers reduced motion', async () => {
+    stubMatchMedia(true);
+    const user = userEvent.setup();
+    render(<ScrollToTopButton />);
+    scrollTo(3 * window.innerHeight);
+
+    await user.click(screen.getByRole('button', { name: 'Back to top' }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+  });
+
+  it('removes its scroll listener on unmount', () => {
+    const removeListener = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<ScrollToTopButton />);
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+});

--- a/src/components/layout/ScrollToTopButton.test.tsx
+++ b/src/components/layout/ScrollToTopButton.test.tsx
@@ -21,13 +21,17 @@ function stubMatchMedia(matches: boolean) {
 // jsdom never actually scrolls, so set scrollY directly and fire the event the
 // component listens for. requestAnimationFrame is made synchronous for just
 // this dispatch so the state update settles inside the act() block — userEvent
-// keeps the real one for its own internal scheduling.
+// keeps the real one for its own internal scheduling. The stub hands back an
+// incrementing nonzero id, like real browsers do (ids start at 1): a stub that
+// returned 0 would coincide with the guard's post-callback reset value and
+// mask a naive `if (frame === 0)` guard wedging on synchronous rAF.
+let rafHandle = 0;
 function scrollTo(y: number) {
   Object.defineProperty(window, 'scrollY', { value: y, configurable: true });
   const realRaf = window.requestAnimationFrame;
   window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
     cb(0);
-    return 0;
+    return ++rafHandle;
   }) as typeof window.requestAnimationFrame;
   act(() => {
     window.dispatchEvent(new Event('scroll'));

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -49,20 +49,32 @@ export function ScrollToTopButton() {
     };
   }, []);
 
-  if (!visible) return null;
-
   const handleClick = () => {
     const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
     window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
   };
 
   return (
+    // Always mounted so the show/hide can be a transition rather than a mount.
+    // `invisible` matters as much as `opacity-0`: opacity alone still counts as
+    // visible to Playwright (and to the tab order), so visibility is what
+    // actually takes the button out of play once it has faded.
+    //
+    // Inverted fill, deliberately: `bg-card`/`border-border` is the exact pair
+    // Panel and RankedRow use, so a card-coloured button is invisible against
+    // the surface it most often floats over. foreground/background is the
+    // contrast pole of the palette and so cannot collide with any surface in
+    // any theme, while still reading as chrome rather than as a page action.
     <button
       type="button"
       onClick={handleClick}
       aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? undefined : -1}
       data-testid="scroll-to-top"
-      className="fixed bottom-6 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-lg transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+      className={`fixed bottom-6 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full bg-foreground text-background shadow-lg motion-safe:transition-[opacity,visibility] motion-safe:duration-200 hover:bg-foreground/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background ${
+        visible ? 'visible opacity-100' : 'invisible opacity-0 pointer-events-none'
+      }`}
     >
       <ArrowUp className="size-5" aria-hidden="true" />
     </button>

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -62,9 +62,12 @@ export function ScrollToTopButton() {
     //
     // Inverted fill, deliberately: `bg-card`/`border-border` is the exact pair
     // Panel and RankedRow use, so a card-coloured button is invisible against
-    // the surface it most often floats over. foreground/background is the
-    // contrast pole of the palette and so cannot collide with any surface in
-    // any theme, while still reading as chrome rather than as a page action.
+    // the surface it most often floats over. Any `*-foreground` token is by
+    // definition picked to be legible against the surfaces, so it cannot
+    // collide with one in any theme. muted-foreground rather than foreground
+    // because foreground is the palette's extreme — near-white in dark mode,
+    // which reads as untinted; muted-foreground is the same idea a step in,
+    // carrying the theme's hue (sky, violet, green, slate, rose) instead.
     <button
       type="button"
       onClick={handleClick}
@@ -72,7 +75,7 @@ export function ScrollToTopButton() {
       aria-hidden={!visible}
       tabIndex={visible ? undefined : -1}
       data-testid="scroll-to-top"
-      className={`fixed bottom-6 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full bg-foreground text-background shadow-lg motion-safe:transition-[opacity,visibility] motion-safe:duration-200 hover:bg-foreground/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background ${
+      className={`fixed bottom-6 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full bg-muted-foreground text-background shadow-lg motion-safe:transition-[opacity,visibility] motion-safe:duration-300 hover:bg-muted-foreground/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background ${
         visible ? 'visible opacity-100' : 'invisible opacity-0 pointer-events-none'
       }`}
     >

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+
+/**
+ * Two full screens. The game page's ranked list starts roughly 1200-1400px down
+ * on a phone, so the button first appears just as you enter the list — the point
+ * where the trip back becomes annoying. Showing it early costs a small icon in a
+ * corner; showing it late means the user has already started flinging and never
+ * learns it exists.
+ */
+const VIEWPORTS_BEFORE_SHOWING = 2;
+
+export function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // innerHeight is read on every update rather than captured once, so
+    // orientation changes and window resizes need no separate listener.
+    let ticking = false;
+    let frame = 0;
+
+    const update = () => {
+      ticking = false;
+      setVisible(window.scrollY > VIEWPORTS_BEFORE_SHOWING * window.innerHeight);
+    };
+
+    // scroll fires far more often than we need to re-render, so coalesce to one
+    // update per frame. The guard is a separate boolean, not the frame handle:
+    // when requestAnimationFrame runs synchronously, update() would clear the
+    // handle before the assignment overwrote it, wedging the guard forever.
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      frame = window.requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const handleClick = () => {
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Back to top"
+      data-testid="scroll-to-top"
+      className="fixed bottom-6 right-4 z-40 inline-flex size-11 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-lg transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+    >
+      <ArrowUp className="size-5" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -16,8 +16,10 @@ export function ScrollToTopButton() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    // innerHeight is read on every update rather than captured once, so
-    // orientation changes and window resizes need no separate listener.
+    // innerHeight is read live inside update() rather than captured once, but
+    // that only matters on a resize if update() actually runs — and update()
+    // only runs off a scroll event. So orientation changes and window resizes
+    // are handled explicitly below, by listening for 'resize' too.
     let ticking = false;
     let frame = 0;
 
@@ -26,10 +28,11 @@ export function ScrollToTopButton() {
       setVisible(window.scrollY > VIEWPORTS_BEFORE_SHOWING * window.innerHeight);
     };
 
-    // scroll fires far more often than we need to re-render, so coalesce to one
-    // update per frame. The guard is a separate boolean, not the frame handle:
-    // when requestAnimationFrame runs synchronously, update() would clear the
-    // handle before the assignment overwrote it, wedging the guard forever.
+    // scroll (and resize) fire far more often than we need to re-render, so
+    // coalesce to one update per frame. The guard is a separate boolean, not
+    // the frame handle: when requestAnimationFrame runs synchronously,
+    // update() would clear the handle before the assignment overwrote it,
+    // wedging the guard forever.
     const onScroll = () => {
       if (ticking) return;
       ticking = true;
@@ -38,8 +41,10 @@ export function ScrollToTopButton() {
 
     update();
     window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
     return () => {
       window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
       if (frame) window.cancelAnimationFrame(frame);
     };
   }, []);

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { Navbar } from './Navbar';
 export { Providers } from './Providers';
+export { ScrollToTopButton } from './ScrollToTopButton';
 export { StatusBanner } from './StatusBanner';


### PR DESCRIPTION
Fixes #146.

The schedule tab's sidebar is `lg:sticky` and, for long scheduling windows, taller than the viewport — and a sticky element only unsticks once its containing block scrolls past, so months past the third (and the response-status panel below them) were unreachable until you scrolled to the very bottom of the page; the mini-calendar now pages three months at a time behind ‹/› arrows, and the sidebar renders **once** in a flat CSS grid with a desktop-only `max-h`/`overflow-y-auto` cap that makes trapped content structurally impossible rather than merely unlikely. Separately, a mobile user asked for a way back to the top — the navbar and the game page's tab bar are both non-sticky, so a deep-scrolled user has no navigation at all — which a new globally-mounted button addresses, fading in past two viewport heights and using a `*-foreground` token so it can't blend into the cards it floats over in any of the five themes.

Known trade-off: as a fixed bottom-right element the button can overlap content in that corner (e.g. the right edge of an expanded ranked row's action button), which scrolling slightly clears — filing that as expected rather than a regression.

Verified with `lint`, `typecheck`, `build`, 786 unit tests, and the full Playwright suite at 326/326.