### PR TITLE
Label game timezones in the admin upcoming table and fix the Today badge

### DIFF
--- a/e2e/tests/admin/upcoming-games.spec.ts
+++ b/e2e/tests/admin/upcoming-games.spec.ts
@@ -215,4 +215,103 @@ test.describe('Admin Upcoming Games tab', () => {
     await expect(rows).toHaveCount(20);
     await expect(previousButton).toBeDisabled();
   });
+
+  // Pinning the browser timezone makes the "for you" conversion deterministic:
+  // with no saved profile timezone the tab falls back to the browser's.
+  test.describe('across timezones', () => {
+    test.use({ timezoneId: 'America/Los_Angeles' });
+
+    test('orders by true instant and labels the timezone that explains the order', async ({
+      page,
+      request,
+    }) => {
+      const ts = Date.now();
+      const admin = await createTestUser(request, {
+        email: `admin-upcoming-tz-${ts}@e2e.local`,
+        name: 'Admin Upcoming TZ',
+        is_gm: false,
+        is_admin: true,
+      });
+      const gm = await createTestUser(request, {
+        email: `upcoming-tz-gm-${ts}@e2e.local`,
+        name: 'Upcoming TZ GM',
+        is_gm: true,
+        is_admin: false,
+      });
+
+      const tokyoGame = await createTestGame({
+        gm_id: gm.id,
+        name: `Upcoming TZ Tokyo ${ts}`,
+        play_days: [5, 6],
+        timezone: 'Asia/Tokyo',
+      });
+      const laGame = await createTestGame({
+        gm_id: gm.id,
+        name: `Upcoming TZ LA ${ts}`,
+        play_days: [5, 6],
+        timezone: 'America/Los_Angeles',
+      });
+
+      // The inversion this view has to survive: Tokyo's 08:30 on the LATER
+      // calendar date is 23:30 UTC on the earlier one, so it genuinely starts
+      // 90 minutes BEFORE the LA session dated a day before it.
+      const laMarker = `TzMarker-${ts}-LA`;
+      const tokyoMarker = `TzMarker-${ts}-TOKYO`;
+      await createTestSession({
+        game_id: laGame.id,
+        date: futureDate(4),
+        confirmed_by: gm.id,
+        start_time: '18:00',
+        end_time: '22:00',
+        location: laMarker,
+      });
+      await createTestSession({
+        game_id: tokyoGame.id,
+        date: futureDate(5),
+        confirmed_by: gm.id,
+        start_time: '08:30',
+        end_time: '11:30',
+        location: tokyoMarker,
+      });
+
+      await loginTestUser(page, {
+        email: admin.email,
+        name: admin.name,
+        is_gm: false,
+        is_admin: true,
+      });
+
+      await page.goto('/admin');
+      await page.getByRole('button', { name: 'Upcoming Games', exact: true }).click();
+
+      const rows = page.locator('table tbody tr');
+      await expect(rows.first()).toBeVisible({ timeout: TEST_TIMEOUTS.LONG });
+
+      // This route is system-wide, so our markers can land on any page.
+      const pagerText = await page.getByText(/page \d+ of \d+/i).innerText();
+      const totalPages = Number(pagerText.match(/page \d+ of (\d+)/i)![1]);
+      const nextButton = page.getByRole('button', { name: 'Next page of upcoming sessions' });
+      const allRowTexts: string[] = await rows.allTextContents();
+      for (let p = 2; p <= totalPages; p++) {
+        await nextButton.click();
+        await expect(page.getByText(new RegExp(`page ${p} of`, 'i'))).toBeVisible();
+        allRowTexts.push(...(await rows.allTextContents()));
+      }
+
+      const tokyoIndex = allRowTexts.findIndex((t) => t.includes(tokyoMarker));
+      const laIndex = allRowTexts.findIndex((t) => t.includes(laMarker));
+      expect(tokyoIndex).toBeGreaterThanOrEqual(0);
+      expect(laIndex).toBeGreaterThanOrEqual(0);
+      // Later calendar date, earlier instant, so it sorts first.
+      expect(tokyoIndex).toBeLessThan(laIndex);
+
+      // The label that keeps that from reading as a sorting bug.
+      expect(allRowTexts[tokyoIndex]).toContain('8:30am–11:30am');
+      expect(allRowTexts[tokyoIndex]).toContain('GMT+9');
+      expect(allRowTexts[tokyoIndex]).toContain('for you');
+      // The viewer's own zone needs no label.
+      expect(allRowTexts[laIndex]).toContain('6pm–10pm');
+      expect(allRowTexts[laIndex]).not.toContain('for you');
+    });
+  });
 });

--- a/src/app/api/admin/upcoming-sessions/route.ts
+++ b/src/app/api/admin/upcoming-sessions/route.ts
@@ -3,9 +3,9 @@ import { requireAdmin, paginate } from '@/lib/api/admin';
 import {
   buildUpcomingSessionRows,
   getUpcomingQueryFloor,
+  resolveViewerToday,
   type GameDisplayInfo,
 } from '@/lib/schedule';
-import { getTodayLocalDate } from '@/lib/date';
 import { paginateArray } from '@/lib/pagination';
 import { serverError } from '@/lib/apiError';
 import type { GameSession, AdminUpcomingSessionRow } from '@/types';
@@ -30,7 +30,11 @@ export async function GET(request: NextRequest): Promise<Response> {
     const page = Number.isFinite(pageParam) && pageParam >= 1 ? Math.floor(pageParam) : 1;
 
     const nowMs = Date.now();
-    const today = getTodayLocalDate();
+    // The Today/Tomorrow badge is viewer-relative, so it has to come from the
+    // client's timezone. This route runs on a UTC server in production, and
+    // reading its own clock tagged tomorrow's session "Today" all evening for
+    // anyone west of UTC.
+    const today = resolveViewerToday(nowMs, request.nextUrl.searchParams.get('tz'));
     // Two-day buffer covers the full UTC-12..UTC+14 span; buildUpcomingSessionRows
     // then trims precisely against each game's own timezone (see DashboardContent).
     const floor = getUpcomingQueryFloor(nowMs);

--- a/src/components/admin/UpcomingGamesTab.tsx
+++ b/src/components/admin/UpcomingGamesTab.tsx
@@ -6,7 +6,8 @@ import { parseISO } from 'date-fns';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import { Button, Card, CardContent, CardHeader, EmptyState, LoadingSpinner } from '@/components/ui';
-import { formatTimeShort } from '@/lib/formatting';
+import { buildSessionTimeRange } from '@/lib/formatting';
+import { getBrowserTimezone } from '@/lib/timezone';
 import { queryKeys } from '@/lib/queryKeys';
 import type { AdminUpcomingSessionRow } from '@/types';
 import { AdminTable, AdminTh } from './AdminTable';
@@ -29,12 +30,17 @@ function formatUpcomingSessionDate(dateStr: string): string {
 }
 
 export function UpcomingGamesTab() {
-  const { use24h } = useUserPreferences();
+  const { use24h, timezone: profileTimezone } = useUserPreferences();
+  // The route needs the viewer's zone to date the Today/Tomorrow badge; it runs
+  // on a UTC server, so its own clock is not the admin's. Prefer the saved
+  // preference, fall back to whatever the browser reports.
+  const viewerTimezone = profileTimezone ?? getBrowserTimezone();
   const [page, setPage] = useState(1);
   const { data, isPending: loading, error } = useQuery({
-    queryKey: queryKeys.adminUpcomingSessions(page),
+    queryKey: queryKeys.adminUpcomingSessions(page, viewerTimezone),
     queryFn: async (): Promise<UpcomingSessionsResponse> => {
-      const url = `/api/admin/upcoming-sessions?page=${page}`;
+      const tzParam = viewerTimezone ? `&tz=${encodeURIComponent(viewerTimezone)}` : '';
+      const url = `/api/admin/upcoming-sessions?page=${page}${tzParam}`;
       const res = await fetch(url);
       if (!res.ok) throw new Error(`Failed to fetch ${url}`);
       return res.json();
@@ -89,7 +95,16 @@ export function UpcomingGamesTab() {
             </tr>
           </thead>
           <tbody>
-            {data.sessions.map((row) => (
+            {data.sessions.map((row) => {
+              const timeRange = buildSessionTimeRange(
+                row.session.date,
+                row.session.start_time,
+                row.session.end_time,
+                row.gameTimezone,
+                viewerTimezone,
+                use24h
+              );
+              return (
               <tr key={row.session.id} className="border-b border-border/50 hover:bg-muted/50">
                 <td className="py-3 px-2 text-foreground whitespace-nowrap">
                   <div className="flex items-center gap-2">
@@ -101,14 +116,31 @@ export function UpcomingGamesTab() {
                     )}
                   </div>
                 </td>
-                <td className="py-3 px-2 text-muted-foreground whitespace-nowrap">
-                  {row.session.start_time
-                    ? `${formatTimeShort(row.session.start_time, use24h)}${
-                        row.session.end_time
-                          ? `–${formatTimeShort(row.session.end_time, use24h)}`
-                          : ''
-                      }`
-                    : 'TBD'}
+                {/*
+                  Rows are ordered by absolute instant across every game's
+                  timezone, so a bare wall clock reads as mis-sorted (8:30am in
+                  Tokyo really does precede 6pm the previous day in LA). The
+                  abbreviation and the viewer conversion are what make the order
+                  legible.
+                */}
+                <td className="py-3 px-2 text-muted-foreground">
+                  {timeRange ? (
+                    <>
+                      <span className="whitespace-nowrap">
+                        {timeRange.gameTime}
+                        {timeRange.gameTzAbbrev && (
+                          <span className="ml-1 text-xs">{timeRange.gameTzAbbrev}</span>
+                        )}
+                      </span>
+                      {timeRange.viewerTime && (
+                        <span className="block whitespace-nowrap text-xs text-muted-foreground/70">
+                          {timeRange.viewerTime} {timeRange.viewerTzAbbrev} for you
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    'TBD'
+                  )}
                 </td>
                 <td className="py-3 px-2 font-medium text-foreground">
                   <Link
@@ -122,7 +154,8 @@ export function UpcomingGamesTab() {
                 <td className="py-3 px-2 text-muted-foreground">{row.gmName}</td>
                 <td className="py-3 px-2 text-muted-foreground">{row.session.location ?? '—'}</td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </AdminTable>
 

--- a/src/components/dashboard/UpcomingSessionsPanel.tsx
+++ b/src/components/dashboard/UpcomingSessionsPanel.tsx
@@ -4,8 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { parseISO } from 'date-fns';
 import { CalendarClock, MapPin, StickyNote } from 'lucide-react';
-import { formatTimeShort } from '@/lib/formatting';
-import { convertTimeForDisplay } from '@/lib/timezone';
+import { buildSessionTimeRange } from '@/lib/formatting';
 import type { UpcomingSessionRow } from '@/lib/schedule';
 
 const SOFT_CAP = 5;
@@ -19,9 +18,12 @@ function formatSessionDate(dateStr: string): string {
 }
 
 /**
- * Build the time label for a session row, mirroring the game schedule view:
- * a compact game-local time, labelled with the game's timezone abbreviation
- * and a "(… for you)" conversion when the viewer is in a different timezone.
+ * Flatten a session's time range into this panel's one-line label.
+ *
+ * Intentional divergence from ScheduledRow (the game-page view), which only shows the
+ * "for you" conversion when both start and end times exist. Here we also show it for a
+ * start-only session, since this aggregate view is the one place a player sees the start
+ * time in their own zone.
  */
 function formatTimeRange(
   date: string,
@@ -31,31 +33,11 @@ function formatTimeRange(
   userTimezone: string | null,
   use24h: boolean
 ): string {
-  if (!start) return 'time TBD';
-  const base = end
-    ? `${formatTimeShort(start, use24h)}–${formatTimeShort(end, use24h)}`
-    : formatTimeShort(start, use24h);
-
-  // No game timezone recorded: nothing to convert against.
-  if (!gameTimezone) return base;
-
-  const startConv = convertTimeForDisplay(date, start, gameTimezone, userTimezone, use24h);
+  const range = buildSessionTimeRange(date, start, end, gameTimezone, userTimezone, use24h);
+  if (!range) return 'time TBD';
   // Same (or equivalent) timezone: the compact local time is already "for you".
-  if (!startConv.isDifferentTz) return base;
-
-  const gameLabel = `${base} ${startConv.gameTzAbbrev}`;
-  const endConv = end
-    ? convertTimeForDisplay(date, end, gameTimezone, userTimezone, use24h)
-    : null;
-  // Intentional divergence from ScheduledRow (the game-page view), which only shows the
-  // "for you" conversion when both start and end times exist. Here we also show it for a
-  // start-only session, since this aggregate view is the one place a player sees the start
-  // time in their own zone. startConv.userTime is non-null whenever isDifferentTz is true.
-  const forYou =
-    endConv?.userTime != null
-      ? `${startConv.userTime} – ${endConv.userTime} ${startConv.userTzAbbrev}`
-      : `${startConv.userTime} ${startConv.userTzAbbrev}`;
-  return `${gameLabel} (${forYou} for you)`;
+  if (!range.viewerTime) return range.gameTime;
+  return `${range.gameTime} ${range.gameTzAbbrev} (${range.viewerTime} ${range.viewerTzAbbrev} for you)`;
 }
 
 interface UpcomingSessionsPanelProps {

--- a/src/lib/formatting.test.ts
+++ b/src/lib/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatTime, formatTimeShort } from "./formatting";
+import { buildSessionTimeRange, formatTime, formatTimeShort } from "./formatting";
 
 describe("formatTime", () => {
   it("returns empty string for null input", () => {
@@ -145,5 +145,95 @@ describe("backwards compatibility (explicit use24h=false)", () => {
 
   it("formatTimeShort still returns compact 12h format with explicit false", () => {
     expect(formatTimeShort("19:00", false)).toBe("7pm");
+  });
+});
+
+describe("buildSessionTimeRange", () => {
+  it("returns null when the session has no start time", () => {
+    expect(
+      buildSessionTimeRange("2026-08-15", null, "11:30:00", "Asia/Tokyo", "America/Los_Angeles", false)
+    ).toBeNull();
+  });
+
+  it("returns a bare compact range when the game has no timezone", () => {
+    const range = buildSessionTimeRange(
+      "2026-08-15",
+      "08:30:00",
+      "11:30:00",
+      null,
+      "America/Los_Angeles",
+      false
+    );
+    expect(range).toEqual({
+      gameTime: "8:30am–11:30am",
+      gameTzAbbrev: null,
+      viewerTime: null,
+      viewerTzAbbrev: null,
+    });
+  });
+
+  it("omits the timezone label when the viewer shares the game's offset", () => {
+    // Amsterdam and Berlin are distinct IANA zones with an identical offset —
+    // the wall clocks agree, so labelling them would be noise.
+    const range = buildSessionTimeRange(
+      "2026-08-16",
+      "19:00:00",
+      "23:00:00",
+      "Europe/Amsterdam",
+      "Europe/Berlin",
+      false
+    );
+    expect(range).toEqual({
+      gameTime: "7pm–11pm",
+      gameTzAbbrev: null,
+      viewerTime: null,
+      viewerTzAbbrev: null,
+    });
+  });
+
+  it("labels the game timezone and converts for a viewer in a different zone", () => {
+    // 08:30 JST on Aug 15 is 16:30 UTC on Aug 14 — i.e. 9:30 AM the previous
+    // day in Los Angeles. This is the row that makes the admin table look
+    // mis-sorted without a label.
+    const range = buildSessionTimeRange(
+      "2026-08-15",
+      "08:30:00",
+      "11:30:00",
+      "Asia/Tokyo",
+      "America/Los_Angeles",
+      false
+    );
+    expect(range?.gameTime).toBe("8:30am–11:30am");
+    expect(range?.gameTzAbbrev).toBe("GMT+9");
+    expect(range?.viewerTime).toBe("4:30 PM – 7:30 PM");
+    expect(range?.viewerTzAbbrev).toBe("PDT");
+  });
+
+  it("converts a start-only session without inventing an end time", () => {
+    const range = buildSessionTimeRange(
+      "2026-08-14",
+      "19:00:00",
+      null,
+      "America/New_York",
+      "America/Los_Angeles",
+      false
+    );
+    expect(range?.gameTime).toBe("7pm");
+    expect(range?.gameTzAbbrev).toBe("EDT");
+    expect(range?.viewerTime).toBe("4:00 PM");
+    expect(range?.viewerTzAbbrev).toBe("PDT");
+  });
+
+  it("honours the 24-hour preference in the game-local range", () => {
+    const range = buildSessionTimeRange(
+      "2026-08-15",
+      "08:30:00",
+      "11:30:00",
+      "Asia/Tokyo",
+      "America/Los_Angeles",
+      true
+    );
+    expect(range?.gameTime).toBe("8:30–11:30");
+    expect(range?.viewerTime).toBe("16:30 – 19:30");
   });
 });

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,3 +1,5 @@
+import { convertTimeForDisplay } from "./timezone";
+
 /**
  * Format a 24-hour time string to 12-hour format with AM/PM, or keep as 24h
  * @param time - Time in "HH:MM" or "HH:MM:SS" format
@@ -34,4 +36,78 @@ export function formatTimeShort(time: string | null, use24h: boolean = false): s
   const ampm = h >= 12 ? "pm" : "am";
   const h12 = h % 12 || 12;
   return m === 0 ? `${h12}${ampm}` : `${h12}:${minutes}${ampm}`;
+}
+
+/**
+ * The parts of a session's time range, ready to lay out in whatever shape a
+ * view needs (one line, two lines, a table cell).
+ *
+ * `gameTzAbbrev` and the viewer fields are non-null only when the viewer is in
+ * a genuinely different *offset* from the game. Equal-offset zones (Amsterdam
+ * vs Berlin) show the same wall clock, so labelling them would be noise.
+ */
+export interface SessionTimeRange {
+  /** Compact game-local range, e.g. "8:30am–11:30am". */
+  gameTime: string;
+  /** Game timezone abbreviation, or null when there is nothing to disambiguate. */
+  gameTzAbbrev: string | null;
+  /** The same range in the viewer's timezone, or null when it matches the game's. */
+  viewerTime: string | null;
+  viewerTzAbbrev: string | null;
+}
+
+/**
+ * Resolve a session's start/end into game-local and viewer-local parts.
+ *
+ * Views that list sessions from several games order them by absolute instant
+ * (see `buildUpcomingSessionRows`), which reads as scrambled if each row only
+ * shows a bare wall clock: 8:30am in Tokyo really does precede 6pm the previous
+ * day in Los Angeles. Rendering the returned abbreviation is what makes that
+ * ordering legible.
+ *
+ * @param date           Session date in YYYY-MM-DD (game-local)
+ * @param start          Start time HH:MM[:SS] (game-local); null → no range
+ * @param end            End time HH:MM[:SS] (game-local), or null
+ * @param gameTimezone   The game's IANA timezone, or null if unrecorded
+ * @param viewerTimezone The viewer's IANA timezone, or null if unknown
+ * @param use24h         Viewer's 12/24-hour preference
+ * @returns The range parts, or null when the session has no start time.
+ */
+export function buildSessionTimeRange(
+  date: string,
+  start: string | null,
+  end: string | null,
+  gameTimezone: string | null,
+  viewerTimezone: string | null,
+  use24h: boolean
+): SessionTimeRange | null {
+  if (!start) return null;
+
+  const gameTime = end
+    ? `${formatTimeShort(start, use24h)}–${formatTimeShort(end, use24h)}`
+    : formatTimeShort(start, use24h);
+  const bare: SessionTimeRange = {
+    gameTime,
+    gameTzAbbrev: null,
+    viewerTime: null,
+    viewerTzAbbrev: null,
+  };
+
+  // No game timezone recorded: nothing to convert against.
+  if (!gameTimezone) return bare;
+
+  const startConv = convertTimeForDisplay(date, start, gameTimezone, viewerTimezone, use24h);
+  if (!startConv.isDifferentTz) return bare;
+
+  const endConv = end ? convertTimeForDisplay(date, end, gameTimezone, viewerTimezone, use24h) : null;
+  // startConv.userTime is non-null whenever isDifferentTz is true.
+  return {
+    gameTime,
+    gameTzAbbrev: startConv.gameTzAbbrev,
+    viewerTime:
+      endConv?.userTime != null
+        ? `${startConv.userTime} – ${endConv.userTime}`
+        : startConv.userTime,
+    viewerTzAbbrev: startConv.userTzAbbrev,
+  };
 }

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -52,7 +52,10 @@ export const queryKeys = {
   /** Admin top-users leaderboard. */
   adminTopUsers: () => ['adminTopUsers'] as const,
   /** One page of the admin upcoming-sessions table. */
-  adminUpcomingSessions: (page: number) => ['adminUpcomingSessions', page] as const,
+  // The viewer's timezone is part of the key because the route derives each
+  // row's Today/Tomorrow badge from it — same page, different tz, different data.
+  adminUpcomingSessions: (page: number, timezone: string | null) =>
+    ['adminUpcomingSessions', page, timezone] as const,
   /** Full admin snapshot of a single game (NOT the same shape as `game`). */
   adminGame: (gameId: string) => ['adminGame', gameId] as const,
 } as const;

--- a/src/lib/schedule/upcomingSessions.test.ts
+++ b/src/lib/schedule/upcomingSessions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildUpcomingSessionRows,
   getUpcomingQueryFloor,
+  resolveViewerToday,
 } from './upcomingSessions';
 import { toLocalDateString } from '../date';
 import type { GameSession } from '@/types';
@@ -47,6 +48,24 @@ describe('getUpcomingQueryFloor', () => {
     // Parsed as UTC midnight on both sides, so the diff is exact and tz-independent.
     const diffDays = (Date.parse(today) - Date.parse(floor)) / 86_400_000;
     expect(diffDays).toBe(2);
+  });
+});
+
+describe('resolveViewerToday', () => {
+  // 2026-08-13 02:00 UTC is still the evening of 2026-08-12 in the Americas.
+  // Every assertion pins an explicit zone, so these hold on any dev machine.
+  const nowMs = Date.UTC(2026, 7, 13, 2, 0, 0);
+
+  it("returns the viewer's calendar date, not the runtime's", () => {
+    expect(resolveViewerToday(nowMs, 'America/Los_Angeles')).toBe('2026-08-12');
+    expect(resolveViewerToday(nowMs, 'UTC')).toBe('2026-08-13');
+    expect(resolveViewerToday(nowMs, 'Asia/Tokyo')).toBe('2026-08-13');
+  });
+
+  it('falls back to the runtime date for a null or unrecognised timezone', () => {
+    const runtimeToday = toLocalDateString(new Date(nowMs));
+    expect(resolveViewerToday(nowMs, null)).toBe(runtimeToday);
+    expect(resolveViewerToday(nowMs, 'Not/AZone')).toBe(runtimeToday);
   });
 });
 
@@ -106,6 +125,31 @@ describe('buildUpcomingSessionRows', () => {
     expect(byId.today).toBe('today');
     expect(byId.tom).toBe('tomorrow');
     expect(byId.later).toBeNull();
+  });
+
+  it('tags from the viewer date, so a UTC server clock cannot shift the badge a day early', () => {
+    // 2026-08-13 02:00 UTC = the evening of Aug 12 in Los Angeles. The admin
+    // route used to derive `today` from its own runtime (UTC on Vercel), which
+    // tagged an Aug 13 session "Today" while the viewer was still on Aug 12.
+    const nowMs = Date.UTC(2026, 7, 13, 2, 0, 0);
+    const sessions = [mkSession({ id: 'aug13', game_id: 'g1', date: '2026-08-13' })];
+
+    const viewerRows = buildUpcomingSessionRows(
+      sessions,
+      names,
+      resolveViewerToday(nowMs, 'America/Los_Angeles'),
+      nowMs
+    );
+    expect(viewerRows[0].dayHighlight).toBe('tomorrow');
+
+    // The old server-clock behaviour, pinned so the regression is unmistakable.
+    const serverRows = buildUpcomingSessionRows(
+      sessions,
+      names,
+      resolveViewerToday(nowMs, 'UTC'),
+      nowMs
+    );
+    expect(serverRows[0].dayHighlight).toBe('today');
   });
 
   it('computes tomorrow across a month/year boundary', () => {

--- a/src/lib/schedule/upcomingSessions.ts
+++ b/src/lib/schedule/upcomingSessions.ts
@@ -1,5 +1,5 @@
 import type { GameSession } from '@/types';
-import { getSessionInstantMs, getDateInTimezone } from '../timezone';
+import { getSessionInstantMs, getDateInTimezone, isValidTimezone } from '../timezone';
 import { toLocalDateString } from '../date';
 
 export type DayHighlight = 'today' | 'tomorrow' | null;
@@ -33,6 +33,27 @@ export function getUpcomingQueryFloor(nowMs: number): string {
   const d = new Date(nowMs);
   d.setDate(d.getDate() - 2);
   return toLocalDateString(d);
+}
+
+/**
+ * The viewer's own calendar date at `nowMs`, used for the Today/Tomorrow badge.
+ *
+ * `getTodayLocalDate()` reads the *runtime's* timezone, which is only the
+ * viewer's when it runs in the browser. Called from an API route it returns the
+ * server's date — UTC on Vercel — which tags tomorrow's session "Today" for
+ * every viewer west of UTC once their evening rolls past midnight UTC. Routes
+ * must therefore take the viewer's timezone from the request and resolve it
+ * here rather than reading their own clock.
+ *
+ * @param nowMs            Current instant (epoch ms).
+ * @param viewerTimezone   Viewer's IANA timezone; null or unrecognised falls
+ *                         back to the runtime's local date.
+ */
+export function resolveViewerToday(nowMs: number, viewerTimezone: string | null): string {
+  if (!viewerTimezone || !isValidTimezone(viewerTimezone)) {
+    return toLocalDateString(new Date(nowMs));
+  }
+  return getDateInTimezone(nowMs, viewerTimezone);
 }
 
 /** Add one calendar day to a YYYY-MM-DD string, handling month/year rollover. */


### PR DESCRIPTION
The admin "Upcoming Games" table sorts by absolute UTC instant across every game's timezone — correct, but it read as scrambled because the table rendered a bare wall clock, so a Tokyo 8:30am row sat above an LA 6pm row dated the day before. It now shows the game's timezone abbreviation plus a "(… for you)" conversion (as the dashboard panel already did), leaving same-offset zones unlabelled, so the ordering explains itself.

Separately, the Today/Tomorrow badge was genuinely wrong: the route derived `today` from `getTodayLocalDate()`, which reads the *runtime's* timezone — UTC on Vercel, not the viewer's — so it tagged tomorrow's session "Today" for anyone west of UTC between their evening and midnight UTC. The viewer's timezone now travels with the request through the new `resolveViewerToday()`, and is part of the TanStack query key since it's an input to the response.

`buildSessionTimeRange()` is extracted into `src/lib/formatting.ts` and returns the range as parts, so the dashboard panel keeps its one-line label while the admin table uses two; `UpcomingSessionsPanel`'s rendered output is unchanged.

Covered by 6 new unit tests for the formatter, 3 for the viewer-date resolution (including one pinning the old UTC-server behaviour beside the new one), and an E2E test seeding the Tokyo/LA inversion. `lint`, `typecheck`, 795 unit tests, `build`, and the full 327-test E2E suite all pass, and the result was checked visually at 570px and 1440px.